### PR TITLE
Single kamon instance per jvm

### DIFF
--- a/kamon-akka-remote/src/main/scala/kamon/akka/instrumentation/RemotingInstrumentation.scala
+++ b/kamon-akka-remote/src/main/scala/kamon/akka/instrumentation/RemotingInstrumentation.scala
@@ -5,7 +5,8 @@ import akka.remote.instrumentation.TraceContextAwareWireFormats.{ TraceContextAw
 import akka.remote.{ RemoteActorRefProvider, Ack, SeqNo }
 import akka.remote.WireFormats._
 import akka.util.ByteString
-import kamon.trace.{ Tracer, TraceContext }
+import kamon.Kamon
+import kamon.trace.TraceContext
 import kamon.util.MilliTimestamp
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -83,7 +84,7 @@ class RemotingInstrumentation {
     if (ackAndEnvelope.hasEnvelope && ackAndEnvelope.getEnvelope.hasTraceContext) {
       val remoteTraceContext = ackAndEnvelope.getEnvelope.getTraceContext
       val system = provider.guardian.underlying.system
-      val tracer = Tracer.get(system)
+      val tracer = Kamon.tracer
 
       val ctx = tracer.newContext(
         remoteTraceContext.getTraceName,

--- a/kamon-akka-remote/src/test/scala/kamon/akka/instrumentation/RemotingInstrumentationSpec.scala
+++ b/kamon-akka-remote/src/test/scala/kamon/akka/instrumentation/RemotingInstrumentationSpec.scala
@@ -16,23 +16,27 @@ import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Matchers with ImplicitSender {
-  implicit lazy val system: ActorSystem = ActorSystem("remoting-spec-local-system", ConfigFactory.parseString(
-    """
-      |akka {
-      |  loggers = ["akka.event.slf4j.Slf4jLogger"]
-      |
-      |  actor {
-      |    provider = "akka.remote.RemoteActorRefProvider"
-      |  }
-      |  remote {
-      |    enabled-transports = ["akka.remote.netty.tcp"]
-      |    netty.tcp {
-      |      hostname = "127.0.0.1"
-      |      port = 2552
-      |    }
-      |  }
-      |}
-    """.stripMargin))
+
+  implicit lazy val system: ActorSystem = {
+    Kamon.start()
+    ActorSystem("remoting-spec-local-system", ConfigFactory.parseString(
+      """
+        |akka {
+        |  loggers = ["akka.event.slf4j.Slf4jLogger"]
+        |
+        |  actor {
+        |    provider = "akka.remote.RemoteActorRefProvider"
+        |  }
+        |  remote {
+        |    enabled-transports = ["akka.remote.netty.tcp"]
+        |    netty.tcp {
+        |      hostname = "127.0.0.1"
+        |      port = 2552
+        |    }
+        |  }
+        |}
+      """.stripMargin))
+  }
 
   val remoteSystem: ActorSystem = ActorSystem("remoting-spec-remote-system", ConfigFactory.parseString(
     """
@@ -52,13 +56,12 @@ class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Mat
       |}
     """.stripMargin))
 
-  lazy val kamon = Kamon(system)
   val RemoteSystemAddress = AddressFromURIString("akka.tcp://remoting-spec-remote-system@127.0.0.1:2553")
-  import kamon.tracer.newContext
+  import Kamon.tracer
 
   "The Remoting instrumentation" should {
     "propagate the TraceContext when creating a new remote actor" in {
-      TraceContext.withContext(newContext("deploy-remote-actor", "deploy-remote-actor-1")) {
+      TraceContext.withContext(tracer.newContext("deploy-remote-actor", "deploy-remote-actor-1")) {
         system.actorOf(TraceTokenReplier.remoteProps(Some(testActor), RemoteSystemAddress), "remote-deploy-fixture")
       }
 
@@ -68,7 +71,7 @@ class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Mat
     "propagate the TraceContext when sending a message to a remotely deployed actor" in {
       val remoteRef = system.actorOf(TraceTokenReplier.remoteProps(None, RemoteSystemAddress), "remote-message-fixture")
 
-      TraceContext.withContext(newContext("message-remote-actor", "message-remote-actor-1")) {
+      TraceContext.withContext(tracer.newContext("message-remote-actor", "message-remote-actor-1")) {
         remoteRef ! "reply-trace-token"
       }
 
@@ -80,7 +83,7 @@ class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Mat
       implicit val askTimeout = Timeout(10 seconds)
       val remoteRef = system.actorOf(TraceTokenReplier.remoteProps(None, RemoteSystemAddress), "remote-ask-and-pipe-fixture")
 
-      TraceContext.withContext(newContext("ask-and-pipe-remote-actor", "ask-and-pipe-remote-actor-1")) {
+      TraceContext.withContext(tracer.newContext("ask-and-pipe-remote-actor", "ask-and-pipe-remote-actor-1")) {
         (remoteRef ? "reply-trace-token") pipeTo (testActor)
       }
 
@@ -92,7 +95,7 @@ class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Mat
       remoteSystem.actorOf(TraceTokenReplier.props(None), "actor-selection-target-b")
       val selection = system.actorSelection(RemoteSystemAddress + "/user/actor-selection-target-*")
 
-      TraceContext.withContext(newContext("message-remote-actor-selection", "message-remote-actor-selection-1")) {
+      TraceContext.withContext(tracer.newContext("message-remote-actor-selection", "message-remote-actor-selection-1")) {
         selection ! "reply-trace-token"
       }
 
@@ -104,7 +107,7 @@ class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Mat
     "propagate the TraceContext a remotely supervised child fails" in {
       val supervisor = system.actorOf(Props(new SupervisorOfRemote(testActor, RemoteSystemAddress)))
 
-      TraceContext.withContext(newContext("remote-supervision", "remote-supervision-1")) {
+      TraceContext.withContext(tracer.newContext("remote-supervision", "remote-supervision-1")) {
         supervisor ! "fail"
       }
 
@@ -115,7 +118,7 @@ class RemotingInstrumentationSpec extends TestKitBase with WordSpecLike with Mat
       remoteSystem.actorOf(TraceTokenReplier.props(None), "remote-routee")
       val router = system.actorOf(RoundRobinGroup(List(RemoteSystemAddress + "/user/actor-selection-target-*")).props(), "router")
 
-      TraceContext.withContext(newContext("remote-routee", "remote-routee-1")) {
+      TraceContext.withContext(tracer.newContext("remote-routee", "remote-routee-1")) {
         router ! "reply-trace-token"
       }
 

--- a/kamon-akka/src/main/resources/reference.conf
+++ b/kamon-akka/src/main/resources/reference.conf
@@ -12,8 +12,6 @@ kamon {
     #   - heavyweight: logs the warning when a timeout is reached using a stack trace captured at the moment the future was created.
     ask-pattern-timeout-warning = off
 
-    # Default dispatcher for all akka module operations
-    dispatcher = kamon.default-dispatcher
   }
 
   metric.filters {

--- a/kamon-akka/src/main/scala/kamon/akka/AkkaExtension.scala
+++ b/kamon-akka/src/main/scala/kamon/akka/AkkaExtension.scala
@@ -23,7 +23,7 @@ import kamon._
 class AkkaExtension(system: ExtendedActorSystem) extends Kamon.Extension {
   val config = system.settings.config.getConfig("kamon.akka")
   val askPatternTimeoutWarning = config.getString("ask-pattern-timeout-warning")
-  val dispatcher = system.dispatchers.lookup(config.getString("dispatcher"))
+  val dispatcher = system.dispatcher
 }
 
 object Akka extends ExtensionId[AkkaExtension] with ExtensionIdProvider {

--- a/kamon-akka/src/main/scala/kamon/akka/instrumentation/AskPatternInstrumentation.scala
+++ b/kamon-akka/src/main/scala/kamon/akka/instrumentation/AskPatternInstrumentation.scala
@@ -44,7 +44,7 @@ class AskPatternInstrumentation {
       actor match {
         // the AskPattern will only work for InternalActorRef's with these conditions.
         case ref: InternalActorRef if !ref.isTerminated && timeout.duration.length > 0 ⇒
-          val akkaExtension = ctx.lookupExtension(Akka)
+          val akkaExtension = Kamon.extension(Akka)
           val future = pjp.proceed().asInstanceOf[Future[AnyRef]]
           val system = ref.provider.guardian.underlying.system
 

--- a/kamon-akka/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
+++ b/kamon-akka/src/main/scala/kamon/akka/instrumentation/DispatcherInstrumentation.scala
@@ -22,8 +22,9 @@ import akka.actor.{ ActorSystem, ActorSystemImpl }
 import akka.dispatch.ForkJoinExecutorConfigurator.AkkaForkJoinPool
 import akka.dispatch._
 import akka.kamon.instrumentation.LookupDataAware.LookupData
+import kamon.Kamon
 import kamon.akka.{ AkkaDispatcherMetrics, ThreadPoolExecutorDispatcherMetrics, ForkJoinPoolDispatcherMetrics }
-import kamon.metric.{ Metrics, Entity }
+import kamon.metric.Entity
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
 
@@ -58,10 +59,10 @@ class DispatcherInstrumentation {
   private def registerDispatcher(dispatcherName: String, executorService: ExecutorService, system: ActorSystem): Unit =
     executorService match {
       case fjp: AkkaForkJoinPool ⇒
-        Metrics.get(system).register(ForkJoinPoolDispatcherMetrics.factory(fjp), dispatcherName)
+        Kamon.metrics.register(ForkJoinPoolDispatcherMetrics.factory(fjp), dispatcherName)
 
       case tpe: ThreadPoolExecutor ⇒
-        Metrics.get(system).register(ThreadPoolExecutorDispatcherMetrics.factory(tpe), dispatcherName)
+        Kamon.metrics.register(ThreadPoolExecutorDispatcherMetrics.factory(tpe), dispatcherName)
 
       case others ⇒ // Currently not interested in other kinds of dispatchers.
     }
@@ -119,7 +120,7 @@ class DispatcherInstrumentation {
     import lazyExecutor.lookupData
 
     if (lookupData.actorSystem != null)
-      Metrics.get(lookupData.actorSystem).unregister(Entity(lookupData.dispatcherName, AkkaDispatcherMetrics.Category))
+      Kamon.metrics.unregister(Entity(lookupData.dispatcherName, AkkaDispatcherMetrics.Category))
   }
 
 }

--- a/kamon-akka/src/test/scala/kamon/akka/DispatcherMetricsSpec.scala
+++ b/kamon-akka/src/test/scala/kamon/akka/DispatcherMetricsSpec.scala
@@ -15,17 +15,14 @@
 
 package kamon.akka
 
-import java.nio.LongBuffer
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.ActorRef
 import akka.dispatch.MessageDispatcher
-import akka.testkit.{ TestKitBase, TestProbe }
+import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import kamon.Kamon
-import kamon.metric.instrument.CollectionContext
 import kamon.metric.{ EntityRecorder, EntitySnapshot }
 import kamon.testkit.BaseKamonSpec
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }

--- a/kamon-akka/src/test/scala/kamon/akka/instrumentation/AskPatternInstrumentationSpec.scala
+++ b/kamon-akka/src/test/scala/kamon/akka/instrumentation/AskPatternInstrumentationSpec.scala
@@ -114,7 +114,7 @@ class AskPatternInstrumentationSpec extends BaseKamonSpec("ask-pattern-tracing-s
   }
 
   def setAskPatternTimeoutWarningMode(mode: String): Unit = {
-    val target = Kamon(Akka)(system)
+    val target = Kamon(Akka)
     val field = target.getClass.getDeclaredField("askPatternTimeoutWarning")
     field.setAccessible(true)
     field.set(target, mode)

--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -82,15 +82,6 @@ kamon {
     instrument-settings {
 
     }
-
-    dispatchers {
-
-      # Dispatcher for the actor that will collect all recorded metrics on every tick and dispatch them to all subscribers.
-      metric-collection = kamon.default-dispatcher
-
-      # Dispatcher for the Kamon refresh scheduler, used by all MinMaxCounters and Gaugues to update their values.
-      refresh-scheduler = kamon.default-dispatcher
-    }
   }
 
 
@@ -140,35 +131,30 @@ kamon {
       # open after this point.
       max-incubation-time = 20 seconds
     }
-
-    # Default dispatcher for all trace module operations
-    dispatcher = kamon.default-dispatcher
   }
 
-  default-dispatcher {
-    # Dispatcher is the name of the event-based dispatcher
-    type = Dispatcher
 
-    # What kind of ExecutionService to use
-    executor = "fork-join-executor"
+  # All settings included under the internal-config key will be used to repleace the akka.* and spray.* settings. By
+  # doing this we avoid applying custom settings that might make sense for the user application to the internal actor
+  # system and Spray facilities used by Kamon.
+  internal-config {
 
-    # Configuration for the fork join pool
-    fork-join-executor {
-      # Min number of threads to cap factor-based parallelism number to
-      parallelism-min = 2
+    akka.actor.default-dispatcher {
+      fork-join-executor {
+        parallelism-min = 2
+        parallelism-factor = 2.0
+        parallelism-max = 10
+      }
+    }
 
-      # The parallelism factor is used to determine thread pool size using the
-      # following formula: ceil(available processors * factor). Resulting size
-      # is then bounded by the parallelism-min and parallelism-max values.
-      parallelism-factor = 2.0
+    spray {
 
-      # Max number of threads to cap factor-based parallelism number to
-      parallelism-max = 10
     }
   }
 
-
-  disable-aspectj-missing-warning = false
+  # Controls whether the AspectJ Weaver missing warning should be displayed if any Kamon module requiring AspectJ is
+  # found in the classpath but the application is started without the AspectJ Weaver.
+  show-aspectj-missing-warning = yes
 
   modules {
     # Just a place holder to ensure that the key is always available. Non-core Kamon modules should provide their

--- a/kamon-core/src/main/scala/kamon/metric/TickMetricSnapshotBuffer.scala
+++ b/kamon-core/src/main/scala/kamon/metric/TickMetricSnapshotBuffer.scala
@@ -29,7 +29,7 @@ class TickMetricSnapshotBuffer(flushInterval: FiniteDuration, receiver: ActorRef
   import MapMerge.Syntax
 
   val flushSchedule = context.system.scheduler.schedule(flushInterval, flushInterval, self, FlushBuffer)(context.dispatcher)
-  val collectionContext: CollectionContext = Kamon(Metrics)(context.system).buildDefaultCollectionContext
+  val collectionContext: CollectionContext = Kamon.metrics.buildDefaultCollectionContext
 
   def receive = empty
 

--- a/kamon-core/src/main/scala/kamon/metric/instrument/Instrument.scala
+++ b/kamon-core/src/main/scala/kamon/metric/instrument/Instrument.scala
@@ -51,22 +51,3 @@ object CollectionContext {
   }
 }
 
-trait RefreshScheduler {
-  def schedule(interval: FiniteDuration, refresh: () ⇒ Unit): Cancellable
-}
-
-object RefreshScheduler {
-  val NoopScheduler = new RefreshScheduler {
-    def schedule(interval: FiniteDuration, refresh: () ⇒ Unit): Cancellable = new Cancellable {
-      override def isCancelled: Boolean = true
-      override def cancel(): Boolean = true
-    }
-  }
-
-  def apply(scheduler: Scheduler, dispatcher: MessageDispatcher): RefreshScheduler = new RefreshScheduler {
-    def schedule(interval: FiniteDuration, refresh: () ⇒ Unit): Cancellable =
-      scheduler.schedule(interval, interval)(refresh.apply())(dispatcher)
-  }
-
-  def create(scheduler: Scheduler, dispatcher: MessageDispatcher): RefreshScheduler = apply(scheduler, dispatcher)
-}

--- a/kamon-core/src/main/scala/kamon/metric/instrument/RefreshScheduler.scala
+++ b/kamon-core/src/main/scala/kamon/metric/instrument/RefreshScheduler.scala
@@ -1,0 +1,99 @@
+package kamon.metric.instrument
+
+import akka.actor.{ Scheduler, Cancellable }
+import org.HdrHistogram.WriterReaderPhaser
+
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+trait RefreshScheduler {
+  def schedule(interval: FiniteDuration, refresh: () ⇒ Unit): Cancellable
+}
+
+/**
+ *  Default implementation of RefreshScheduler that simply uses an [[akka.actor.Scheduler]] to schedule tasks to be run
+ *  in the provided ExecutionContext.
+ */
+class DefaultRefreshScheduler(scheduler: Scheduler, dispatcher: ExecutionContext) extends RefreshScheduler {
+  def schedule(interval: FiniteDuration, refresh: () ⇒ Unit): Cancellable =
+    scheduler.schedule(interval, interval)(refresh.apply())(dispatcher)
+}
+
+object DefaultRefreshScheduler {
+  def apply(scheduler: Scheduler, dispatcher: ExecutionContext): RefreshScheduler =
+    new DefaultRefreshScheduler(scheduler, dispatcher)
+
+  def create(scheduler: Scheduler, dispatcher: ExecutionContext): RefreshScheduler =
+    apply(scheduler, dispatcher)
+}
+
+/**
+ *  RefreshScheduler implementation that accumulates all the scheduled actions until it is pointed to another refresh
+ *  scheduler. Once it is pointed, all subsequent calls to `schedule` will immediately be scheduled in the pointed
+ *  scheduler.
+ */
+class LazyRefreshScheduler extends RefreshScheduler {
+  private val _schedulerPhaser = new WriterReaderPhaser
+  private val _backlog = new TrieMap[(FiniteDuration, () ⇒ Unit), RepointableCancellable]()
+  @volatile private var _target: Option[RefreshScheduler] = None
+
+  def schedule(interval: FiniteDuration, refresh: () ⇒ Unit): Cancellable = {
+    val criticalEnter = _schedulerPhaser.writerCriticalSectionEnter()
+    try {
+      _target.map { scheduler ⇒
+        scheduler.schedule(interval, refresh)
+
+      } getOrElse {
+        val entry = (interval, refresh)
+        val cancellable = new RepointableCancellable(entry)
+
+        _backlog.put(entry, cancellable)
+        cancellable
+      }
+
+    } finally {
+      _schedulerPhaser.writerCriticalSectionExit(criticalEnter)
+    }
+  }
+
+  def point(target: RefreshScheduler): Unit = try {
+    _schedulerPhaser.readerLock()
+
+    if (_target.isEmpty) {
+      _target = Some(target)
+      _schedulerPhaser.flipPhase(10000L)
+      _backlog.dropWhile {
+        case ((interval, refresh), repointableCancellable) ⇒
+          repointableCancellable.point(target.schedule(interval, refresh))
+          true
+      }
+    } else sys.error("A LazyRefreshScheduler cannot be pointed more than once.")
+  } finally { _schedulerPhaser.readerUnlock() }
+
+  class RepointableCancellable(entry: (FiniteDuration, () ⇒ Unit)) extends Cancellable {
+    private var _isCancelled = false
+    private var _cancellable: Option[Cancellable] = None
+
+    def isCancelled: Boolean = synchronized {
+      _cancellable.map(_.isCancelled).getOrElse(_isCancelled)
+    }
+
+    def cancel(): Boolean = synchronized {
+      _isCancelled = true
+      _cancellable.map(_.cancel()).getOrElse(_backlog.remove(entry).nonEmpty)
+    }
+
+    def point(cancellable: Cancellable): Unit = synchronized {
+      if (_cancellable.isEmpty) {
+        _cancellable = Some(cancellable)
+
+        if (_isCancelled)
+          cancellable.cancel()
+
+      } else sys.error("A RepointableCancellable cannot be pointed more than once.")
+
+    }
+  }
+}
+

--- a/kamon-core/src/main/scala/kamon/supervisor/ModuleSupervisorExtension.scala
+++ b/kamon-core/src/main/scala/kamon/supervisor/ModuleSupervisorExtension.scala
@@ -62,7 +62,7 @@ class KamonSupervisor(settings: ModuleSupervisorSettings, dynamicAccess: Dynamic
     } getOrElse (childPromise.complete(Success(context.actorOf(props, name))))
 
   def init(): Unit = {
-    if (settings.modulesRequiringAspectJ.nonEmpty && !isAspectJPresent && !settings.disableAspectJMissingWarning)
+    if (settings.modulesRequiringAspectJ.nonEmpty && !isAspectJPresent && settings.showAspectJMissingWarning)
       logAspectJWeaverMissing(settings.modulesRequiringAspectJ)
 
     // Force initialization of all modules marked with auto-start.
@@ -106,7 +106,7 @@ class KamonSupervisor(settings: ModuleSupervisorSettings, dynamicAccess: Dynamic
         |
         | If you need help on setting up the aspectj weaver go to http://kamon.io/introduction/get-started/ for more info. On the
         | other hand, if you are sure that you do not need or do not want to use the weaver then you can disable this error message
-        | by changing the kamon.disable-aspectj-missing-warning setting in your configuration file.
+        | by changing the kamon.show-aspectj-missing-warning setting in your configuration file.
         |
       """.stripMargin
 

--- a/kamon-core/src/main/scala/kamon/supervisor/ModuleSupervisorSettings.scala
+++ b/kamon-core/src/main/scala/kamon/supervisor/ModuleSupervisorSettings.scala
@@ -19,7 +19,7 @@ package kamon.supervisor
 import akka.actor.ActorSystem
 
 case class AvailableModuleInfo(name: String, extensionClass: String, requiresAspectJ: Boolean, autoStart: Boolean)
-case class ModuleSupervisorSettings(disableAspectJMissingWarning: Boolean, availableModules: List[AvailableModuleInfo]) {
+case class ModuleSupervisorSettings(showAspectJMissingWarning: Boolean, availableModules: List[AvailableModuleInfo]) {
   val modulesRequiringAspectJ = availableModules.filter(_.requiresAspectJ)
 }
 
@@ -29,7 +29,7 @@ object ModuleSupervisorSettings {
     import kamon.util.ConfigTools.Syntax
 
     val config = system.settings.config.getConfig("kamon.modules")
-    val disableAspectJMissingWarning = system.settings.config.getBoolean("kamon.disable-aspectj-missing-warning")
+    val showAspectJMissingWarning = system.settings.config.getBoolean("kamon.show-aspectj-missing-warning")
 
     val modules = config.firstLevelKeys
     val availableModules = modules.map { moduleName ⇒
@@ -43,7 +43,7 @@ object ModuleSupervisorSettings {
 
     } toList
 
-    ModuleSupervisorSettings(disableAspectJMissingWarning, availableModules)
+    ModuleSupervisorSettings(showAspectJMissingWarning, availableModules)
   }
 
 }

--- a/kamon-core/src/main/scala/kamon/trace/MetricsOnlyContext.scala
+++ b/kamon-core/src/main/scala/kamon/trace/MetricsOnlyContext.scala
@@ -18,16 +18,14 @@ package kamon.trace
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import akka.actor.{ ExtensionId, ActorSystem }
 import akka.event.LoggingAdapter
-import kamon.Kamon.Extension
 import kamon.metric.{ MetricsExtension, TraceMetrics }
 import kamon.util.{ NanoInterval, RelativeNanoTimestamp }
 
 import scala.annotation.tailrec
 
 private[kamon] class MetricsOnlyContext(traceName: String, val token: String, izOpen: Boolean, val levelOfDetail: LevelOfDetail,
-  val startTimestamp: RelativeNanoTimestamp, log: LoggingAdapter, metricsExtension: MetricsExtension, val actorSystem: ActorSystem)
+  val startTimestamp: RelativeNanoTimestamp, log: LoggingAdapter, metricsExtension: MetricsExtension)
     extends TraceContext {
 
   @volatile private var _name = traceName
@@ -47,8 +45,6 @@ private[kamon] class MetricsOnlyContext(traceName: String, val token: String, iz
   def isEmpty: Boolean = false
   def isOpen: Boolean = _isOpen
   def addMetadata(key: String, value: String): Unit = {}
-
-  def lookupExtension[T <: Extension](id: ExtensionId[T]): T = id(actorSystem)
 
   def finish(): Unit = {
     _isOpen = false

--- a/kamon-core/src/main/scala/kamon/trace/TraceContext.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TraceContext.scala
@@ -17,12 +17,8 @@
 package kamon.trace
 
 import java.io.ObjectStreamException
-import akka.actor.{ ExtensionId, ActorSystem }
-import kamon.Kamon.Extension
-import kamon._
-import kamon.metric._
 import kamon.trace.TraceContextAware.DefaultTraceContextAware
-import kamon.util.{ NanoInterval, RelativeNanoTimestamp }
+import kamon.util.RelativeNanoTimestamp
 
 trait TraceContext {
   def name: String
@@ -39,8 +35,6 @@ trait TraceContext {
   def addMetadata(key: String, value: String)
 
   def startTimestamp: RelativeNanoTimestamp
-
-  def lookupExtension[T <: Kamon.Extension](id: ExtensionId[T]): T
 }
 
 object TraceContext {
@@ -98,9 +92,6 @@ case object EmptyTraceContext extends TraceContext {
   def startSegment(segmentName: String, category: String, library: String): Segment = EmptySegment
   def addMetadata(key: String, value: String): Unit = {}
   def startTimestamp = new RelativeNanoTimestamp(0L)
-
-  override def lookupExtension[T <: Extension](id: ExtensionId[T]): T =
-    sys.error("Can't lookup extensions on a EmptyTraceContext.")
 
   case object EmptySegment extends Segment {
     val name: String = "empty-segment"

--- a/kamon-core/src/main/scala/kamon/trace/TracerExtensionSettings.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TracerExtensionSettings.scala
@@ -18,13 +18,13 @@ package kamon.trace
 
 import java.util.concurrent.TimeUnit
 
-import akka.actor.ActorSystem
+import com.typesafe.config.Config
 
 case class TraceSettings(levelOfDetail: LevelOfDetail, sampler: Sampler)
 
 object TraceSettings {
-  def apply(system: ActorSystem): TraceSettings = {
-    val tracerConfig = system.settings.config.getConfig("kamon.trace")
+  def apply(config: Config): TraceSettings = {
+    val tracerConfig = config.getConfig("kamon.trace")
 
     val detailLevel: LevelOfDetail = tracerConfig.getString("level-of-detail") match {
       case "metrics-only" ⇒ LevelOfDetail.MetricsOnly

--- a/kamon-core/src/main/scala/kamon/trace/TracingContext.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TracingContext.scala
@@ -19,7 +19,6 @@ package kamon.trace
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 
-import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import kamon.util.{ NanoInterval, RelativeNanoTimestamp, NanoTimestamp }
 import kamon.metric.MetricsExtension
@@ -28,8 +27,8 @@ import scala.collection.concurrent.TrieMap
 
 private[trace] class TracingContext(traceName: String, token: String, izOpen: Boolean, levelOfDetail: LevelOfDetail,
   isLocal: Boolean, startTimeztamp: RelativeNanoTimestamp, log: LoggingAdapter, metricsExtension: MetricsExtension,
-  traceExtension: TracerExtensionImpl, system: ActorSystem, traceInfoSink: TracingContext ⇒ Unit)
-    extends MetricsOnlyContext(traceName, token, izOpen, levelOfDetail, startTimeztamp, log, metricsExtension, system) {
+  traceExtension: TracerExtensionImpl, traceInfoSink: TracingContext ⇒ Unit)
+    extends MetricsOnlyContext(traceName, token, izOpen, levelOfDetail, startTimeztamp, log, metricsExtension) {
 
   private val _openSegments = new AtomicInteger(0)
   private val _startTimestamp = NanoTimestamp.now

--- a/kamon-core/src/main/scala/kamon/util/LazyActorRef.scala
+++ b/kamon-core/src/main/scala/kamon/util/LazyActorRef.scala
@@ -1,0 +1,53 @@
+package kamon.util
+
+import java.util
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import akka.actor.{ Actor, ActorRef }
+import org.HdrHistogram.WriterReaderPhaser
+
+import scala.annotation.tailrec
+
+/**
+ *  A LazyActorRef accumulates messages sent to an actor that doesn't exist yet. Once the actor is created and
+ *  the LazyActorRef is pointed to it, all the accumulated messages are flushed and any new message sent to the
+ *  LazyActorRef will immediately be sent to the pointed ActorRef.
+ *
+ *  This is intended to be used during Kamon's initialization where some components need to use ActorRefs to work
+ *  (like subscriptions and the trace incubator) but our internal ActorSystem is not yet ready to create the
+ *  required actors.
+ */
+class LazyActorRef {
+  private val _refPhaser = new WriterReaderPhaser
+  private val _backlog = new ConcurrentLinkedQueue[(Any, ActorRef)]()
+  @volatile private var _target: Option[ActorRef] = None
+
+  def tell(message: Any)(implicit sender: ActorRef = Actor.noSender): Unit = {
+    val criticalEnter = _refPhaser.writerCriticalSectionEnter()
+    try {
+      _target.map(_.tell(message, sender)) getOrElse {
+        _backlog.add((message, sender))
+      }
+
+    } finally { _refPhaser.writerCriticalSectionExit(criticalEnter) }
+  }
+
+  def point(target: ActorRef): Unit = {
+    @tailrec def drain(q: util.Queue[(Any, ActorRef)]): Unit = if (!q.isEmpty) {
+      val (msg, sender) = q.poll()
+      target.tell(msg, sender)
+      drain(q)
+    }
+
+    try {
+      _refPhaser.readerLock()
+
+      if (_target.isEmpty) {
+        _target = Some(target)
+        _refPhaser.flipPhase(1000L)
+        drain(_backlog)
+
+      } else sys.error("A LazyActorRef cannot be pointed more than once.")
+    } finally { _refPhaser.readerUnlock() }
+  }
+}

--- a/kamon-core/src/test/scala/kamon/metric/SubscriptionsProtocolSpec.scala
+++ b/kamon-core/src/test/scala/kamon/metric/SubscriptionsProtocolSpec.scala
@@ -19,6 +19,7 @@ package kamon.metric
 import akka.actor._
 import akka.testkit.{ TestProbe, ImplicitSender }
 import com.typesafe.config.ConfigFactory
+import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
 import kamon.testkit.BaseKamonSpec
 import scala.concurrent.duration._
@@ -32,7 +33,7 @@ class SubscriptionsProtocolSpec extends BaseKamonSpec("subscriptions-protocol-sp
         |}
       """.stripMargin)
 
-  val metricsModule = kamon.metrics
+  lazy val metricsModule = Kamon.metrics
   import metricsModule.{ register, subscribe, unsubscribe }
 
   "the Subscriptions messaging protocol" should {

--- a/kamon-core/src/test/scala/kamon/metric/TickMetricSnapshotBufferSpec.scala
+++ b/kamon-core/src/test/scala/kamon/metric/TickMetricSnapshotBufferSpec.scala
@@ -17,6 +17,7 @@
 package kamon.metric
 
 import com.typesafe.config.ConfigFactory
+import kamon.Kamon
 import kamon.metric.instrument.Histogram.MutableRecord
 import kamon.testkit.BaseKamonSpec
 import kamon.util.MilliTimestamp
@@ -85,9 +86,9 @@ class TickMetricSnapshotBufferSpec extends BaseKamonSpec("trace-metrics-spec") w
   }
 
   trait SnapshotFixtures {
-    val collectionContext = kamon.metrics.buildDefaultCollectionContext
+    val collectionContext = Kamon.metrics.buildDefaultCollectionContext
     val testTraceIdentity = Entity("buffer-spec-test-trace", "trace")
-    val traceRecorder = kamon.metrics.register(TraceMetrics, "buffer-spec-test-trace").get.recorder
+    val traceRecorder = Kamon.metrics.register(TraceMetrics, "buffer-spec-test-trace").get.recorder
 
     val firstEmpty = TickMetricSnapshot(new MilliTimestamp(1000), new MilliTimestamp(2000), Map.empty)
     val secondEmpty = TickMetricSnapshot(new MilliTimestamp(2000), new MilliTimestamp(3000), Map.empty)

--- a/kamon-core/src/test/scala/kamon/metric/UserMetricsSpec.scala
+++ b/kamon-core/src/test/scala/kamon/metric/UserMetricsSpec.scala
@@ -17,6 +17,7 @@
 package kamon.metric
 
 import com.typesafe.config.ConfigFactory
+import kamon.Kamon
 import kamon.metric.instrument.Histogram.DynamicRange
 import kamon.testkit.BaseKamonSpec
 import scala.concurrent.duration._
@@ -34,54 +35,54 @@ class UserMetricsSpec extends BaseKamonSpec("user-metrics-spec") {
   "the UserMetrics extension" should {
 
     "allow registering a fully configured Histogram and get the same Histogram if registering again" in {
-      val histogramA = kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 10000, 2))
-      val histogramB = kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 10000, 2))
+      val histogramA = Kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 10000, 2))
+      val histogramB = Kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 10000, 2))
 
       histogramA shouldBe theSameInstanceAs(histogramB)
     }
 
     "return the original Histogram when registering a fully configured Histogram for second time but with different settings" in {
-      val histogramA = kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 10000, 2))
-      val histogramB = kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 50000, 2))
+      val histogramA = Kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 10000, 2))
+      val histogramB = Kamon.userMetrics.histogram("histogram-with-settings", DynamicRange(1, 50000, 2))
 
       histogramA shouldBe theSameInstanceAs(histogramB)
     }
 
     "allow registering a Histogram that takes the default configuration from the kamon.metrics.precision settings" in {
-      kamon.userMetrics.histogram("histogram-with-default-configuration")
+      Kamon.userMetrics.histogram("histogram-with-default-configuration")
     }
 
     "allow registering a Counter and get the same Counter if registering again" in {
-      val counterA = kamon.userMetrics.counter("counter")
-      val counterB = kamon.userMetrics.counter("counter")
+      val counterA = Kamon.userMetrics.counter("counter")
+      val counterB = Kamon.userMetrics.counter("counter")
 
       counterA shouldBe theSameInstanceAs(counterB)
     }
 
     "allow registering a fully configured MinMaxCounter and get the same MinMaxCounter if registering again" in {
-      val minMaxCounterA = kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 10000, 2), 1 second)
-      val minMaxCounterB = kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 10000, 2), 1 second)
+      val minMaxCounterA = Kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 10000, 2), 1 second)
+      val minMaxCounterB = Kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 10000, 2), 1 second)
 
       minMaxCounterA shouldBe theSameInstanceAs(minMaxCounterB)
     }
 
     "return the original MinMaxCounter when registering a fully configured MinMaxCounter for second time but with different settings" in {
-      val minMaxCounterA = kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 10000, 2), 1 second)
-      val minMaxCounterB = kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 50000, 2), 1 second)
+      val minMaxCounterA = Kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 10000, 2), 1 second)
+      val minMaxCounterB = Kamon.userMetrics.minMaxCounter("min-max-counter-with-settings", DynamicRange(1, 50000, 2), 1 second)
 
       minMaxCounterA shouldBe theSameInstanceAs(minMaxCounterB)
     }
 
     "allow registering a MinMaxCounter that takes the default configuration from the kamon.metrics.precision settings" in {
-      kamon.userMetrics.minMaxCounter("min-max-counter-with-default-configuration")
+      Kamon.userMetrics.minMaxCounter("min-max-counter-with-default-configuration")
     }
 
     "allow registering a fully configured Gauge and get the same Gauge if registering again" in {
-      val gaugeA = kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
+      val gaugeA = Kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
         () ⇒ 1L
       })
 
-      val gaugeB = kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
+      val gaugeB = Kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
         () ⇒ 1L
       })
 
@@ -89,11 +90,11 @@ class UserMetricsSpec extends BaseKamonSpec("user-metrics-spec") {
     }
 
     "return the original Gauge when registering a fully configured Gauge for second time but with different settings" in {
-      val gaugeA = kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
+      val gaugeA = Kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
         () ⇒ 1L
       })
 
-      val gaugeB = kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
+      val gaugeB = Kamon.userMetrics.gauge("gauge-with-settings", DynamicRange(1, 10000, 2), 1 second, {
         () ⇒ 1L
       })
 
@@ -101,26 +102,26 @@ class UserMetricsSpec extends BaseKamonSpec("user-metrics-spec") {
     }
 
     "allow registering a Gauge that takes the default configuration from the kamon.metrics.precision settings" in {
-      kamon.userMetrics.gauge("gauge-with-default-configuration", {
+      Kamon.userMetrics.gauge("gauge-with-default-configuration", {
         () ⇒ 2L
       })
     }
 
     "allow un-registering user metrics" in {
-      val counter = kamon.userMetrics.counter("counter-for-remove")
-      val histogram = kamon.userMetrics.histogram("histogram-for-remove")
-      val minMaxCounter = kamon.userMetrics.minMaxCounter("min-max-counter-for-remove")
-      val gauge = kamon.userMetrics.gauge("gauge-for-remove", { () ⇒ 2L })
+      val counter = Kamon.userMetrics.counter("counter-for-remove")
+      val histogram = Kamon.userMetrics.histogram("histogram-for-remove")
+      val minMaxCounter = Kamon.userMetrics.minMaxCounter("min-max-counter-for-remove")
+      val gauge = Kamon.userMetrics.gauge("gauge-for-remove", { () ⇒ 2L })
 
-      kamon.userMetrics.removeCounter("counter-for-remove")
-      kamon.userMetrics.removeHistogram("histogram-for-remove")
-      kamon.userMetrics.removeMinMaxCounter("min-max-counter-for-remove")
-      kamon.userMetrics.removeGauge("gauge-for-remove")
+      Kamon.userMetrics.removeCounter("counter-for-remove")
+      Kamon.userMetrics.removeHistogram("histogram-for-remove")
+      Kamon.userMetrics.removeMinMaxCounter("min-max-counter-for-remove")
+      Kamon.userMetrics.removeGauge("gauge-for-remove")
 
-      counter should not be (theSameInstanceAs(kamon.userMetrics.counter("counter-for-remove")))
-      histogram should not be (theSameInstanceAs(kamon.userMetrics.histogram("histogram-for-remove")))
-      minMaxCounter should not be (theSameInstanceAs(kamon.userMetrics.minMaxCounter("min-max-counter-for-remove")))
-      gauge should not be (theSameInstanceAs(kamon.userMetrics.gauge("gauge-for-remove", { () ⇒ 2L })))
+      counter should not be (theSameInstanceAs(Kamon.userMetrics.counter("counter-for-remove")))
+      histogram should not be (theSameInstanceAs(Kamon.userMetrics.histogram("histogram-for-remove")))
+      minMaxCounter should not be (theSameInstanceAs(Kamon.userMetrics.minMaxCounter("min-max-counter-for-remove")))
+      gauge should not be (theSameInstanceAs(Kamon.userMetrics.gauge("gauge-for-remove", { () ⇒ 2L })))
     }
   }
 }

--- a/kamon-core/src/test/scala/kamon/metric/instrument/GaugeSpec.scala
+++ b/kamon-core/src/test/scala/kamon/metric/instrument/GaugeSpec.scala
@@ -17,6 +17,7 @@
 package kamon.metric.instrument
 
 import java.util.concurrent.atomic.AtomicLong
+import kamon.Kamon
 import kamon.metric.instrument.Histogram.DynamicRange
 import kamon.testkit.BaseKamonSpec
 import scala.concurrent.duration._
@@ -48,7 +49,7 @@ class GaugeSpec extends BaseKamonSpec("gauge-spec") {
 
       Thread.sleep(1.second.toMillis)
       gauge.cleanup
-      val snapshot = gauge.collect(kamon.metrics.buildDefaultCollectionContext)
+      val snapshot = gauge.collect(Kamon.metrics.buildDefaultCollectionContext)
 
       snapshot.numberOfMeasurements should be(10L +- 1L)
       snapshot.min should be(1)
@@ -58,7 +59,7 @@ class GaugeSpec extends BaseKamonSpec("gauge-spec") {
     "not record the current value when doing a collection" in new GaugeFixture {
       val (numberOfValuesRecorded, gauge) = createGauge(10 seconds)
 
-      val snapshot = gauge.collect(kamon.metrics.buildDefaultCollectionContext)
+      val snapshot = gauge.collect(Kamon.metrics.buildDefaultCollectionContext)
       snapshot.numberOfMeasurements should be(0)
       numberOfValuesRecorded.get() should be(0)
     }
@@ -67,7 +68,7 @@ class GaugeSpec extends BaseKamonSpec("gauge-spec") {
   trait GaugeFixture {
     def createGauge(refreshInterval: FiniteDuration = 100 millis): (AtomicLong, Gauge) = {
       val recordedValuesCounter = new AtomicLong(0)
-      val gauge = Gauge(DynamicRange(1, 100, 2), refreshInterval, kamon.metrics.settings.refreshScheduler, {
+      val gauge = Gauge(DynamicRange(1, 100, 2), refreshInterval, Kamon.metrics.settings.refreshScheduler, {
         () ⇒ recordedValuesCounter.addAndGet(1)
       })
 

--- a/kamon-core/src/test/scala/kamon/metric/instrument/MinMaxCounterSpec.scala
+++ b/kamon-core/src/test/scala/kamon/metric/instrument/MinMaxCounterSpec.scala
@@ -19,6 +19,7 @@ import java.nio.LongBuffer
 
 import akka.actor._
 import akka.testkit.TestProbe
+import kamon.Kamon
 import kamon.metric.instrument.Histogram.{ DynamicRange, MutableRecord }
 import kamon.testkit.BaseKamonSpec
 import scala.concurrent.duration._
@@ -109,7 +110,7 @@ class MinMaxCounterSpec extends BaseKamonSpec("min-max-counter-spec") {
       val buffer: LongBuffer = LongBuffer.allocate(64)
     }
 
-    val mmCounter = MinMaxCounter(DynamicRange(1, 1000, 2), 1 hour, kamon.metrics.settings.refreshScheduler)
+    val mmCounter = MinMaxCounter(DynamicRange(1, 1000, 2), 1 hour, Kamon.metrics.settings.refreshScheduler)
     mmCounter.cleanup // cancel the refresh schedule
 
     def collectCounterSnapshot(): Histogram.Snapshot = mmCounter.collect(collectionContext)

--- a/kamon-core/src/test/scala/kamon/trace/SimpleTraceSpec.scala
+++ b/kamon-core/src/test/scala/kamon/trace/SimpleTraceSpec.scala
@@ -40,7 +40,7 @@ class SimpleTraceSpec extends BaseKamonSpec("simple-trace-spec") {
 
   "the simple tracing" should {
     "send a TraceInfo when the trace has finished and all segments are finished" in {
-      Kamon(Tracer)(system).subscribe(testActor)
+      Kamon.tracer.subscribe(testActor)
 
       TraceContext.withContext(newContext("simple-trace-without-segments")) {
         TraceContext.currentContext.startSegment("segment-one", "test-segment", "test").finish()
@@ -49,7 +49,7 @@ class SimpleTraceSpec extends BaseKamonSpec("simple-trace-spec") {
       }
 
       val traceInfo = expectMsgType[TraceInfo]
-      Kamon(Tracer)(system).unsubscribe(testActor)
+      Kamon.tracer.unsubscribe(testActor)
 
       traceInfo.name should be("simple-trace-without-segments")
       traceInfo.segments.size should be(2)
@@ -58,7 +58,7 @@ class SimpleTraceSpec extends BaseKamonSpec("simple-trace-spec") {
     }
 
     "incubate the tracing context if there are open segments after finishing" in {
-      Kamon(Tracer)(system).subscribe(testActor)
+      Kamon.tracer.subscribe(testActor)
 
       val secondSegment = TraceContext.withContext(newContext("simple-trace-without-segments")) {
         TraceContext.currentContext.startSegment("segment-one", "test-segment", "test").finish()
@@ -72,7 +72,7 @@ class SimpleTraceSpec extends BaseKamonSpec("simple-trace-spec") {
 
       within(10 seconds) {
         val traceInfo = expectMsgType[TraceInfo]
-        Kamon(Tracer)(system).unsubscribe(testActor)
+        Kamon.tracer.unsubscribe(testActor)
 
         traceInfo.name should be("simple-trace-without-segments")
         traceInfo.segments.size should be(2)

--- a/kamon-datadog/src/main/scala/kamon/datadog/Datadog.scala
+++ b/kamon-datadog/src/main/scala/kamon/datadog/Datadog.scala
@@ -50,7 +50,7 @@ class DatadogExtension(system: ExtendedActorSystem) extends Kamon.Extension {
   val subscriptions = datadogConfig.getConfig("subscriptions")
   subscriptions.firstLevelKeys.map { subscriptionCategory ⇒
     subscriptions.getStringList(subscriptionCategory).asScala.foreach { pattern ⇒
-      Kamon(Metrics).subscribe(subscriptionCategory, pattern, datadogMetricsListener, permanently = true)
+      Kamon.metrics.subscribe(subscriptionCategory, pattern, datadogMetricsListener, permanently = true)
     }
   }
 

--- a/kamon-datadog/src/test/scala/kamon/datadog/DatadogMetricSenderSpec.scala
+++ b/kamon-datadog/src/test/scala/kamon/datadog/DatadogMetricSenderSpec.scala
@@ -20,6 +20,7 @@ import akka.testkit.{ TestKitBase, TestProbe }
 import akka.actor.{ Props, ActorRef, ActorSystem }
 import kamon.Kamon
 import kamon.metric.instrument._
+import kamon.testkit.BaseKamonSpec
 import kamon.util.MilliTimestamp
 import org.scalatest.{ Matchers, WordSpecLike }
 import kamon.metric._
@@ -29,22 +30,21 @@ import java.lang.management.ManagementFactory
 import java.net.InetSocketAddress
 import com.typesafe.config.ConfigFactory
 
-class DatadogMetricSenderSpec extends TestKitBase with WordSpecLike with Matchers {
-  implicit lazy val system: ActorSystem = ActorSystem("datadog-metric-sender-spec", ConfigFactory.parseString(
-    """
-      |kamon {
-      |  metrics {
-      |    disable-aspectj-weaver-missing-error = true
-      |  }
-      |
-      |  datadog {
-      |    max-packet-size = 256 bytes
-      |  }
-      |}
-      |
-    """.stripMargin))
-
-  val collectionContext = Kamon(Metrics).buildDefaultCollectionContext
+class DatadogMetricSenderSpec extends BaseKamonSpec("datadog-metric-sender-spec") {
+  override lazy val config =
+    ConfigFactory.parseString(
+      """
+        |kamon {
+        |  metrics {
+        |    disable-aspectj-weaver-missing-error = true
+        |  }
+        |
+        |  datadog {
+        |    max-packet-size = 256 bytes
+        |  }
+        |}
+        |
+      """.stripMargin)
 
   "the DataDogMetricSender" should {
     "send latency measurements" in new UdpListenerFixture {
@@ -106,7 +106,7 @@ class DatadogMetricSenderSpec extends TestKitBase with WordSpecLike with Matcher
     val testMaxPacketSize = system.settings.config.getBytes("kamon.datadog.max-packet-size")
 
     def buildRecorder(name: String): (Entity, TestEntityRecorder) = {
-      val registration = Kamon(Metrics).register(TestEntityRecorder, name).get
+      val registration = Kamon.metrics.register(TestEntityRecorder, name).get
       (registration.entity, registration.recorder)
     }
 

--- a/kamon-jdbc/src/main/scala/kamon/jdbc/instrumentation/StatementInstrumentation.scala
+++ b/kamon-jdbc/src/main/scala/kamon/jdbc/instrumentation/StatementInstrumentation.scala
@@ -17,9 +17,9 @@ package kamon.jdbc.instrumentation
 
 import java.util.concurrent.TimeUnit.{ NANOSECONDS ⇒ nanos }
 
+import kamon.Kamon
 import kamon.jdbc.{ JdbcExtension, Jdbc }
 import kamon.jdbc.metric.StatementsMetrics
-import kamon.metric.Metrics
 import kamon.trace.{ TraceContext, SegmentCategory }
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.{ Around, Aspect, Pointcut }
@@ -44,8 +44,8 @@ class StatementInstrumentation {
   @Around("onExecuteStatement(sql) || onExecutePreparedStatement(sql) || onExecutePreparedCall(sql)")
   def aroundExecuteStatement(pjp: ProceedingJoinPoint, sql: String): Any = {
     TraceContext.map { ctx ⇒
-      val metricsExtension = ctx.lookupExtension(Metrics)
-      val jdbcExtension = ctx.lookupExtension(Jdbc)
+      val metricsExtension = Kamon.metrics
+      val jdbcExtension = Kamon(Jdbc)
       implicit val statementRecorder = metricsExtension.register(StatementsMetrics, "jdbc-statements").map(_.recorder)
 
       sql.replaceAll(CommentPattern, Empty) match {

--- a/kamon-log-reporter/src/main/scala/kamon/logreporter/LogReporter.scala
+++ b/kamon-log-reporter/src/main/scala/kamon/logreporter/LogReporter.scala
@@ -35,13 +35,13 @@ class LogReporterExtension(system: ExtendedActorSystem) extends Kamon.Extension 
   val logReporterConfig = system.settings.config.getConfig("kamon.log-reporter")
   val subscriber = system.actorOf(Props[LogReporterSubscriber], "kamon-log-reporter")
 
-  Kamon(Metrics)(system).subscribe("trace", "**", subscriber, permanently = true)
-  Kamon(Metrics)(system).subscribe("actor", "**", subscriber, permanently = true)
-  Kamon(Metrics)(system).subscribe("user-metrics", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("trace", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("actor", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("user-metrics", "**", subscriber, permanently = true)
 
   val includeSystemMetrics = logReporterConfig.getBoolean("report-system-metrics")
   if (includeSystemMetrics) {
-    Kamon(Metrics)(system).subscribe("system-metric", "**", subscriber, permanently = true)
+    Kamon.metrics.subscribe("system-metric", "**", subscriber, permanently = true)
   }
 
 }

--- a/kamon-newrelic/src/main/scala/kamon/newrelic/CustomMetricExtractor.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/CustomMetricExtractor.scala
@@ -16,13 +16,13 @@
 
 package kamon.newrelic
 
-import kamon.metric.{ UserMetrics, EntitySnapshot, Entity }
+import kamon.metric.{ UserMetricsExtensionImpl, EntitySnapshot, Entity }
 import kamon.metric.instrument.CollectionContext
 
 object CustomMetricExtractor extends MetricExtractor {
 
   def extract(settings: AgentSettings, collectionContext: CollectionContext, metrics: Map[Entity, EntitySnapshot]): Map[MetricID, MetricData] = {
-    metrics.get(UserMetrics.entity).map { allUserMetrics ⇒
+    metrics.get(UserMetricsExtensionImpl.UserMetricEntity).map { allUserMetrics ⇒
       allUserMetrics.metrics.map {
         case (key, snapshot) ⇒ Metric(snapshot, key.unitOfMeasurement, s"Custom/${key.name}", None)
       }

--- a/kamon-newrelic/src/main/scala/kamon/newrelic/MetricReporter.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/MetricReporter.scala
@@ -19,7 +19,7 @@ import JsonProtocol._
 class MetricReporter(settings: AgentSettings) extends Actor with ActorLogging with SprayJsonSupport {
   import context.dispatcher
 
-  val metricsExtension = Kamon(Metrics)(context.system)
+  val metricsExtension = Kamon.metrics
   val collectionContext = metricsExtension.buildDefaultCollectionContext
   val metricsSubscriber = {
     val tickInterval = context.system.settings.config.getDuration("kamon.metric.tick-interval", TimeUnit.MILLISECONDS)

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/MetricReporterSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/MetricReporterSpec.scala
@@ -16,43 +16,44 @@
 
 package kamon.newrelic
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.actor.ActorRef
 import akka.io.IO
 import akka.testkit._
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
-import kamon.metric.{ Entity, Metrics, TraceMetrics }
+import kamon.metric.{ Entity, TraceMetrics }
+import kamon.testkit.BaseKamonSpec
 import kamon.util.MilliTimestamp
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
-import org.scalatest.{ Matchers, WordSpecLike }
 import spray.can.Http
 import spray.http.Uri.Query
 import spray.http._
 import spray.httpx.encoding.Deflate
-import spray.httpx.{ RequestBuilding, SprayJsonSupport }
+import spray.httpx.SprayJsonSupport
 import testkit.AkkaExtensionSwap
 import scala.concurrent.duration._
 import spray.json._
 
-class MetricReporterSpec extends TestKitBase with WordSpecLike with Matchers with RequestBuilding with SprayJsonSupport {
+class MetricReporterSpec extends BaseKamonSpec("metric-reporter-spec") with SprayJsonSupport {
   import kamon.newrelic.JsonProtocol._
 
-  implicit lazy val system: ActorSystem = ActorSystem("metric-reporter-spec", ConfigFactory.parseString(
-    """
-      |akka {
-      |  loggers = ["akka.testkit.TestEventListener"]
-      |  loglevel = "INFO"
-      |}
-      |kamon {
-      |  metric {
-      |    tick-interval = 1 hour
-      |  }
-      |
-      |  modules.kamon-newrelic.auto-start = no
-      |}
-      |
-    """.stripMargin))
+  override lazy val config =
+    ConfigFactory.parseString(
+      """
+        |akka {
+        |  loggers = ["akka.testkit.TestEventListener"]
+        |  loglevel = "INFO"
+        |}
+        |kamon {
+        |  metric {
+        |    tick-interval = 1 hour
+        |  }
+        |
+        |  modules.kamon-newrelic.auto-start = no
+        |}
+        |
+      """.stripMargin)
 
   val agentSettings = AgentSettings("1111111111", "kamon", "test-host", 1, Timeout(5 seconds), 1, 30 seconds, 1D)
   val baseQuery = Query(
@@ -138,8 +139,8 @@ class MetricReporterSpec extends TestKitBase with WordSpecLike with Matchers wit
 
   trait FakeTickSnapshotsFixture {
     val testTraceID = Entity("example-trace", "trace")
-    val recorder = Kamon(Metrics).register(TraceMetrics, testTraceID.name).get.recorder
-    val collectionContext = Kamon(Metrics).buildDefaultCollectionContext
+    val recorder = Kamon.metrics.register(TraceMetrics, testTraceID.name).get.recorder
+    val collectionContext = Kamon.metrics.buildDefaultCollectionContext
 
     def collectRecorder = recorder.collect(collectionContext)
 

--- a/kamon-play/src/main/resources/reference.conf
+++ b/kamon-play/src/main/resources/reference.conf
@@ -21,7 +21,6 @@ kamon {
     # to traces and client http segments.
     name-generator = kamon.play.DefaultPlayNameGenerator
 
-    dispatcher = kamon.default-dispatcher
   }
 
   modules {

--- a/kamon-play/src/main/scala/kamon/play/Play.scala
+++ b/kamon-play/src/main/scala/kamon/play/Play.scala
@@ -20,7 +20,7 @@ import akka.actor.{ ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProv
 import akka.event.Logging
 import kamon.Kamon
 import kamon.http.HttpServerMetrics
-import kamon.metric.{ Entity, Metrics }
+import kamon.metric.Entity
 import play.api.libs.ws.WSRequest
 import play.api.mvc.RequestHeader
 
@@ -37,11 +37,11 @@ class PlayExtension(private val system: ExtendedActorSystem) extends Kamon.Exten
 
   private val config = system.settings.config.getConfig("kamon.play")
   val httpServerMetrics = {
-    val metricsExtension = Metrics.get(system)
+    val metricsExtension = Kamon.metrics
     val factory = metricsExtension.instrumentFactory(HttpServerMetrics.category)
     val entity = Entity("play-server", HttpServerMetrics.category)
 
-    Metrics.get(system).register(entity, new HttpServerMetrics(factory)).recorder
+    metricsExtension.register(entity, new HttpServerMetrics(factory)).recorder
   }
 
   val defaultDispatcher = system.dispatchers.lookup(config.getString("dispatcher"))

--- a/kamon-play/src/main/scala/kamon/play/Play.scala
+++ b/kamon-play/src/main/scala/kamon/play/Play.scala
@@ -44,7 +44,7 @@ class PlayExtension(private val system: ExtendedActorSystem) extends Kamon.Exten
     metricsExtension.register(entity, new HttpServerMetrics(factory)).recorder
   }
 
-  val defaultDispatcher = system.dispatchers.lookup(config.getString("dispatcher"))
+  val defaultDispatcher = system.dispatcher
   val includeTraceToken: Boolean = config.getBoolean("automatic-trace-token-propagation")
   val traceTokenHeaderName: String = config.getString("trace-token-header-name")
 

--- a/kamon-play/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
+++ b/kamon-play/src/main/scala/kamon/play/instrumentation/RequestInstrumentation.scala
@@ -34,11 +34,6 @@ class RequestInstrumentation {
   @DeclareMixin("play.api.mvc.RequestHeader+")
   def mixinContextAwareNewRequest: TraceContextAware = TraceContextAware.default
 
-  @After("call(* play.api.GlobalSettings.onStart(*)) && args(application)")
-  def afterApplicationStart(application: play.api.Application): Unit = {
-    Kamon(Play)
-  }
-
   @Before("call(* play.api.GlobalSettings.onRouteRequest(..)) && args(requestHeader)")
   def beforeRouteRequest(requestHeader: RequestHeader): Unit = {
     import Kamon.tracer

--- a/kamon-play/src/main/scala/kamon/play/instrumentation/WSInstrumentation.scala
+++ b/kamon-play/src/main/scala/kamon/play/instrumentation/WSInstrumentation.scala
@@ -16,6 +16,7 @@
 
 package kamon.play.instrumentation
 
+import kamon.Kamon
 import kamon.play.Play
 import kamon.trace.{ TraceContext, SegmentCategory }
 import org.aspectj.lang.ProceedingJoinPoint
@@ -33,7 +34,7 @@ class WSInstrumentation {
   @Around("onExecuteRequest(request)")
   def aroundExecuteRequest(pjp: ProceedingJoinPoint, request: WSRequest): Any = {
     TraceContext.map { ctx ⇒
-      val playExtension = ctx.lookupExtension(Play)
+      val playExtension = Kamon(Play)
       val executor = playExtension.defaultDispatcher
       val segmentName = playExtension.generateHttpClientSegmentName(request)
       val segment = ctx.startSegment(segmentName, SegmentCategory.HttpClient, Play.SegmentLibraryName)

--- a/kamon-play/src/test/scala/kamon/play/LoggerLikeInstrumentationSpec.scala
+++ b/kamon-play/src/test/scala/kamon/play/LoggerLikeInstrumentationSpec.scala
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{ AsyncAppender, LoggerContext }
 import ch.qos.logback.core.read.ListAppender
 import ch.qos.logback.core.status.NopStatusListener
+import kamon.Kamon
 import kamon.trace.TraceLocal
 import kamon.trace.TraceLocal.AvailableToMdc
 import org.scalatest.BeforeAndAfter
@@ -34,7 +35,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
 class LoggerLikeInstrumentationSpec extends PlaySpec with OneServerPerSuite with BeforeAndAfter {
-
+  Kamon.start()
   System.setProperty("config.file", "./kamon-play/src/test/resources/conf/application.conf")
 
   val executor = scala.concurrent.ExecutionContext.Implicits.global

--- a/kamon-play/src/test/scala/kamon/play/RequestInstrumentationSpec.scala
+++ b/kamon-play/src/test/scala/kamon/play/RequestInstrumentationSpec.scala
@@ -39,6 +39,7 @@ class RequestInstrumentationSpec extends PlaySpec with OneServerPerSuite {
   Kamon.start()
   System.setProperty("config.file", "./kamon-play/src/test/resources/conf/application.conf")
 
+  override lazy val port: Port = 19002
   val executor = scala.concurrent.ExecutionContext.Implicits.global
 
   implicit override lazy val app = FakeApplication(withGlobal = Some(MockGlobalTest), withRoutes = {
@@ -126,22 +127,22 @@ class RequestInstrumentationSpec extends PlaySpec with OneServerPerSuite {
     }
 
     "response to the getRouted Action and normalise the current TraceContext name" in {
-      Await.result(WS.url("http://localhost:19001/getRouted").get(), 10 seconds)
+      Await.result(WS.url(s"http://localhost:$port/getRouted").get(), 10 seconds)
       Kamon.metrics.find("getRouted.get", "trace") must not be empty
     }
 
     "response to the postRouted Action and normalise the current TraceContext name" in {
-      Await.result(WS.url("http://localhost:19001/postRouted").post("content"), 10 seconds)
+      Await.result(WS.url(s"http://localhost:$port/postRouted").post("content"), 10 seconds)
       Kamon.metrics.find("postRouted.post", "trace") must not be empty
     }
 
     "response to the showRouted Action and normalise the current TraceContext name" in {
-      Await.result(WS.url("http://localhost:19001/showRouted/2").get(), 10 seconds)
+      Await.result(WS.url(s"http://localhost:$port/showRouted/2").get(), 10 seconds)
       Kamon.metrics.find("show.some.id.get", "trace") must not be empty
     }
 
     "include HttpContext information for help to diagnose possible errors" in {
-      Await.result(WS.url("http://localhost:19001/getRouted").get(), 10 seconds)
+      Await.result(WS.url(s"http://localhost:$port/getRouted").get(), 10 seconds)
       route(FakeRequest(GET, "/default").withHeaders("User-Agent" -> "Fake-Agent"))
 
       val httpCtx = TraceLocal.retrieve(HttpContextKey).get

--- a/kamon-play/src/test/scala/kamon/play/WSInstrumentationSpec.scala
+++ b/kamon-play/src/test/scala/kamon/play/WSInstrumentationSpec.scala
@@ -17,8 +17,8 @@
 package kamon.play
 
 import kamon.Kamon
-import kamon.metric.{ Metrics, EntitySnapshot, TraceMetrics }
-import kamon.trace.{ Tracer, TraceContext, SegmentCategory }
+import kamon.metric.{ EntitySnapshot, TraceMetrics }
+import kamon.trace.{ TraceContext, SegmentCategory }
 import org.scalatest.{ Matchers, WordSpecLike }
 import org.scalatestplus.play.OneServerPerSuite
 import play.api.libs.ws.WS
@@ -26,12 +26,12 @@ import play.api.mvc.Action
 import play.api.mvc.Results.Ok
 import play.api.test.Helpers._
 import play.api.test._
-import play.libs.Akka
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class WSInstrumentationSpec extends WordSpecLike with Matchers with OneServerPerSuite {
+  Kamon.start()
   import kamon.metric.TraceMetricsSpec.SegmentSyntax
   System.setProperty("config.file", "./kamon-play/src/test/resources/conf/application.conf")
 
@@ -66,11 +66,11 @@ class WSInstrumentationSpec extends WordSpecLike with Matchers with OneServerPer
   }
 
   def newContext(name: String): TraceContext =
-    Kamon(Tracer)(Akka.system).newContext(name)
+    Kamon.tracer.newContext(name)
 
   def takeSnapshotOf(traceName: String): EntitySnapshot = {
-    val recorder = Kamon(Metrics)(Akka.system()).register(TraceMetrics, traceName).get.recorder
-    val collectionContext = Kamon(Metrics)(Akka.system()).buildDefaultCollectionContext
+    val recorder = Kamon.metrics.register(TraceMetrics, traceName).get.recorder
+    val collectionContext = Kamon.metrics.buildDefaultCollectionContext
     recorder.collect(collectionContext)
   }
 

--- a/kamon-playground/src/main/scala/test/SimpleRequestProcessor.scala
+++ b/kamon-playground/src/main/scala/test/SimpleRequestProcessor.scala
@@ -38,7 +38,7 @@ object SimpleRequestProcessor extends App with SimpleRoutingApp with RequestBuil
   import scala.concurrent.duration._
 
   implicit val system = ActorSystem("test")
-  val kamon = Kamon(system)
+  Kamon.start()
   import test.SimpleRequestProcessor.system.dispatcher
 
   val printer = system.actorOf(Props[PrintWhatever])
@@ -49,7 +49,7 @@ object SimpleRequestProcessor extends App with SimpleRoutingApp with RequestBuil
 
   implicit val timeout = Timeout(30 seconds)
 
-  val counter = Kamon(UserMetrics).counter("requests")
+  val counter = Kamon.userMetrics.counter("requests")
   val pipeline = sendReceive
   val replier = system.actorOf(Props[Replier].withRouter(RoundRobinPool(nrOfInstances = 4)), "replier")
 
@@ -179,6 +179,6 @@ object PingPong extends App {
     def receive: Actor.Receive = { case "ping" ⇒ sender ! "pong" }
   }))
 
-  pinger.tell("pong", ponger)
+  //pinger.tell("pong", ponger)
 
 }

--- a/kamon-spray/src/main/scala/kamon/spray/SprayExtension.scala
+++ b/kamon-spray/src/main/scala/kamon/spray/SprayExtension.scala
@@ -21,7 +21,7 @@ import akka.actor
 import akka.event.{ Logging, LoggingAdapter }
 import kamon.Kamon
 import kamon.http.HttpServerMetrics
-import kamon.metric.{ Entity, Metrics }
+import kamon.metric.Entity
 import spray.http.HttpHeaders.Host
 import spray.http.HttpRequest
 
@@ -46,11 +46,11 @@ class SprayExtensionImpl(system: ExtendedActorSystem) extends SprayExtension {
   val log = Logging(system, "SprayExtension")
 
   val httpServerMetrics = {
-    val metricsExtension = Metrics.get(system)
+    val metricsExtension = Kamon.metrics
     val factory = metricsExtension.instrumentFactory(HttpServerMetrics.category)
     val entity = Entity("spray-server", HttpServerMetrics.category)
 
-    Metrics.get(system).register(entity, new HttpServerMetrics(factory)).recorder
+    metricsExtension.register(entity, new HttpServerMetrics(factory)).recorder
   }
 
   def generateTraceName(request: HttpRequest): String =

--- a/kamon-spray/src/main/scala/kamon/spray/instrumentation/ClientRequestInstrumentation.scala
+++ b/kamon-spray/src/main/scala/kamon/spray/instrumentation/ClientRequestInstrumentation.scala
@@ -16,6 +16,7 @@
 
 package spray.can.client
 
+import kamon.Kamon
 import org.aspectj.lang.annotation._
 import org.aspectj.lang.ProceedingJoinPoint
 import spray.http._
@@ -47,7 +48,7 @@ class ClientRequestInstrumentation {
     requestContext.traceContext
 
     TraceContext.map { ctx ⇒
-      val sprayExtension = ctx.lookupExtension(Spray)
+      val sprayExtension = Kamon.extension(Spray)
 
       if (sprayExtension.settings.clientInstrumentationLevel == ClientInstrumentationLevel.HostLevelAPI) {
         if (requestContext.segment.isEmpty) {
@@ -112,7 +113,7 @@ class ClientRequestInstrumentation {
 
     (request: HttpRequest) ⇒ {
       TraceContext.map { ctx ⇒
-        val sprayExtension = ctx.lookupExtension(Spray)
+        val sprayExtension = Kamon.extension(Spray)
         val segment =
           if (sprayExtension.settings.clientInstrumentationLevel == ClientInstrumentationLevel.RequestLevelAPI)
             ctx.startSegment(sprayExtension.generateRequestLevelApiSegmentName(request), SegmentCategory.HttpClient, Spray.SegmentLibraryName)
@@ -139,7 +140,7 @@ class ClientRequestInstrumentation {
   def aroundIncludingDefaultHeadersAtHttpHostConnector(pjp: ProceedingJoinPoint, request: HttpMessage, defaultHeaders: List[HttpHeader]): Any = {
 
     val modifiedHeaders = TraceContext.map { ctx ⇒
-      val sprayExtension = ctx.lookupExtension(Spray)
+      val sprayExtension = Kamon.extension(Spray)
       if (sprayExtension.settings.includeTraceTokenHeader)
         RawHeader(sprayExtension.settings.traceTokenHeaderName, ctx.token) :: defaultHeaders
       else

--- a/kamon-spray/src/test/scala/kamon/spray/ClientRequestInstrumentationSpec.scala
+++ b/kamon-spray/src/test/scala/kamon/spray/ClientRequestInstrumentationSpec.scala
@@ -264,14 +264,14 @@ class ClientRequestInstrumentationSpec extends BaseKamonSpec("client-request-ins
   def disableAutomaticTraceTokenPropagation(): Unit = setIncludeTraceToken(false)
 
   def setSegmentCollectionStrategy(strategy: ClientInstrumentationLevel.Level): Unit = {
-    val target = Kamon(Spray)(system).settings
+    val target = Kamon(Spray).settings
     val field = target.getClass.getDeclaredField("clientInstrumentationLevel")
     field.setAccessible(true)
     field.set(target, strategy)
   }
 
   def setIncludeTraceToken(include: Boolean): Unit = {
-    val target = Kamon(Spray)(system).settings
+    val target = Kamon(Spray).settings
     val field = target.getClass.getDeclaredField("includeTraceTokenHeader")
     field.setAccessible(true)
     field.set(target, include)

--- a/kamon-spray/src/test/scala/kamon/spray/SprayServerTracingSpec.scala
+++ b/kamon-spray/src/test/scala/kamon/spray/SprayServerTracingSpec.scala
@@ -79,7 +79,7 @@ class SprayServerTracingSpec extends BaseKamonSpec("spray-server-tracing-spec") 
   def disableAutomaticTraceTokenPropagation(): Unit = setIncludeTraceToken(false)
 
   def setIncludeTraceToken(include: Boolean): Unit = {
-    val target = Kamon(Spray)(system).settings
+    val target = Kamon(Spray).settings
     val field = target.getClass.getDeclaredField("includeTraceTokenHeader")
     field.setAccessible(true)
     field.set(target, include)

--- a/kamon-statsd/src/main/scala/kamon/statsd/StatsD.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/StatsD.scala
@@ -40,7 +40,7 @@ class StatsDExtension(system: ExtendedActorSystem) extends Kamon.Extension {
 
   private val config = system.settings.config
   private val statsDConfig = config.getConfig("kamon.statsd")
-  val metricsExtension = Kamon(Metrics)
+  val metricsExtension = Kamon.metrics
 
   val tickInterval = metricsExtension.settings.tickInterval
   val statsDHost = new InetSocketAddress(statsDConfig.getString("hostname"), statsDConfig.getInt("port"))

--- a/kamon-system-metrics/src/main/scala/kamon/system/SystemMetricsExtension.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/system/SystemMetricsExtension.scala
@@ -42,7 +42,7 @@ class SystemMetricsExtension(system: ExtendedActorSystem) extends Kamon.Extensio
   val sigarFolder = config.getString("sigar-native-folder")
   val sigarRefreshInterval = config.getFiniteDuration("sigar-metrics-refresh-interval")
   val contextSwitchesRefreshInterval = config.getFiniteDuration("context-switches-refresh-interval")
-  val metricsExtension = Kamon(Metrics)(system)
+  val metricsExtension = Kamon.metrics
 
   // Sigar-based metrics
   SigarProvisioner.provision(new File(sigarFolder))

--- a/kamon-system-metrics/src/main/scala/kamon/system/custom/ContextSwitchesMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/system/custom/ContextSwitchesMetrics.scala
@@ -88,7 +88,7 @@ class ContextSwitchesMetrics(pid: Long, log: LoggingAdapter, instrumentFactory: 
 object ContextSwitchesMetrics {
 
   def register(system: ActorSystem, refreshInterval: FiniteDuration): ContextSwitchesMetrics = {
-    val metricsExtension = Kamon(Metrics)(system)
+    val metricsExtension = Kamon.metrics
     val log = Logging(system, "ContextSwitchesMetrics")
     val pid = (new Sigar).getPid
 

--- a/kamon-system-metrics/src/main/scala/kamon/system/sigar/SigarMetricsUpdater.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/system/sigar/SigarMetricsUpdater.scala
@@ -19,7 +19,7 @@ package kamon.system.sigar
 import akka.actor.{ Props, Actor }
 import kamon.Kamon
 import kamon.metric.instrument.InstrumentFactory
-import kamon.metric.{ Entity, EntityRecorder, MetricsExtension, Metrics }
+import kamon.metric.{ Entity, EntityRecorder, MetricsExtension }
 import kamon.system.sigar.SigarMetricsUpdater.UpdateSigarMetrics
 import org.hyperic.sigar.Sigar
 
@@ -27,7 +27,7 @@ import scala.concurrent.duration.FiniteDuration
 
 class SigarMetricsUpdater(refreshInterval: FiniteDuration) extends Actor {
   val sigar = new Sigar
-  val metricsExtension = Kamon(Metrics)(context.system)
+  val metricsExtension = Kamon.metrics
 
   val sigarMetrics = List(
     CpuMetrics.register(sigar, metricsExtension),

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -111,7 +111,7 @@ object Projects extends Build {
         compile(sprayCan, sprayClient, sprayRouting, sprayJson, sprayJsonLenses, newrelic, akkaSlf4j) ++
         provided(aspectJ) ++
         test(scalatest, akkaTestKit, sprayTestkit, slf4Api, akkaSlf4j))
-    .dependsOn(kamonCore)
+    .dependsOn(kamonCore % "compile->compile;test->test")
     .dependsOn(kamonTestkit % "compile->compile;test->test")
 
 
@@ -165,7 +165,7 @@ object Projects extends Build {
       libraryDependencies ++=
         compile(akkaActor) ++
         test(scalatest, akkaTestKit, slf4Api, slf4nop))
-    .dependsOn(kamonCore)
+    .dependsOn(kamonCore % "compile->compile;test->test")
     .dependsOn(kamonSystemMetrics % "provided")
  
   lazy val kamonDatadog = Project("kamon-datadog", file("kamon-datadog"))
@@ -175,7 +175,7 @@ object Projects extends Build {
       libraryDependencies ++=
         compile(akkaActor) ++
         test(scalatest, akkaTestKit, slf4Api, slf4nop))
-    .dependsOn(kamonCore)
+    .dependsOn(kamonCore % "compile->compile;test->test")
     .dependsOn(kamonSystemMetrics % "provided")
 
   lazy val kamonLogReporter = Project("kamon-log-reporter", file("kamon-log-reporter"))


### PR DESCRIPTION
After this PR, there will no longer be a Kamon instance anywhere. There will be only one instance wrapped in the `kamon.Kamon` companion object and such instance needs to be `.start(..)`ed to work properly.

By having a single place to look for a Kamon instance we can simplify our current instrumentation a bit, as well as opening the door for more interesting possibilities, such as the `kamon-annotation` module, richer APIs for our tracer (see #126).