### PR TITLE
+ core: add a clock-sampler, fix ordered-sampler, add unit tests for samplers.

### DIFF
--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -87,15 +87,15 @@ kamon {
 
   trace {
 
-    # Level of detail used when recording trace information. The posible values are:
+    # Level of detail used when recording trace information. The possible values are:
     #  - metrics-only: metrics for all included traces and all segments are recorded, but no Trace messages will be sent
-    #    to the subscriptors of trace data.
+    #    to the subscribers of trace data.
     #  - simple-trace: metrics for all included traces and all segments are recorded and additionally a Trace message
     #    containing the trace and segments details and metadata.
     level-of-detail = metrics-only
 
-    # Sampling strategy to apply when the tracing level is set to `simple-trace`. The options are: all, random, ordered
-    # and threshold. The details of each sampler are bellow.
+    # Sampling strategy to apply when the tracing level is set to `simple-trace`. The options are: all, random, ordered,
+    # threshold and clock. The details of each sampler are below.
     sampling = random
 
     # Use a ThreadLocalRandom to generate numbers between 1 and 100, if the random number is less or equal to .chance
@@ -118,6 +118,11 @@ kamon {
     # .minimum-elapsed-time setting.
     threshold-sampler {
       minimum-elapsed-time = 1 second
+    }
+
+    # Use a FiniteDuration to only record a trace each .pause nanoseconds.
+    clock-sampler {
+      pause = 1 second
     }
 
     incubator {

--- a/kamon-core/src/main/scala/kamon/trace/MetricsOnlyContext.scala
+++ b/kamon-core/src/main/scala/kamon/trace/MetricsOnlyContext.scala
@@ -39,7 +39,7 @@ private[kamon] class MetricsOnlyContext(traceName: String, val token: String, iz
   def rename(newName: String): Unit =
     if (isOpen)
       _name = newName
-    else if (log.isWarningEnabled)
+    else
       log.warning("Can't rename trace from [{}] to [{}] because the trace is already closed.", name, newName)
 
   def name: String = _name
@@ -101,7 +101,7 @@ private[kamon] class MetricsOnlyContext(traceName: String, val token: String, iz
     def rename(newName: String): Unit =
       if (isOpen)
         _segmentName = newName
-      else if (log.isWarningEnabled)
+      else
         log.warning("Can't rename segment from [{}] to [{}] because the segment is already closed.", name, newName)
 
     def finish: Unit = {

--- a/kamon-core/src/main/scala/kamon/trace/TraceSettings.scala
+++ b/kamon-core/src/main/scala/kamon/trace/TraceSettings.scala
@@ -16,9 +16,9 @@
 
 package kamon.trace
 
-import java.util.concurrent.TimeUnit
 import kamon.util.ConfigTools.Syntax
 import com.typesafe.config.Config
+import kamon.util.NanoInterval
 
 case class TraceSettings(levelOfDetail: LevelOfDetail, sampler: Sampler, tokenGeneratorFQN: String)
 
@@ -37,8 +37,9 @@ object TraceSettings {
       else tracerConfig.getString("sampling") match {
         case "all"       ⇒ SampleAll
         case "random"    ⇒ new RandomSampler(tracerConfig.getInt("random-sampler.chance"))
-        case "ordered"   ⇒ new OrderedSampler(tracerConfig.getInt("ordered-sampler.interval"))
-        case "threshold" ⇒ new ThresholdSampler(tracerConfig.getFiniteDuration("threshold-sampler.minimum-elapsed-time").toNanos)
+        case "ordered"   ⇒ new OrderedSampler(tracerConfig.getInt("ordered-sampler.sample-interval"))
+        case "threshold" ⇒ new ThresholdSampler(new NanoInterval(tracerConfig.getFiniteDuration("threshold-sampler.minimum-elapsed-time").toNanos))
+        case "clock"     ⇒ new ClockSampler(new NanoInterval(tracerConfig.getFiniteDuration("clock-sampler.pause").toNanos))
       }
 
     val tokenGeneratorFQN = tracerConfig.getString("token-generator")

--- a/kamon-core/src/test/scala/kamon/trace/SamplerSpec.scala
+++ b/kamon-core/src/test/scala/kamon/trace/SamplerSpec.scala
@@ -1,0 +1,76 @@
+package kamon.trace
+
+import kamon.testkit.BaseKamonSpec
+import kamon.util.NanoInterval
+
+class SamplerSpec extends BaseKamonSpec("sampler-spec") {
+
+  "the Sampler" should {
+    "work as intended" when {
+      "using all mode" in {
+        val sampler = SampleAll
+
+        sampler.shouldTrace should be(true)
+
+        sampler.shouldReport(NanoInterval.default) should be(true)
+      }
+
+      "using random mode" in {
+        val sampler = new RandomSampler(100)
+
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(true)
+
+        sampler.shouldReport(NanoInterval.default) should be(true)
+      }
+
+      "using ordered mode" in {
+        var sampler = new OrderedSampler(1)
+
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(true)
+
+        sampler = new OrderedSampler(2)
+
+        sampler.shouldTrace should be(false)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(false)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(false)
+        sampler.shouldTrace should be(true)
+
+        sampler.shouldReport(NanoInterval.default) should be(true)
+      }
+
+      "using threshold mode" in {
+        val sampler = new ThresholdSampler(new NanoInterval(10000000L))
+
+        sampler.shouldTrace should be(true)
+
+        sampler.shouldReport(new NanoInterval(5000000L)) should be(false)
+        sampler.shouldReport(new NanoInterval(10000000L)) should be(true)
+        sampler.shouldReport(new NanoInterval(15000000L)) should be(true)
+        sampler.shouldReport(new NanoInterval(0L)) should be(false)
+      }
+
+      "using clock mode" in {
+        val sampler = new ClockSampler(new NanoInterval(10000000L))
+
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(false)
+        Thread.sleep(1L)
+        sampler.shouldTrace should be(false)
+        Thread.sleep(10L)
+        sampler.shouldTrace should be(true)
+        sampler.shouldTrace should be(false)
+
+        sampler.shouldReport(NanoInterval.default) should be(true)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
I wanted a steady sample of traces in my project, but the current ordered sampler depends on the number of requests, which varies a lot during the day. With a clock sampler, I can for example have an idea of the state of the application each 5 seconds.

This PR also fix the ordered sampler problem as described in https://github.com/kamon-io/Kamon/pull/201.