### PR TITLE
= core: Fix usage of GaugeKey for gauges in MetricsModule

### DIFF
--- a/kamon-core/src/main/scala/kamon/metric/MetricsModule.scala
+++ b/kamon-core/src/main/scala/kamon/metric/MetricsModule.scala
@@ -281,7 +281,7 @@ private[kamon] class MetricsModuleImpl(config: Config) extends MetricsModule {
     val gaugeEntity = Entity(name, SingleInstrumentEntityRecorder.Gauge, tags)
     val recorder = _trackedEntities.atomicGetOrElseUpdate(gaugeEntity, {
       val factory = instrumentFactory(gaugeEntity.category)
-      GaugeRecorder(MinMaxCounterKey(gaugeEntity.category, unitOfMeasurement.getOrElse(UnitOfMeasurement.Unknown)),
+      GaugeRecorder(GaugeKey(gaugeEntity.category, unitOfMeasurement.getOrElse(UnitOfMeasurement.Unknown)),
         factory.createGauge(name, dynamicRange, refreshInterval, valueCollector))
     }, _.cleanup)
 


### PR DESCRIPTION
In MetricsModule MinMaxCounterKey is used for Gauges, which caueses None.get NoSuchElementException in LogReporter