### PR TITLE
= add aspjectj option to retain class serialization compatibility #160

### DIFF
--- a/kamon-spray/src/main/resources/META-INF/aop.xml
+++ b/kamon-spray/src/main/resources/META-INF/aop.xml
@@ -11,7 +11,7 @@
 
   </aspects>
 
-  <weaver>
+  <weaver options="-XaddSerialVersionUID">
     <include within="spray..*"/>
   </weaver>
 </aspectj>


### PR DESCRIPTION
The XaddSerialVersionUID option tells aspjectj to add a serialversion uid
according to the class before weaving occurs.  The allows the modified class
to be deserialized.
