### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Kamon     [![Build Status](https://api.travis-ci.org/kamon-io/Kamon.png)](https://api.travis-ci.org/kamon-io/Kamon.png)
+Kamon     [![Build Status](https://api.travis-ci.org/kamon-io/Kamon.png)](https://travis-ci.org/kamon-io/Kamon/builds)
 =========  
 Kamon is a set of tools for monitoring applications running on the JVM.
 


### PR DESCRIPTION
Image should link to the build history instead of a png, so that anyone can easily check why the last build failed when he accesses to the github repository.