### PR TITLE
+ statsd: added metric name normalization strategy 'normalize-uuid' 

### DIFF
--- a/kamon-statsd/src/main/resources/reference.conf
+++ b/kamon-statsd/src/main/resources/reference.conf
@@ -50,6 +50,7 @@ kamon {
       # names) or forward slashes (all actor metrics) we need to sanitize those values before sending them to StatsD
       # with one of the following strategies:
       #   - normalize: changes ': ' to '-' and ' ', '/' and '.' to '_'.
+      #   - normalize-uuid: same as 'normalize' + UUID patterns are replaced with constant string 'UUID'
       #   - percent-encode: percent encode the section on the metric name. Please note that StatsD doesn't support
       #     percent encoded metric names, this option is only useful if using our docker image which has a patched
       #     version of StatsD or if you are running your own, customized version of StatsD that supports this.

--- a/kamon-statsd/src/main/scala/kamon/statsd/SimpleMetricKeyGenerator.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/SimpleMetricKeyGenerator.scala
@@ -9,6 +9,8 @@ import kamon.metric.{ MetricIdentity, MetricGroupIdentity }
 class SimpleMetricKeyGenerator(config: Config) extends StatsD.MetricKeyGenerator {
   type Normalizer = String ⇒ String
 
+  val uuidPattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
   val configSettings = config.getConfig("kamon.statsd.simple-metric-key-generator")
   val application = configSettings.getString("application")
   val includeHostname = configSettings.getBoolean("include-hostname")
@@ -37,7 +39,8 @@ class SimpleMetricKeyGenerator(config: Config) extends StatsD.MetricKeyGenerator
 
   def createNormalizer(strategy: String): Normalizer = strategy match {
     case "percent-encode" ⇒ PercentEncoder.encode
-    case "normalize"      ⇒ (s: String) ⇒ s.replace(": ", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
+    case "normalize" ⇒ (s: String) ⇒ s.replace(": ", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
+    case "normalize-uuid" ⇒ (s: String) ⇒ s.replaceAll(uuidPattern, "UUID").replace(": ", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
   }
 }
 


### PR DESCRIPTION
This metric name normalization strategy replaces random UUIDs with the constant 'UUID'.
The intention is to generate constant metric names for akka actors with randomized names.
