### PR TITLE
= core: fix ordered-sampler

### DIFF
--- a/kamon-core/src/main/scala/kamon/trace/Sampler.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Sampler.scala
@@ -45,8 +45,8 @@ class RandomSampler(chance: Int) extends Sampler {
 class OrderedSampler(interval: Int) extends Sampler {
   import OrderedSampler._
 
-  require(interval > 0, "kamon.trace.ordered-sampler.interval cannot be <= 0")
-  assume(interval isPowerOfTwo, "kamon.trace.ordered-sampler.interval must be power of two")
+  require(interval > 0, "kamon.trace.ordered-sampler.sample-interval cannot be <= 0")
+  assume(interval isPowerOfTwo, "kamon.trace.ordered-sampler.sample-interval must be power of two")
 
   private val sequencer = Sequencer()
 

--- a/kamon-core/src/main/scala/kamon/trace/TracerExtensionSettings.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TracerExtensionSettings.scala
@@ -16,7 +16,6 @@
 
 package kamon.trace
 
-import java.util.concurrent.TimeUnit
 import kamon.util.ConfigTools.Syntax
 import com.typesafe.config.Config
 
@@ -37,7 +36,7 @@ object TraceSettings {
       else tracerConfig.getString("sampling") match {
         case "all"       ⇒ SampleAll
         case "random"    ⇒ new RandomSampler(tracerConfig.getInt("random-sampler.chance"))
-        case "ordered"   ⇒ new OrderedSampler(tracerConfig.getInt("ordered-sampler.interval"))
+        case "ordered"   ⇒ new OrderedSampler(tracerConfig.getInt("ordered-sampler.sample-interval"))
         case "threshold" ⇒ new ThresholdSampler(tracerConfig.getFiniteDuration("threshold-sampler.minimum-elapsed-time").toNanos)
       }
 

--- a/kamon-core/src/main/scala/kamon/trace/TracerModule.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TracerModule.scala
@@ -118,16 +118,16 @@ private[kamon] class TracerModuleImpl(metricsExtension: MetricsModule, config: C
     isOpen: Boolean = true, isLocal: Boolean = true): TraceContext = {
 
     def newMetricsOnlyContext(token: String): TraceContext =
-      new MetricsOnlyContext(traceName, token, isOpen, _settings.levelOfDetail, startTimestamp, null)
+      new MetricsOnlyContext(traceName, token, isOpen, LevelOfDetail.MetricsOnly, startTimestamp, null)
 
     val traceToken = token.getOrElse(newToken)
 
-    if (_settings.levelOfDetail == LevelOfDetail.MetricsOnly || !isLocal)
-      newMetricsOnlyContext(traceToken)
-    else {
-      if (!_settings.sampler.shouldTrace)
+    _settings.levelOfDetail match {
+      case LevelOfDetail.MetricsOnly ⇒
         newMetricsOnlyContext(traceToken)
-      else
+      case _ if !isLocal || !_settings.sampler.shouldTrace ⇒
+        newMetricsOnlyContext(traceToken)
+      case _ ⇒
         new TracingContext(traceName, traceToken, true, _settings.levelOfDetail, isLocal, startTimestamp, null, dispatchTracingContext)
     }
   }

--- a/kamon-core/src/main/scala/kamon/trace/TracingContext.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TracingContext.scala
@@ -66,7 +66,7 @@ private[trace] class TracingContext(traceName: String, token: String, izOpen: Bo
       val segment = currentSegments.next()
       if (segment.isClosed)
         segmentsInfo += segment.createSegmentInfo(_startTimestamp, startTimestamp)
-      else
+      else if (log != null)
         log.warning("Segment [{}] will be left out of TraceInfo because it was still open.", segment.name)
     }
 


### PR DESCRIPTION
According to [kamon.io](http://kamon.io/core/tracing/core-concepts/), the ordered-sampler config should be named *kamon.trace.ordered-sampler.sample-interval*, but TracerSettings was loading *interval* instead of *sample-interval*.