### PR TITLE
Git commit hash support, signed artifacts publishing, and releases to sonatype

### DIFF
--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,52 +1,22 @@
 import sbt._
 import sbt.Keys._
-import sbt.Project.Initialize
-import java.lang.Boolean.{valueOf => convertToBoolean }
 
 object Publish {
 
   lazy val settings = Seq(
     crossPaths := false,
     pomExtra := kamonPomExtra,
-    publishTo <<= kamonPublish,
-    organization := kamonOrganization,
-    credentials ++= kamonCredentials,
+    publishTo := kamonRepo,
+    organization := "io.kamon",
     pomIncludeRepository := { x => false },
     publishMavenStyle := true,
     publishArtifact in Test := false
   )
 
-  def kamonPublish:Initialize[Option[Resolver]] = {
-    if(convertToBoolean(System.getProperty("publish.to.sonatype"))) sonatypePublishRepository
-    else kamonPublishRepository
-  }
-
-  def sonatypePublishRepository: Initialize[Option[Resolver]] = {
-    version { v: String =>
-      val nexus = "https://oss.sonatype.org/"
-      if (v.trim.endsWith("SNAPSHOT"))
-        Some("snapshots" at nexus + "content/repositories/snapshots")
-      else
-        Some("releases" at nexus + "service/local/staging/deploy/maven2")
-    }
-  }
-
-  def kamonPublishRepository :Initialize[Option[Resolver]] = {
-    version { (v: String) =>
-      if (v.trim.endsWith("SNAPSHOT"))
-        Some(Resolver.sftp("Kamon Snapshots Repository", "snapshots.kamon.io", "/var/local/snapshots-repo"))
-      else
-        Some(Resolver.sftp("Kamon Repository", "repo.kamon.io", "/var/local/releases-repo"))
-    }
-  }
-
-  def kamonOrganization: String = Option(System.getProperty("kamon.publish.organization", "kamon")).get
-
-  def kamonCredentials: Seq[Credentials] =
-    Option(System.getProperty("kamon.publish.credentials", null)) map (f => Credentials(new File(f))) toSeq
+  def kamonRepo = Some(Resolver.sftp("Kamon Snapshots Repository", "snapshots.kamon.io", "/var/local/snapshots-repo"))
 
   def kamonPomExtra = {
-      <url>http://kamon.io</url>
+    <url>http://kamon.io</url>
       <licenses>
         <license>
           <name>Apache 2</name>

--- a/project/Release.scala
+++ b/project/Release.scala
@@ -1,0 +1,65 @@
+import com.typesafe.sbt.pgp._
+import sbt._
+import sbt.Keys._
+import sbtrelease.ReleasePlugin._
+import sbtrelease.ReleaseStateTransformations._
+import sbtrelease.ReleaseStep
+import sbtrelease.Utilities._
+import xerial.sbt.Sonatype._
+
+object Release {
+
+  def settings = Seq.empty ++
+    releaseSettings ++
+    Seq(
+      ReleaseKeys.releaseProcess := Seq[ReleaseStep](
+        checkSnapshotDependencies,
+        inquireVersions,
+        runClean,
+        runTest,
+        setReleaseVersion,
+        commitReleaseVersion, // .copy(check = identity), // FIX 0: to skip "all changes committed" precondition
+        tagRelease,
+        publishSignedArtifacts, // FIX 1: publish signed. Otherwise sonatype won't sync artifact to maven central
+        setNextVersion,
+        commitNextVersion,
+        pushChanges,
+        refreshVersionWithSHA // FIX 2: update "version" by replacing the "-SNAPSHOT" with "-WHATEVER_COMMIT_SHA"
+      )
+    ) ++
+    sonatypeSettings ++
+    Seq(
+      // sbt-sonatype overrides publishTo. So we need to restore kamon repo declaration for snapshots
+      publishTo := { if (isSnapshot.value) Publish.kamonRepo else publishTo.value }
+    )
+
+
+  def kamonSonatypeCredentials =
+    Credentials.toDirect(Credentials(Path.userHome / ".ivy2" / "kamon-credentials-sonatype.properties"))
+
+  /**
+   * Hijacked from [[sbtrelease.ReleaseStateTransformations.publishArtifacts]]
+   */
+  lazy val publishSignedArtifacts = ReleaseStep(
+    action = { st: State =>
+      val extracted = st.extract
+      val ref = extracted.get(thisProjectRef)
+      extracted.runAggregated(PgpKeys.publishSigned in Global in ref, st)
+    },
+    check = st => {
+      // getPublishTo fails if no publish repository is set up.
+      val ex = st.extract
+      val ref = ex.get(thisProjectRef)
+      Classpaths.getPublishTo(ex.get(publishTo in Global in ref))
+      st
+    },
+    enableCrossBuild = true
+  )
+
+  lazy val refreshVersionWithSHA = ReleaseStep(st => {
+    reapply(Seq(
+      version in ThisBuild := VersionWithSHA.kamonVersionWithSHA(st.extract.get(version))
+    ), st)
+  })
+
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,9 +1,9 @@
 import sbt._
 import Keys._
-import sbtrelease.ReleasePlugin._
 import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import Publish.{settings => publishSettings}
+import Release.{settings => releaseSettings}
 import scalariform.formatter.preferences._
 
 object Settings {

--- a/project/VersionWithSHA.scala
+++ b/project/VersionWithSHA.scala
@@ -1,0 +1,13 @@
+import sbt.Process
+
+object VersionWithSHA {
+
+  private lazy val VersionWithShaRegex = """(?:\d+\.)?(?:\d+\.)?(?:\d+)-[0-9a-f]{5,40}"""
+
+  /** Don't use this. You should use version.value instead. */
+  def kamonVersionWithSHA(version: String) = version.takeWhile(_ != '-') + "-" + Process("git rev-parse HEAD").lines.head
+
+  /** Don't use this. You should use isSnapshot.value instead. */
+  def kamonIsSnapshot(version: String) = (version matches VersionWithShaRegex) || (version endsWith "-SNAPSHOT")
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,6 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.2.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.1")

--- a/versionwithsha.sbt
+++ b/versionwithsha.sbt
@@ -1,0 +1,5 @@
+// This file has a sensitive filename. It MUST be loaded after version.sbt, so it can rely in sbt-release version
+
+version in ThisBuild := VersionWithSHA.kamonVersionWithSHA((version in ThisBuild).value)
+
+isSnapshot in ThisBuild := VersionWithSHA.kamonIsSnapshot((version in ThisBuild).value)


### PR DESCRIPTION
Hey guys,

I'm sending this request for you to pull the following changes:
- git commit SHA included in the version (IE: 0.0.15-32416546987684)
- ability to publish signed versions of the artifacts (through sbt-pgp plugin)
- publish releases to sonatype, through "release" command (sbt-release plugin) and then performing "sonatypeRelease" in order to close & promote the staging (sbt-sonatype plugins)
