### PR TITLE
+ Add possibility to send Akka metrics to newrelic

### DIFF
--- a/kamon-newrelic/src/main/resources/reference.conf
+++ b/kamon-newrelic/src/main/resources/reference.conf
@@ -23,6 +23,11 @@ kamon {
 
     # delay between connection attempts to NewRelic collector
     connect-retry-delay = 30 seconds
+
+    metrics {
+      user-metrics = "*"
+      trace  = "*"
+    }
   }
 
   modules {

--- a/kamon-newrelic/src/main/scala/kamon/newrelic/AkkaMetricExtractor.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/AkkaMetricExtractor.scala
@@ -1,0 +1,91 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.newrelic
+
+import kamon.metric.instrument.{ CollectionContext, InstrumentSnapshot }
+import kamon.metric.{ Entity, EntitySnapshot }
+
+/**
+ * @since 21.04.2015
+ */
+object AkkaMetricExtractor extends MetricExtractor {
+
+  private val router = "akka-router"
+  private val actor = "akka-actor"
+  private val dispatcher = "akka-dispatcher"
+  private val akkaCategories = actor :: router :: dispatcher :: Nil
+
+  def extract(settings: AgentSettings, collectionContext: CollectionContext, metrics: Map[Entity, EntitySnapshot]): Map[MetricID, MetricData] = {
+
+    def toNewRelicMetric(entity: Entity, snapshot: EntitySnapshot) = entity.category match {
+      case `actor`      ⇒ logActorMetrics(entity.name, snapshot, actor)
+      case `dispatcher` ⇒ logDispatcherMetrics(entity, snapshot)
+      // TODO case `router` ⇒ logRouterMetrics(entity.name, snapshot)
+    }
+
+    val akka = metrics filter akkaMetrics
+    val result = akka flatMap { case (entity, snapshot) ⇒ toNewRelicMetric(entity, snapshot) }
+    result
+  }
+
+  def logDispatcherMetrics(entity: Entity, snapshot: EntitySnapshot): Iterable[Metric] =
+    entity.tags get "dispatcher-type" match {
+      case Some("fork-join-pool")       ⇒ logForkJoinPool(entity.name, snapshot, "akka-fork-join-pool")
+      case Some("thread-pool-executor") ⇒ logThreadPoolExecutor(entity.name, snapshot, "akka-thread-pool-executor")
+      case ignoreOthers                 ⇒ Nil
+    }
+
+  def logActorMetrics = logMetrics(actorMetrics) _
+  def logForkJoinPool = logMetrics(forkJoinMetrics) _
+  def logThreadPoolExecutor = logMetrics(threadPoolMetrics) _
+
+  def actorMetrics(snapshot: EntitySnapshot) =
+    ("processing-time", snapshot.histogram _) ::
+      ("time-in-mailbox", snapshot.histogram _) ::
+      ("mailbox-size", snapshot.minMaxCounter _) ::
+      ("errors", snapshot.counter _) ::
+      Nil
+
+  def forkJoinMetrics(snapshot: EntitySnapshot) =
+    ("parallelism", snapshot.minMaxCounter _) ::
+      ("pool-size", snapshot.gauge _) ::
+      ("active-threads", snapshot.gauge _) ::
+      ("running-threads", snapshot.gauge _) ::
+      ("queued-task-count", snapshot.gauge _) ::
+      Nil
+
+  def threadPoolMetrics(snapshot: EntitySnapshot) =
+    Seq("core-pool-size", "max-pool-size", "pool-size", "active-threads", "processed-tasks").
+      zip(Vector.fill(5)(snapshot.gauge _))
+
+  protected[newrelic] def akkaMetrics(kv: (Entity, EntitySnapshot)) = akkaCategories.contains(kv._1.category)
+
+  protected[newrelic] def camelize(name: String) =
+    name split "-" filter { _.nonEmpty } map { part ⇒ part.head.toUpper + part.tail.toLowerCase } mkString ""
+
+  protected[newrelic]type Operation = String ⇒ Option[InstrumentSnapshot]
+
+  protected[newrelic] def logMetrics(nameAndGetterPairs: EntitySnapshot ⇒ Seq[(String, Operation)])(actorName: String, actorSnapshot: EntitySnapshot, prefix: String): Iterable[Metric] =
+    for {
+      (name, method) ← nameAndGetterPairs(actorSnapshot)
+      (key, instrumentSnapshot) ← actorSnapshot.metrics.find(_._1.name == name)
+      metric ← method(name)
+      metricName = camelize(name)
+      prefixName = camelize(prefix)
+    } yield Metric(metric, key.unitOfMeasurement, s"$prefixName/$actorName/$metricName", None)
+
+}

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/AkkaMetricExtractorSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/AkkaMetricExtractorSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.newrelic
+
+import kamon.metric.instrument.CollectionContext
+import kamon.metric.{ DefaultEntitySnapshot, Entity }
+import org.scalatest.{ Matchers, WordSpecLike }
+
+/**
+ * @since 21.04.2015
+ */
+class AkkaMetricExtractorSpec extends WordSpecLike with Matchers {
+
+  val ame = AkkaMetricExtractor
+
+  "the AkkaMetricExtractor" should {
+    "have a camelize method" which {
+      "is ok with an empty string" in {
+        ame.camelize("") should be("")
+      }
+      "is ok with normal '-'" in {
+        ame.camelize("akka-dispatcher-string") should be("AkkaDispatcherString")
+      }
+      "is ok with multiple '-'" in {
+        ame.camelize("akka--dispatcher----string") should be("AkkaDispatcherString")
+      }
+      "is ok with starting end ending '-'" in {
+        ame.camelize("--akka-dispatcher-string-") should be("AkkaDispatcherString")
+      }
+      "is ok with solely '-'" in {
+        ame.camelize("----") should be("")
+      }
+      "is ok with single letters" in {
+        ame.camelize("a-b-c-d-e") should be("ABCDE")
+      }
+
+    }
+    "recognize akka categories" when {
+      "provided right category" in {
+        val kv = (Entity("name", "akka-actor"), new DefaultEntitySnapshot(null))
+        ame.akkaMetrics(kv) shouldBe true
+      }
+      "provided wrong category" in {
+        val kv = (Entity("name", "fooBar"), new DefaultEntitySnapshot(null))
+        ame.akkaMetrics(kv) shouldBe false
+      }
+    }
+    "extract akka metrics" when {
+      "given empty snapshot, no metrics are expected" in {
+        val snapshot = new DefaultEntitySnapshot(Map.empty)
+        ame.logMetrics(ame.actorMetrics)("actorName", snapshot, "prefix").isEmpty shouldBe true
+      }
+      "given no metrics, no newrelic metrics are expected" in {
+        val settings = AgentSettings(null, null, null, 0, null, 0, null, 0d)
+        val result = ame.extract(settings, CollectionContext(0), Map.empty)
+        result.isEmpty shouldBe true
+      }
+    }
+  }
+}

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/MetricsSubscriptionSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/MetricsSubscriptionSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.newrelic
+
+import akka.actor.ActorRef
+import akka.event.NoLogging
+import com.typesafe.config.ConfigFactory
+import kamon.metric._
+import org.scalatest._
+
+import scala.collection.JavaConversions._
+
+/**
+ * @since 21.04.2015
+ */
+class MetricsSubscriptionSpec extends WordSpecLike with Matchers {
+
+  val instance = new MetricsSubscription {
+    override def log = NoLogging
+  }
+
+  val metrics = Seq("user-metrics", "trace", "akka-dispatcher", "akka-actor").zipWithIndex
+  val metricsStr = metrics map { m ⇒ m._1 + " = \"" + "*" * (m._2 + 1) + "\"" } mkString "\n"
+  val fullConfig = ConfigFactory.parseString(s"kamon.newrelic.metrics { $metricsStr }")
+  val emptyConfig = ConfigFactory.parseString("kamon.newrelic { foo = bar }")
+
+  // this could be replaced with a mock as soon the project has mocking framework as a dependency
+  class FakeMetricsModule extends MetricsModuleImpl(ConfigFactory.load()) {
+    var callCounter = 0
+    override def subscribe(filter: SubscriptionFilter, subscriber: ActorRef, permanently: Boolean): Unit = {
+      callCounter = callCounter + 1
+    }
+  }
+
+  "the MetricsSubscription" should {
+
+    "read correct subscriptions from full configuration" in {
+      val cfg = instance.subscriptions(fullConfig)
+      cfg.size should be(4)
+      cfg foreach { metric ⇒
+        val idx = metrics.indexWhere(_._1 == metric.getKey)
+        metric.getValue.unwrapped().toString should be("*" * (idx + 1))
+      }
+      cfg.contains()
+    }
+    "read no subscriptions from empty configuration" in {
+      instance.subscriptions(emptyConfig).isEmpty should be(right = true)
+    }
+    "subscribe to correct categories" in {
+      val metricsModule = new FakeMetricsModule
+      instance.subscribeToMetrics(fullConfig, null, metricsModule)
+      metricsModule.callCounter should be(4)
+    }
+    "subscribe to no categories" in {
+      val metricsModule = new FakeMetricsModule
+      instance.subscribeToMetrics(emptyConfig, null, metricsModule)
+      metricsModule.callCounter should be(0)
+    }
+
+  }
+}


### PR DESCRIPTION
Added possibility to send akka metrics to the newrelic as custom metrics.
Externalized categories of newrelic subscription into the configuration file.
This allow to define which metrics categories should be send to newrelic
independent upon which metrics are actually collected.

Example of the relevant configuration file part:

```
kamon.newrelic {
	app-name = "App Name"
	license-key = LicenseKey
	metrics {
	  user-metrics = "*"
	  trace = "*"
	  akka-dispatcher = "**"
	  akka-actor = "**"
	}
}
```

Akka metrics exported to the newrelic as custom metrics and available in custom
dashboards in following format:

AkkaActor/{ActorSystemName}/[user|system|...]/{ActorName}/{MetricName}

Same metrics for multiple actors can be displayed as a single chart by using *
(star) for part of the actor name. For example

`AkkaActor/MyActor/user/*DatabaseWorker/ProcessingTime`

will show processing time for all database workers.

Example of actor metrics displayed by newrelic:
http://s4.postimg.org/sfn9vjzgt/Screen_Shot_2015_04_22_at_11_24_15.png

Example of pool metrics displayed by newrelic:
http://s4.postimg.org/gchy7zoel/Screen_Shot_2015_04_22_at_11_24_24.png