### PR TITLE
= core: Fix ThresholdSampler to use minimum-elapsed-time setting

### DIFF
--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -154,7 +154,7 @@ kamon {
     # Gather tracing information for all traces but only report those whose elapsed-time is equal or greated to the
     # .minimum-elapsed-time setting.
     threshold-sampler {
-      threshold = 1 second
+      minimum-elapsed-time = 1 second
     }
 
     incubator {

--- a/kamon-core/src/main/scala/kamon/trace/TraceExtension.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TraceExtension.scala
@@ -16,6 +16,8 @@
 
 package kamon.trace
 
+import java.util.concurrent.TimeUnit
+
 import akka.actor._
 import akka.actor
 import akka.event.Logging
@@ -39,7 +41,7 @@ class TraceExtension(system: ExtendedActorSystem) extends Kamon.Extension {
       case "all"       ⇒ SampleAll
       case "random"    ⇒ new RandomSampler(config.getInt("random-sampler.chance"))
       case "ordered"   ⇒ new OrderedSampler(config.getInt("ordered-sampler.interval"))
-      case "threshold" ⇒ new RandomSampler(config.getInt("threshold-sampler.threshold"))
+      case "threshold" ⇒ new ThresholdSampler(config.getDuration("threshold-sampler.minimum-elapsed-time", TimeUnit.NANOSECONDS))
     }
 
   val log = Logging(system, "TraceExtension")


### PR DESCRIPTION
Also fixes usage of ThresholdSampler if "threshold" is configured
as sampling strategy.
