### PR TITLE
Kamon with Akka Documentation rewrote

### DIFF
--- a/kamon-examples/kamon-akka-example/build.sbt
+++ b/kamon-examples/kamon-akka-example/build.sbt
@@ -1,0 +1,19 @@
+import sbt._
+
+import sbt.Keys._
+
+name := "kamon-akka-example"
+ 
+version := "1.0"
+ 
+scalaVersion := "2.10.2"
+
+resolvers += "Kamon repo" at "http://repo.kamon.io"
+
+libraryDependencies ++= Seq(
+    "kamon"                         % "kamon-core"              % "0.0.14",
+    "com.typesafe.akka"             %%  "akka-slf4j"            % "2.2.3",
+    "org.slf4j"                     %   "slf4j-api"             % "1.7.5",
+    "ch.qos.logback"                %   "logback-classic"       % "1.0.13",
+    "org.aspectj"                   %   "aspectjweaver"         % "1.7.4"
+)

--- a/kamon-examples/kamon-akka-example/project/build.properties
+++ b/kamon-examples/kamon-akka-example/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.1

--- a/kamon-examples/kamon-akka-example/project/plugins.sbt
+++ b/kamon-examples/kamon-akka-example/project/plugins.sbt
@@ -1,0 +1,5 @@
+resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+
+resolvers += "Kamon Releases" at "http://repo.kamon.io"
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")

--- a/kamon-examples/kamon-akka-example/src/main/resources/application.conf
+++ b/kamon-examples/kamon-akka-example/src/main/resources/application.conf
@@ -1,0 +1,4 @@
+akka {
+   loggers = ["akka.event.slf4j.Slf4jLogger"]
+   logleve = INFO
+}

--- a/kamon-examples/kamon-akka-example/src/main/resources/logback.xml
+++ b/kamon-examples/kamon-akka-example/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration scan="true">
+    <conversionRule conversionWord="traceToken" converterClass="kamon.trace.logging.LogbackTraceTokenConverter" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} %-5level [%X{sourceThread}][%traceToken][%X{akkaSource}] %msg%n</pattern>
+        </encoder>
+     </appender>
+     <root level="debug">
+         <appender-ref ref="STDOUT" />
+     </root>
+</configuration>

--- a/kamon-examples/kamon-akka-example/src/main/scala/AkkaWithKamonExample.scala
+++ b/kamon-examples/kamon-akka-example/src/main/scala/AkkaWithKamonExample.scala
@@ -1,0 +1,107 @@
+/* ===================================================
+ * Copyright © 2013 2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+
+import akka.actor
+import akka.actor._
+
+import kamon.metrics.Subscriptions.TickMetricSnapshot
+import kamon.metrics.{Metrics, TraceMetrics}
+import kamon.Kamon
+import kamon.trace.TraceRecorder
+
+case object BeginWithoutTraceContext
+case object BeginWithTraceContext
+case object Finish
+
+object AkkaWithKamonExample extends App {
+  implicit val system = ActorSystem("simple-context-propagation")
+
+  val simpleMetricExtension = SimpleExtension(system)
+
+  val mainActor = system.actorOf(Props[JobSender], "mainActor")
+
+  for (_ <- 1 to 5) mainActor ! BeginWithTraceContext
+}
+
+class JobSender extends Actor with ActorLogging {
+  val upperCaser = context.actorOf(Props[UpperCaser], "upper-caser")
+  var counter = 1
+
+  def receive = {
+    case BeginWithTraceContext => {
+      //TraceRecorder requires an implicit ActorSystem
+      implicit val system = context.system
+        TraceRecorder.withNewTraceContext("uppercaser") {
+          upperCaser ! "Hello World with TraceContext"
+      }
+    }
+    case length: Int => {
+      log.info("Length [{}]", length)
+      self ! Finish
+    }
+
+    case Finish => {
+      log.info("Finishing request {}", counter += 1)
+      TraceRecorder.finish()
+
+    if (counter == 5) {
+      Thread.sleep(10000)
+      log.info("Shutting down the system")
+      context.system.shutdown()
+      }
+    }
+  }
+}
+
+class UpperCaser extends Actor with ActorLogging {
+  val lengthCalculator = context.actorOf(Props[LengthCalculator], "length-calculator")
+
+  def receive = {
+    case anyString: String => {
+      log.info("Upper casing [{}]", anyString)
+      lengthCalculator.forward(anyString.toUpperCase)
+    }
+  }
+}
+
+class LengthCalculator extends Actor with ActorLogging  {
+  def receive = {
+    case anyString: String =>
+      log.info("Calculating the length of: [{}]", anyString)
+      sender ! anyString.length
+  }
+}
+
+class SimpleExtension(system: ExtendedActorSystem) extends Kamon.Extension {
+  val metricsListener = system.actorOf(Props[SimpleMetricsListener])
+
+  Kamon(Metrics)(system).subscribe(TraceMetrics, "*", metricsListener, permanently = true)
+
+}
+
+class SimpleMetricsListener extends Actor with ActorLogging {
+  log.info("Starting the Kamon(SimpleMetricsListener) extension")
+
+  override def receive: Actor.Receive = {
+    case TickMetricSnapshot(tickFrom, tickTo, metrics) => log.info("Tick From: {} nano To: {} nano => {}", tickFrom, tickTo, metrics)
+  }
+}
+
+object SimpleExtension extends ExtensionId[SimpleExtension] with ExtensionIdProvider {
+  def lookup(): ExtensionId[_ <: actor.Extension] = SimpleExtension
+  def createExtension(system: ExtendedActorSystem): SimpleExtension = new SimpleExtension(system)
+
+}

--- a/site/src/main/jekyll/akka/index.md
+++ b/site/src/main/jekyll/akka/index.md
@@ -5,93 +5,113 @@ layout: default
 
 Akka Module
 ===
+Kamon will help you in monitoring your reactive akka application. Let's go to create our first akka application with kamon. In the near future you will find Kamon template in typesafe Activator.
 
 ---
 Dependencies
 ---
 
-Apart from scala library kamon depends on:
+Apart from scala library, kamon depends on:
 
 - aspectj 
-- spray-io 
-- akka-actor 
+- akka-actor
+- spray (only for spray enabled apps)
+- newrelic (only for new relic enabled apps)
 
 
 Installation
 ---
-Kamon works with SBT, so you need to add Kamon.io repository to your resolvers.
+Let's start with an empty sbt project like kamon-akka-example (you will find the project in kamon-example folder). Edit config files with your favorite editor like vim :)
 
-Configuration
+```
+mkdir -p kamon-akka-example/project
+mkdir -p kamon-akka-example/src/main/scala
+mkdir -p kamon-akka-example/src/main/resources
+
+touch kamon-akka-example/build.sbt
+
+touch kamon-akka-example/project/build.properties
+touch kamon-akka-example/project/plugins.sbt
+
+touch kamon-akka-example/src/main/application.conf
+```
+
+Edit kamon-akka-example/project/build.properties and add sbt version
+
+```
+sbt.version=0.12.3
+```
+
+Edit kamon-akka-example/build.sbt
+
+```
+import sbt._
+
+import sbt.Keys._
+
+name := "kamon-akka-example"
+ 
+version := "1.0"
+ 
+scalaVersion := "2.10.2"
+
+resolvers += "Kamon repo" at "http://repo.kamon.io"
+
+libraryDependencies ++= Seq(
+    "kamon"             % "kamon-core"      % "0.0.14",
+    "com.typesafe.akka" % "akka-slf4j"      % "2.2.3",
+    "org.slf4j"         % "slf4j-api"       % "1.7.5",
+    "ch.qos.logback"    % "logback-classic" % "1.0.13",
+    "org.aspectj"       % "aspectjweaver"   % "1.7.4"
+    )
+```
+
+Edit plugins.sbt (kamon-akka-example/project), note that sbt-idea is not required, however, if you want to be a happy coder, you should give a try to intellij and run sbt gen-idea!
+
+```
+resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+
+resolvers += "Kamon Releases" at "http://repo.kamon.io"
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.2")
+```
+Finally, step into kammon-akka-example, you can run your app like any scala app, passing the aspectjweaver.jar version 1.7.4/1.7.2 to the jvm
+
+```
+-javaagent:/path/to/file/aspectjweaver-1.7.4.jar 
+```
+
+Take a look to [get started](http://kamon.io/get-started/) for more information with the javaagent.
+
+
+Akka Configuration
 ---
 Just like other products in the scala ecosystem, it relies on the typesafe configuration library. 
     
 Since kamon uses the same configuration technique as [Spray](http://spray.io/documentation "Spray") / [Akka](http://akka.io/docs "Akka") you might want to check out the [Akka-Documentation-configuration](http://doc.akka.io/docs/akka/2.1.4/general/configuration.html "Akka Documentation on configuration")
 .
 
-In order to see Kamon in action you need first to set up your sbt project.
+Edit your application.conf from src/main/resources/application.conf
 
-1) Add Kamon repository to resolvers
-
-```scala
-"Kamon Repository" at "http://repo.kamon.io"
-```
-
-2) Add libraryDepenency
-
-```scala 
-    "kamon" %%  "kamon-spray" % "0.0.11",
-```
-
-In addition we suggest to create aspectj.sbt file and add this content
-
-```scala
-    import com.typesafe.sbt.SbtAspectj._
-
-    aspectjSettings
-
-    javaOptions <++= AspectjKeys.weaverOptions in Aspectj
-```
-
-3) Add to your plugins.sbt in project folder (if you don't have one yet, create the file) and add the Kamon release to the resolver and the aspecj.
-
-```scala
-    resolvers += Resolver.url("Kamon Releases", url("http://repo.kamon.io"))(Resolver.ivyStylePatterns)
-
-    addSbtPlugin("com.typesafe.sbt" % "sbt-aspectj" % "0.9.2")
-``` 
 **application.conf**
 
 ```scala
     akka {
       loggers = ["akka.event.slf4j.Slf4jLogger"]
-  
-        actor {
-           debug {
-                    unhandled = on
-            }
-        }
+      loglevel = INFO
+         }
     }
 ```
+Then, your are done
+
+Happy Coding
 
 Examples
 ---
-
-TODO: (to be published) The example will start a spray server with akka and logback configuration. Adjust it to your needs. 
-
-Follow the steps in order to clone the repository
+You will find some of them in kamon-example folder
 
 1. git clone git://github.com/kamon/kamon.git
 
-2. cd kamon
+2. cd Kamon/kamon-examples
 
-For the first example run
-
-```bash
-    sbt "project kamon-uow-example"
-```
-
-In order to see how it works, you need to send a message to the rest service
-
-```bash
-    curl -v --header 'X-UOW:YOUR_TRACER_ID' -X GET 'http://0.0.0.0:6666/fibonacci'
-```
+For akka, you will find akka-kamon-examples that shows you how to add a TraceContext and how to add a Console Reporter with the metrics.


### PR DESCRIPTION
Kamon Team, I've rewritten again kamon akka documentation from the first version in order to make it more coherent and a guide to follow if you want to add kamon to your akka project. Also, I've used tracing example and put a new version in kamon-examples folder called kamon-akka-example. This change will help new comers to akka in order to add kamon.

Thanks,

Sergio
