### PR TITLE
fixed serialization when using "akka.actor.serialize-messages = on"

### DIFF
--- a/kamon-core/src/main/scala/kamon/http/HttpServerMetrics.scala
+++ b/kamon-core/src/main/scala/kamon/http/HttpServerMetrics.scala
@@ -82,11 +82,16 @@ object HttpServerMetrics extends MetricGroupIdentity {
     }
   }
 
-  val Factory = new MetricGroupFactory {
-    type GroupRecorder = HttpServerMetricsRecorder
+  val Factory = HttpServerMetricGroupFactory
+}
 
-    def create(config: Config, system: ActorSystem): HttpServerMetricsRecorder =
-      new HttpServerMetricsRecorder()
-  }
+case object HttpServerMetricGroupFactory extends MetricGroupFactory {
+
+  import HttpServerMetrics._
+
+  type GroupRecorder = HttpServerMetricsRecorder
+
+  def create(config: Config, system: ActorSystem): HttpServerMetricsRecorder =
+    new HttpServerMetricsRecorder()
 
 }

--- a/kamon-core/src/main/scala/kamon/metric/ActorMetrics.scala
+++ b/kamon-core/src/main/scala/kamon/metric/ActorMetrics.scala
@@ -69,21 +69,25 @@ object ActorMetrics extends MetricGroupCategory {
       (Errors -> errors))
   }
 
-  val Factory = new MetricGroupFactory {
-    type GroupRecorder = ActorMetricsRecorder
+  val Factory = ActorMetricGroupFactory
+}
 
-    def create(config: Config, system: ActorSystem): ActorMetricsRecorder = {
-      val settings = config.getConfig("precision.actor")
+case object ActorMetricGroupFactory extends MetricGroupFactory {
+  import ActorMetrics._
 
-      val processingTimeConfig = settings.getConfig("processing-time")
-      val timeInMailboxConfig = settings.getConfig("time-in-mailbox")
-      val mailboxSizeConfig = settings.getConfig("mailbox-size")
+  type GroupRecorder = ActorMetricsRecorder
 
-      new ActorMetricsRecorder(
-        Histogram.fromConfig(processingTimeConfig),
-        Histogram.fromConfig(timeInMailboxConfig),
-        MinMaxCounter.fromConfig(mailboxSizeConfig, system),
-        Counter())
-    }
+  def create(config: Config, system: ActorSystem): ActorMetricsRecorder = {
+    val settings = config.getConfig("precision.actor")
+
+    val processingTimeConfig = settings.getConfig("processing-time")
+    val timeInMailboxConfig = settings.getConfig("time-in-mailbox")
+    val mailboxSizeConfig = settings.getConfig("mailbox-size")
+
+    new ActorMetricsRecorder(
+      Histogram.fromConfig(processingTimeConfig),
+      Histogram.fromConfig(timeInMailboxConfig),
+      MinMaxCounter.fromConfig(mailboxSizeConfig, system),
+      Counter())
   }
 }

--- a/kamon-core/src/main/scala/kamon/metric/DispatcherMetrics.scala
+++ b/kamon-core/src/main/scala/kamon/metric/DispatcherMetrics.scala
@@ -66,23 +66,28 @@ object DispatcherMetrics extends MetricGroupCategory {
       (PoolSize -> poolSize))
   }
 
-  val Factory = new MetricGroupFactory {
-    type GroupRecorder = DispatcherMetricRecorder
-
-    def create(config: Config, system: ActorSystem): DispatcherMetricRecorder = {
-      val settings = config.getConfig("precision.dispatcher")
-
-      val maximumPoolSizeConfig = settings.getConfig("maximum-pool-size")
-      val runningThreadCountConfig = settings.getConfig("running-thread-count")
-      val queueTaskCountConfig = settings.getConfig("queued-task-count")
-      val poolSizeConfig = settings.getConfig("pool-size")
-
-      new DispatcherMetricRecorder(
-        Histogram.fromConfig(maximumPoolSizeConfig),
-        Histogram.fromConfig(runningThreadCountConfig),
-        Histogram.fromConfig(queueTaskCountConfig),
-        Histogram.fromConfig(poolSizeConfig))
-    }
-  }
+  val Factory = DispatcherMetricGroupFactory
 }
 
+case object DispatcherMetricGroupFactory extends MetricGroupFactory {
+
+  import DispatcherMetrics._
+
+  type GroupRecorder = DispatcherMetricRecorder
+
+  def create(config: Config, system: ActorSystem): DispatcherMetricRecorder = {
+    val settings = config.getConfig("precision.dispatcher")
+
+    val maximumPoolSizeConfig = settings.getConfig("maximum-pool-size")
+    val runningThreadCountConfig = settings.getConfig("running-thread-count")
+    val queueTaskCountConfig = settings.getConfig("queued-task-count")
+    val poolSizeConfig = settings.getConfig("pool-size")
+
+    new DispatcherMetricRecorder(
+      Histogram.fromConfig(maximumPoolSizeConfig),
+      Histogram.fromConfig(runningThreadCountConfig),
+      Histogram.fromConfig(queueTaskCountConfig),
+      Histogram.fromConfig(poolSizeConfig))
+  }
+
+}

--- a/kamon-core/src/main/scala/kamon/metric/RouterMetrics.scala
+++ b/kamon-core/src/main/scala/kamon/metric/RouterMetrics.scala
@@ -58,19 +58,25 @@ object RouterMetrics extends MetricGroupCategory {
       Errors -> errors)
   }
 
-  val Factory = new MetricGroupFactory {
-    type GroupRecorder = RouterMetricsRecorder
+  val Factory = RouterMetricGroupFactory
+}
 
-    def create(config: Config, system: ActorSystem): RouterMetricsRecorder = {
-      val settings = config.getConfig("precision.router")
+case object RouterMetricGroupFactory extends MetricGroupFactory {
 
-      val processingTimeConfig = settings.getConfig("processing-time")
-      val timeInMailboxConfig = settings.getConfig("time-in-mailbox")
+  import RouterMetrics._
 
-      new RouterMetricsRecorder(
-        Histogram.fromConfig(processingTimeConfig),
-        Histogram.fromConfig(timeInMailboxConfig),
-        Counter())
-    }
+  type GroupRecorder = RouterMetricsRecorder
+
+  def create(config: Config, system: ActorSystem): RouterMetricsRecorder = {
+    val settings = config.getConfig("precision.router")
+
+    val processingTimeConfig = settings.getConfig("processing-time")
+    val timeInMailboxConfig = settings.getConfig("time-in-mailbox")
+
+    new RouterMetricsRecorder(
+      Histogram.fromConfig(processingTimeConfig),
+      Histogram.fromConfig(timeInMailboxConfig),
+      Counter())
   }
 }
+

--- a/kamon-core/src/main/scala/kamon/metric/TraceMetrics.scala
+++ b/kamon-core/src/main/scala/kamon/metric/TraceMetrics.scala
@@ -59,19 +59,24 @@ object TraceMetrics extends MetricGroupCategory {
     def metrics: Map[MetricIdentity, MetricSnapshot] = segments + (ElapsedTime -> elapsedTime)
   }
 
-  val Factory = new MetricGroupFactory {
-    type GroupRecorder = TraceMetricRecorder
+  val Factory = TraceMetricGroupFactory
 
-    def create(config: Config, system: ActorSystem): TraceMetricRecorder = {
+}
 
-      val settings = config.getConfig("precision.trace")
-      val elapsedTimeConfig = settings.getConfig("elapsed-time")
-      val segmentConfig = settings.getConfig("segment")
+case object TraceMetricGroupFactory extends MetricGroupFactory {
 
-      new TraceMetricRecorder(
-        Histogram.fromConfig(elapsedTimeConfig, Scale.Nano),
-        () ⇒ Histogram.fromConfig(segmentConfig, Scale.Nano))
-    }
+  import TraceMetrics._
+
+  type GroupRecorder = TraceMetricRecorder
+
+  def create(config: Config, system: ActorSystem): TraceMetricRecorder = {
+
+    val settings = config.getConfig("precision.trace")
+    val elapsedTimeConfig = settings.getConfig("elapsed-time")
+    val segmentConfig = settings.getConfig("segment")
+
+    new TraceMetricRecorder(
+      Histogram.fromConfig(elapsedTimeConfig, Scale.Nano),
+      () ⇒ Histogram.fromConfig(segmentConfig, Scale.Nano))
   }
-
 }

--- a/kamon-core/src/main/scala/kamon/metric/instrument/Histogram.scala
+++ b/kamon-core/src/main/scala/kamon/metric/instrument/Histogram.scala
@@ -156,7 +156,7 @@ class HdrHistogram(lowestTrackableValue: Long, highestTrackableValue: Long, sign
 
 }
 
-class CompactHdrSnapshot(val scale: Scale, val numberOfMeasurements: Long, compactRecords: Array[Long], unitMagnitude: Int,
+case class CompactHdrSnapshot(val scale: Scale, val numberOfMeasurements: Long, compactRecords: Array[Long], unitMagnitude: Int,
     subBucketHalfCount: Int, subBucketHalfCountMagnitude: Int) extends Histogram.Snapshot {
 
   def min: Long = if (compactRecords.length == 0) 0 else levelFromCompactRecord(compactRecords(0))

--- a/kamon-system-metrics/src/main/scala/kamon/metrics/CPUMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/metrics/CPUMetrics.scala
@@ -58,24 +58,27 @@ object CPUMetrics extends MetricGroupCategory {
       Idle -> idle)
   }
 
-  val Factory = new MetricGroupFactory {
-
-    type GroupRecorder = CPUMetricRecorder
-
-    def create(config: Config, system: ActorSystem): GroupRecorder = {
-      val settings = config.getConfig("precision.system.cpu")
-
-      val userConfig = settings.getConfig("user")
-      val systemConfig = settings.getConfig("system")
-      val cpuWaitConfig = settings.getConfig("wait")
-      val idleConfig = settings.getConfig("idle")
-
-      new CPUMetricRecorder(
-        Histogram.fromConfig(userConfig),
-        Histogram.fromConfig(systemConfig),
-        Histogram.fromConfig(cpuWaitConfig),
-        Histogram.fromConfig(idleConfig))
-    }
-  }
+  val Factory = CPUMetricGroupFactory
 }
 
+case object CPUMetricGroupFactory extends MetricGroupFactory {
+
+  import CPUMetrics._
+
+  type GroupRecorder = CPUMetricRecorder
+
+  def create(config: Config, system: ActorSystem): GroupRecorder = {
+    val settings = config.getConfig("precision.system.cpu")
+
+    val userConfig = settings.getConfig("user")
+    val systemConfig = settings.getConfig("system")
+    val cpuWaitConfig = settings.getConfig("wait")
+    val idleConfig = settings.getConfig("idle")
+
+    new CPUMetricRecorder(
+      Histogram.fromConfig(userConfig),
+      Histogram.fromConfig(systemConfig),
+      Histogram.fromConfig(cpuWaitConfig),
+      Histogram.fromConfig(idleConfig))
+  }
+}

--- a/kamon-system-metrics/src/main/scala/kamon/metrics/GCMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/metrics/GCMetrics.scala
@@ -56,20 +56,23 @@ object GCMetrics extends MetricGroupCategory {
       CollectionTime -> time)
   }
 
-  def Factory(gc: GarbageCollectorMXBean) = new MetricGroupFactory {
+  def Factory(gc: GarbageCollectorMXBean) = GCMetricGroupFactory(gc)
+}
 
-    type GroupRecorder = GCMetricRecorder
+case class GCMetricGroupFactory(gc: GarbageCollectorMXBean) extends MetricGroupFactory {
+  import GCMetrics._
 
-    def create(config: Config, system: ActorSystem): GroupRecorder = {
-      val settings = config.getConfig("precision.jvm.gc")
+  type GroupRecorder = GCMetricRecorder
 
-      val countConfig = settings.getConfig("count")
-      val timeConfig = settings.getConfig("time")
+  def create(config: Config, system: ActorSystem): GroupRecorder = {
+    val settings = config.getConfig("precision.jvm.gc")
 
-      new GCMetricRecorder(
-        Gauge.fromConfig(countConfig, system)(() ⇒ gc.getCollectionCount),
-        Gauge.fromConfig(timeConfig, system, Scale.Milli)(() ⇒ gc.getCollectionTime))
-    }
+    val countConfig = settings.getConfig("count")
+    val timeConfig = settings.getConfig("time")
+
+    new GCMetricRecorder(
+      Gauge.fromConfig(countConfig, system)(() ⇒ gc.getCollectionCount),
+      Gauge.fromConfig(timeConfig, system, Scale.Milli)(() ⇒ gc.getCollectionTime))
   }
 }
 

--- a/kamon-system-metrics/src/main/scala/kamon/metrics/HeapMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/metrics/HeapMetrics.scala
@@ -58,26 +58,30 @@ object HeapMetrics extends MetricGroupCategory {
       Committed -> committed)
   }
 
-  val Factory = new MetricGroupFactory {
-    import kamon.system.SystemMetricsExtension._
+  val Factory = HeapMetricGroupFactory
+}
 
-    val memory = ManagementFactory.getMemoryMXBean
-    def heap = memory.getHeapMemoryUsage
+case object HeapMetricGroupFactory extends MetricGroupFactory {
 
-    type GroupRecorder = HeapMetricRecorder
+  import HeapMetrics._
+  import kamon.system.SystemMetricsExtension._
 
-    def create(config: Config, system: ActorSystem): GroupRecorder = {
-      val settings = config.getConfig("precision.jvm.heap")
+  def heap = ManagementFactory.getMemoryMXBean.getHeapMemoryUsage
 
-      val usedHeapConfig = settings.getConfig("used")
-      val maxHeapConfig = settings.getConfig("max")
-      val committedHeapConfig = settings.getConfig("committed")
+  type GroupRecorder = HeapMetricRecorder
 
-      new HeapMetricRecorder(
-        Gauge.fromConfig(usedHeapConfig, system, Scale.Mega)(() ⇒ toMB(heap.getUsed)),
-        Gauge.fromConfig(maxHeapConfig, system, Scale.Mega)(() ⇒ toMB(heap.getMax)),
-        Gauge.fromConfig(committedHeapConfig, system, Scale.Mega)(() ⇒ toMB(heap.getCommitted)))
-    }
+  def create(config: Config, system: ActorSystem): GroupRecorder = {
+    val settings = config.getConfig("precision.jvm.heap")
+
+    val usedHeapConfig = settings.getConfig("used")
+    val maxHeapConfig = settings.getConfig("max")
+    val committedHeapConfig = settings.getConfig("committed")
+
+    new HeapMetricRecorder(
+      Gauge.fromConfig(usedHeapConfig, system, Scale.Mega)(() ⇒ toMB(heap.getUsed)),
+      Gauge.fromConfig(maxHeapConfig, system, Scale.Mega)(() ⇒ toMB(heap.getMax)),
+      Gauge.fromConfig(committedHeapConfig, system, Scale.Mega)(() ⇒ toMB(heap.getCommitted)))
   }
+
 }
 

--- a/kamon-system-metrics/src/main/scala/kamon/metrics/MemoryMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/metrics/MemoryMetrics.scala
@@ -62,27 +62,31 @@ object MemoryMetrics extends MetricGroupCategory {
       SwapFree -> swapFree)
   }
 
-  val Factory = new MetricGroupFactory {
+  val Factory = MemoryMetricGroupFactory
+}
 
-    type GroupRecorder = MemoryMetricRecorder
+case object MemoryMetricGroupFactory extends MetricGroupFactory {
 
-    def create(config: Config, system: ActorSystem): GroupRecorder = {
-      val settings = config.getConfig("precision.system.memory")
+  import MemoryMetrics._
 
-      val usedConfig = settings.getConfig("used")
-      val freeConfig = settings.getConfig("free")
-      val bufferConfig = settings.getConfig("buffer")
-      val cacheConfig = settings.getConfig("cache")
-      val swapUsedConfig = settings.getConfig("swap-used")
-      val swapFreeConfig = settings.getConfig("swap-free")
+  type GroupRecorder = MemoryMetricRecorder
 
-      new MemoryMetricRecorder(
-        Histogram.fromConfig(usedConfig, Scale.Mega),
-        Histogram.fromConfig(freeConfig, Scale.Mega),
-        Histogram.fromConfig(swapUsedConfig, Scale.Mega),
-        Histogram.fromConfig(swapFreeConfig, Scale.Mega),
-        Histogram.fromConfig(bufferConfig, Scale.Mega),
-        Histogram.fromConfig(cacheConfig, Scale.Mega))
-    }
+  def create(config: Config, system: ActorSystem): GroupRecorder = {
+    val settings = config.getConfig("precision.system.memory")
+
+    val usedConfig = settings.getConfig("used")
+    val freeConfig = settings.getConfig("free")
+    val bufferConfig = settings.getConfig("buffer")
+    val cacheConfig = settings.getConfig("cache")
+    val swapUsedConfig = settings.getConfig("swap-used")
+    val swapFreeConfig = settings.getConfig("swap-free")
+
+    new MemoryMetricRecorder(
+      Histogram.fromConfig(usedConfig, Scale.Mega),
+      Histogram.fromConfig(freeConfig, Scale.Mega),
+      Histogram.fromConfig(swapUsedConfig, Scale.Mega),
+      Histogram.fromConfig(swapFreeConfig, Scale.Mega),
+      Histogram.fromConfig(bufferConfig, Scale.Mega),
+      Histogram.fromConfig(cacheConfig, Scale.Mega))
   }
 }

--- a/kamon-system-metrics/src/main/scala/kamon/metrics/NetworkMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/metrics/NetworkMetrics.scala
@@ -58,23 +58,26 @@ object NetworkMetrics extends MetricGroupCategory {
       TxErrors -> txErrors)
   }
 
-  val Factory = new MetricGroupFactory {
+  val Factory = NetworkMetricGroupFactory
+}
 
-    type GroupRecorder = NetworkMetricRecorder
+case object NetworkMetricGroupFactory extends MetricGroupFactory {
+  import NetworkMetrics._
 
-    def create(config: Config, system: ActorSystem): GroupRecorder = {
-      val settings = config.getConfig("precision.system.network")
+  type GroupRecorder = NetworkMetricRecorder
 
-      val rxBytesConfig = settings.getConfig("rx-bytes")
-      val txBytesConfig = settings.getConfig("tx-bytes")
-      val rxErrorsConfig = settings.getConfig("rx-errors")
-      val txErrorsConfig = settings.getConfig("tx-errors")
+  def create(config: Config, system: ActorSystem): GroupRecorder = {
+    val settings = config.getConfig("precision.system.network")
 
-      new NetworkMetricRecorder(
-        Histogram.fromConfig(rxBytesConfig, Scale.Kilo),
-        Histogram.fromConfig(txBytesConfig, Scale.Kilo),
-        Histogram.fromConfig(rxErrorsConfig),
-        Histogram.fromConfig(txErrorsConfig))
-    }
+    val rxBytesConfig = settings.getConfig("rx-bytes")
+    val txBytesConfig = settings.getConfig("tx-bytes")
+    val rxErrorsConfig = settings.getConfig("rx-errors")
+    val txErrorsConfig = settings.getConfig("tx-errors")
+
+    new NetworkMetricRecorder(
+      Histogram.fromConfig(rxBytesConfig, Scale.Kilo),
+      Histogram.fromConfig(txBytesConfig, Scale.Kilo),
+      Histogram.fromConfig(rxErrorsConfig),
+      Histogram.fromConfig(txErrorsConfig))
   }
 }

--- a/kamon-system-metrics/src/main/scala/kamon/metrics/ProcessCPUMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/metrics/ProcessCPUMetrics.scala
@@ -54,20 +54,23 @@ object ProcessCPUMetrics extends MetricGroupCategory {
       TotalProcessTime -> totalProcessTime)
   }
 
-  val Factory = new MetricGroupFactory {
+  val Factory = ProcessCPUMetricGroupFactory
+}
 
-    type GroupRecorder = ProcessCPUMetricsRecorder
+case object ProcessCPUMetricGroupFactory extends MetricGroupFactory {
+  import ProcessCPUMetrics._
 
-    def create(config: Config, system: ActorSystem): GroupRecorder = {
-      val settings = config.getConfig("precision.system.process-cpu")
+  type GroupRecorder = ProcessCPUMetricsRecorder
 
-      val cpuPercentageConfig = settings.getConfig("cpu-percentage")
-      val totalProcessTimeConfig = settings.getConfig("total-process-time")
+  def create(config: Config, system: ActorSystem): GroupRecorder = {
+    val settings = config.getConfig("precision.system.process-cpu")
 
-      new ProcessCPUMetricsRecorder(
-        Histogram.fromConfig(cpuPercentageConfig),
-        Histogram.fromConfig(totalProcessTimeConfig))
-    }
+    val cpuPercentageConfig = settings.getConfig("cpu-percentage")
+    val totalProcessTimeConfig = settings.getConfig("total-process-time")
+
+    new ProcessCPUMetricsRecorder(
+      Histogram.fromConfig(cpuPercentageConfig),
+      Histogram.fromConfig(totalProcessTimeConfig))
   }
 }
 


### PR DESCRIPTION
The blog entry at http://kamon.io/teamblog/2014/08/31/experimental-support-for-akka-remoting-and-cluster-is-now-available/ states the following:
"First, it doesn't blow up in your face anymore, previous to this snapshot users of remoting and cluster might experiment errors because some parts of Kamon were not Serializable, making it imposible for them to use Kamon in such projects. Now we did what was necessary to ensure that all messages flow without problems, keep reading for more on that."
It turns out that if akka is configured with option "akka.actor.serialize-messages = on" it still blows up.
This commit seems to fix the issue.
