### PR TITLE
Update spray-json to 1.3.0 For 0.3 Scala 2.11 Release

### DIFF
--- a/kamon-newrelic/src/main/scala/kamon/newrelic/AgentJsonProtocol.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/AgentJsonProtocol.scala
@@ -33,7 +33,7 @@ object AgentJsonProtocol extends DefaultJsonProtocol {
   }
 
   implicit def seqWriter[T: JsonWriter] = new JsonWriter[Seq[T]] {
-    def write(seq: Seq[T]) = JsArray(seq.map(_.toJson).toList)
+    def write(seq: Seq[T]) = JsArray(seq.map(_.toJson).toVector)
   }
 
   implicit object MetricDetailWriter extends JsonWriter[NewRelic.Metric] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,19 +7,19 @@ object Dependencies {
     "typesafe repo" at "http://repo.typesafe.com/typesafe/releases/"
   )
 
-  val sprayVersion    = "1.3.1"
-  val akkaVersion     = "2.3.3"
+  val sprayVersion    = "1.3.2"
+  val akkaVersion     = "2.3.4"
   val aspectjVersion  = "1.8.2"
   val slf4jVersion    = "1.7.7"
   val playVersion     = "2.3.0"
 
-  val sprayJson       = "io.spray"                  %%  "spray-json"            % "1.2.6"
+  val sprayJson       = "io.spray"                  %%  "spray-json"            % "1.3.0"
   val sprayJsonLenses = "net.virtual-void"          %%  "json-lenses"           % "0.5.4"
-  val scalatest       = "org.scalatest"             %   "scalatest_2.11"        % "2.1.7"
+  val scalatest       = "org.scalatest"             %%  "scalatest"             % "2.1.7"
   val logback         = "ch.qos.logback"            %   "logback-classic"       % "1.0.13"
   val aspectJ         = "org.aspectj"               %   "aspectjrt"             % aspectjVersion
   val aspectjWeaver   = "org.aspectj"               %   "aspectjweaver"         % aspectjVersion
-  val newrelic        = "com.newrelic.agent.java"   %   "newrelic-api"          % "3.1.0"
+  val newrelic        = "com.newrelic.agent.java"   %   "newrelic-api"          % "3.11.0"
   val snakeYaml       = "org.yaml"                  %   "snakeyaml"             % "1.13"
   val hdrHistogram    = "org.hdrhistogram"          %   "HdrHistogram"          % "1.0.8"
   val sprayCan        = "io.spray"                  %%  "spray-can"             % sprayVersion

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -23,9 +23,9 @@ object Projects extends Build {
       mappings in (Compile, packageBin) ++= mappings.in(kamonMacros, Compile, packageBin).value,
       mappings in (Compile, packageSrc) ++= mappings.in(kamonMacros, Compile, packageSrc).value,
       libraryDependencies ++=
-        compile(akkaActor, aspectJ, hdrHistogram) ++
+        compile(akkaActor, aspectJ, hdrHistogram, scalazConcurrent) ++
         optional(akkaRemote, akkaCluster, logback, aspectjWeaver) ++
-        test(scalatest, akkaTestKit, sprayTestkit, akkaSlf4j, logback, scalazConcurrent))
+        test(scalatest, akkaTestKit, sprayTestkit, akkaSlf4j, logback))
 
 
   lazy val kamonSpray = Project("kamon-spray", file("kamon-spray"))


### PR DESCRIPTION
- Updated spray-json 1.2.6 -> 1.3.0.
- Updated spray 1.3.1 -> 1.3.2; this is required becase of binary
  incompatibilities with spray-json 1.3.0 as described here:
  spray/spray#932
- Updated newrelic 3.1.0 -> 3.11.0.
- Updated akka 2.3.3 -> 2.3.4.
- Moved scalaz-concurrent from a test dependency to a compile
  dependency.
