### PR TITLE
Update NewRelicErrorLogger.scala

### DIFF
--- a/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicErrorLogger.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicErrorLogger.scala
@@ -35,7 +35,12 @@ class NewRelicErrorLogger extends Actor {
     for (c ← ctx) {
       params.put("UOW", c.uow)
     }
+    
+    if (error.cause == Error.NoCause) {
+      NewRelic.noticeError(error.message.toString, params)
+    } else {
+      NewRelic.noticeError(error.cause, params)
+    }
 
-    NewRelic.noticeError(error.cause, params)
   }
 }


### PR DESCRIPTION
Send to new relic the Error message instead of the cause, if this one is an NoCause object
