### PR TITLE
StatsD extension now defers the creation of the InetSocketAddress instance until needed

### DIFF
--- a/kamon-statsd/src/main/scala/kamon/statsd/StatsD.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/StatsD.scala
@@ -43,7 +43,6 @@ class StatsDExtension(system: ExtendedActorSystem) extends Kamon.Extension {
   val metricsExtension = Kamon.metrics
 
   val tickInterval = metricsExtension.settings.tickInterval
-  val statsDHost = new InetSocketAddress(statsDConfig.getString("hostname"), statsDConfig.getInt("port"))
   val flushInterval = statsDConfig.getFiniteDuration("flush-interval")
   val maxPacketSizeInBytes = statsDConfig.getBytes("max-packet-size")
   val keyGeneratorFQCN = statsDConfig.getString("metric-key-generator")
@@ -62,7 +61,8 @@ class StatsDExtension(system: ExtendedActorSystem) extends Kamon.Extension {
     val keyGenerator = system.dynamicAccess.createInstanceFor[MetricKeyGenerator](keyGeneratorFQCN, (classOf[Config], config) :: Nil).get
 
     val metricsSender = system.actorOf(StatsDMetricsSender.props(
-      statsDHost,
+      statsDConfig.getString("hostname"),
+      statsDConfig.getInt("port"),
       maxPacketSizeInBytes,
       keyGenerator), "statsd-metrics-sender")
 

--- a/kamon-statsd/src/test/scala/kamon/statsd/StatsDMetricSenderSpec.scala
+++ b/kamon-statsd/src/test/scala/kamon/statsd/StatsDMetricSenderSpec.scala
@@ -138,7 +138,7 @@ class StatsDMetricSenderSpec extends BaseKamonSpec("statsd-metric-sender-spec") 
 
     def setup(metrics: Map[Entity, EntitySnapshot]): TestProbe = {
       val udp = TestProbe()
-      val metricsSender = system.actorOf(Props(new StatsDMetricsSender(new InetSocketAddress("127.0.0.1", 0), testMaxPacketSize, metricKeyGenerator) {
+      val metricsSender = system.actorOf(Props(new StatsDMetricsSender("127.0.0.1", 0, testMaxPacketSize, metricKeyGenerator) {
         override def udpExtension(implicit system: ActorSystem): ActorRef = udp.ref
       }))
 


### PR DESCRIPTION
StatsD extension now defers the creation of the InetSocketAddress instance against the provided UDP host/port until it's required for sending a metric payload. (https://github.com/kamon-io/Kamon/issues/172)

