### PR TITLE
+ akka-http-server: module for akka-http-server

### DIFF
--- a/kamon-akka-http-server/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-http-server/src/main/resources/META-INF/aop.xml
@@ -1,0 +1,15 @@
+<!DOCTYPE aspectj PUBLIC "-//AspectJ//DTD//EN" "http://www.eclipse.org/aspectj/dtd/aspectj.dtd">
+
+<aspectj>
+  <aspects>
+    <!-- Server -->
+    <aspect name="kamon.akka.http.server.instrumentation.HttpRequestInstrumentation"/>
+    <aspect name="kamon.akka.http.server.instrumentation.RequestContextInstrumentation"/>
+    <aspect name="kamon.akka.http.server.instrumentation.HttpResponseInstrumentation"/>
+    <aspect name="kamon.akka.http.server.instrumentation.ServerInstrumentation"/>
+  </aspects>
+
+  <weaver>
+    <include within="akka..*"/>
+  </weaver>
+</aspectj>

--- a/kamon-akka-http-server/src/main/resources/META-INF/aop.xml
+++ b/kamon-akka-http-server/src/main/resources/META-INF/aop.xml
@@ -10,6 +10,6 @@
   </aspects>
 
   <weaver>
-    <include within="akka..*"/>
+    <include within="*"/>
   </weaver>
 </aspectj>

--- a/kamon-akka-http-server/src/main/resources/reference.conf
+++ b/kamon-akka-http-server/src/main/resources/reference.conf
@@ -1,0 +1,31 @@
+# ======================================= #
+# Kamon-Akka-Http Reference Configuration #
+# ======================================= #
+
+kamon {
+  akka {
+    http {
+      server {
+        # When set to true, Kamon will automatically set and propogate the `TraceContext.token` value when a server side
+        # request is received containing the trace token header. The new `TraceContext` will have that token,
+        # and once the response to that request is ready, the trace token header is also included in the response.
+        automatic-trace-token-propagation = true
+
+        # Header name used when propagating the `TraceContext.token` value across applications.
+        trace-token-header-name = "X-Trace-Token"
+
+        # Fully qualified name of the implementation of the kamon.akka.http.server.NameGenerator interface
+        # which should be used for assigning names to traces.
+        name-generator = kamon.akka.http.server.DefaultNameGenerator
+      }
+    }
+  }
+
+  modules {
+    kamon-akka-http-server {
+      auto-start = yes
+      requires-aspectj = yes
+      extension-id = "kamon.akka.http.server.AkkaHttpServer"
+    }
+  }
+}

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/AkkaHttpServerExtension.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/AkkaHttpServerExtension.scala
@@ -1,0 +1,60 @@
+/* ===================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.akka.http.server
+
+import akka.actor._
+import akka.event._
+import akka.http.scaladsl.model.HttpRequest
+import kamon.Kamon
+import kamon.metric.Entity
+
+object AkkaHttpServer extends ExtensionId[AkkaHttpServerExtension] with ExtensionIdProvider {
+  def lookup(): ExtensionId[_ <: Extension] = AkkaHttpServer
+  def createExtension(system: ExtendedActorSystem): AkkaHttpServerExtension = new AkkaHttpServerExtensionImpl(system)
+}
+
+trait AkkaHttpServerExtension extends Kamon.Extension {
+  def settings: AkkaHttpServerExtensionSettings
+  def log: LoggingAdapter
+  def serverMetrics: AkkaHttpServerMetrics
+  def generateTraceName(request: HttpRequest): String
+}
+
+class AkkaHttpServerExtensionImpl(system: ExtendedActorSystem) extends AkkaHttpServerExtension {
+  val settings: AkkaHttpServerExtensionSettings =
+    AkkaHttpServerExtensionSettings(system)
+
+  val log: LoggingAdapter =
+    Logging(system, "AkkaHttpServerExtension")
+
+  def serverMetrics: AkkaHttpServerMetrics = {
+    val entity = Entity("akka-http-server", AkkaHttpServerMetrics.category)
+    Kamon.metrics.entity(AkkaHttpServerMetrics, entity)
+  }
+
+  def generateTraceName(request: HttpRequest): String =
+    settings.nameGenerator.generateTraceName(request)
+
+}
+
+trait NameGenerator {
+  def generateTraceName(request: HttpRequest): String
+}
+
+class DefaultNameGenerator extends NameGenerator {
+  def generateTraceName(request: HttpRequest): String =
+    "UnnamedTrace"
+}

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/AkkaHttpServerExtensionSettings.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/AkkaHttpServerExtensionSettings.scala
@@ -1,0 +1,37 @@
+/* ===================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.akka.http.server
+
+import akka.actor.ExtendedActorSystem
+
+case class AkkaHttpServerExtensionSettings(
+  includeTraceTokenHeader: Boolean,
+  traceTokenHeaderName: String,
+  nameGenerator: NameGenerator)
+
+object AkkaHttpServerExtensionSettings {
+  def apply(system: ExtendedActorSystem): AkkaHttpServerExtensionSettings = {
+    val config = system.settings.config.getConfig("kamon.akka.http.server")
+
+    val includeTraceTokenHeader: Boolean = config.getBoolean("automatic-trace-token-propagation")
+    val traceTokenHeaderName: String = config.getString("trace-token-header-name")
+
+    val nameGeneratorFQN: String = config.getString("name-generator")
+    val nameGenerator: NameGenerator = system.dynamicAccess.createInstanceFor[NameGenerator](nameGeneratorFQN, Nil).get
+
+    AkkaHttpServerExtensionSettings(includeTraceTokenHeader, traceTokenHeaderName, nameGenerator)
+  }
+}

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/AkkaHttpServerMetrics.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/AkkaHttpServerMetrics.scala
@@ -1,0 +1,33 @@
+/* ===================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.akka.http.server
+
+import kamon.http.HttpServerMetrics
+import kamon.metric.EntityRecorderFactory
+import kamon.metric.instrument.InstrumentFactory
+
+class AkkaHttpServerMetrics(instrumentFactory: InstrumentFactory) extends HttpServerMetrics(instrumentFactory) {
+  def recordConnection(bindingAddress: String): Unit =
+    counter(bindingAddress).increment()
+
+  def openConnections = minMaxCounter("open-connections")
+}
+
+object AkkaHttpServerMetrics extends EntityRecorderFactory[AkkaHttpServerMetrics] {
+  def category: String = "akka-http-server"
+  def createRecorder(instrumentFactory: InstrumentFactory): AkkaHttpServerMetrics =
+    new AkkaHttpServerMetrics(instrumentFactory)
+}

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/KamonTraceDirectives.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/KamonTraceDirectives.scala
@@ -1,0 +1,30 @@
+/* ===================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.akka.http.server
+
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.server.directives._
+import kamon.trace.Tracer
+
+trait KamonTraceDirectives {
+  import BasicDirectives._
+  def traceName(name: String): Directive0 = mapRequestContext { requestContext ⇒
+    Tracer.currentContext.rename(name)
+    requestContext
+  }
+}
+
+object KamonTraceDirectives extends KamonTraceDirectives

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/instrumentation/ServerInstrumentation.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/instrumentation/ServerInstrumentation.scala
@@ -150,7 +150,7 @@ trait ServerInstrumentationUtils {
   }
 
   def attachTraceTokenHeader(response: HttpResponse, traceTokenHeaderName: String, traceToken: String): HttpResponse =
-    response.withHeaders(response.headers :+ RawHeader(traceTokenHeaderName, traceToken))
+    response.withHeaders(response.headers.filterNot(_.name == traceTokenHeaderName) :+ RawHeader(traceTokenHeaderName, traceToken))
 }
 
 object ServerInstrumentationUtils extends ServerInstrumentationUtils

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/instrumentation/ServerInstrumentation.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/instrumentation/ServerInstrumentation.scala
@@ -1,0 +1,154 @@
+/* ===================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.akka.http.server.instrumentation
+
+import akka.http.scaladsl.Http.{ IncomingConnection, ServerBinding }
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ HttpResponse, HttpRequest }
+import akka.http.scaladsl.server.RequestContext
+import kamon.Kamon
+import kamon.akka.http.server.{ AkkaHttpServerExtension, AkkaHttpServer, AkkaHttpServerMetrics }
+import kamon.metric.Entity
+import kamon.trace.{ TraceContextAware, Tracer }
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation._
+
+@Aspect
+class HttpRequestInstrumentation extends ServerInstrumentationUtils {
+
+  @DeclareMixin("akka.http.scaladsl.model.HttpRequest")
+  def mixinTraceContextAwareToRequest: TraceContextAware = TraceContextAware.default
+
+  @Pointcut("execution(akka.http.scaladsl.model.HttpRequest.new(..)) && this(request)")
+  def httpRequestCreation(request: HttpRequest with TraceContextAware): Unit = {}
+
+  @After("httpRequestCreation(request)")
+  def afterHttpRequestCreation(request: HttpRequest with TraceContextAware): Unit = {
+    val akkaHttpServerExtension = Kamon(AkkaHttpServer)
+    val serverMetrics = akkaHttpServerExtension.serverMetrics
+
+    val defaultTraceName = akkaHttpServerExtension.generateTraceName(request)
+    val token = request.headers.find(_.name == akkaHttpServerExtension.settings.traceTokenHeaderName).map(_.value)
+
+    val newContext = Kamon.tracer.newContext(defaultTraceName, token)
+    Tracer.setCurrentContext(newContext)
+
+    request.traceContext
+
+    recordAkkaHttpServerMetrics(request, akkaHttpServerExtension)
+  }
+}
+
+@Aspect
+class RequestContextInstrumentation extends ServerInstrumentationUtils {
+
+  @DeclareMixin("akka.http.scaladsl.server.RequestContextImpl")
+  def mixinTraceContextAwareToRequestContext: TraceContextAware = TraceContextAware.default
+
+  @Pointcut("execution(akka.http.scaladsl.server.RequestContextImpl.new(..)) && this(context)")
+  def requestContextCreation(context: RequestContext with TraceContextAware): Unit = {}
+
+  @Around("requestContextCreation(context)")
+  def afterCreation(pjp: ProceedingJoinPoint, context: RequestContext with TraceContextAware): Unit = {
+    val incomingContext = Tracer.currentContext
+
+    Tracer.withContext(incomingContext) {
+      pjp.proceed()
+    }
+  }
+}
+
+@Aspect
+class HttpResponseInstrumentation extends ServerInstrumentationUtils {
+
+  @DeclareMixin("akka.http.scaladsl.model.HttpResponse")
+  def mixinTraceContextAwareToResponse: TraceContextAware = TraceContextAware.default
+
+  @Pointcut("call(akka.http.scaladsl.model.HttpResponse.new(..)) && !cflow(execution(* *..attachTraceTokenHeader(..)))")
+  def httpResponseCreation(): Unit = {}
+
+  @Around("httpResponseCreation()")
+  def afterHttpResponseCreation(pjp: ProceedingJoinPoint) = {
+    val akkaHttpServerExtension = Kamon(AkkaHttpServer)
+    val incomingContext = Tracer.currentContext
+
+    val response: HttpResponse = pjp.proceed().asInstanceOf[HttpResponse]
+
+    val proceed =
+      if (akkaHttpServerExtension.settings.includeTraceTokenHeader) {
+        val responseWithTraceTokenHeader =
+          attachTraceTokenHeader(
+            response,
+            akkaHttpServerExtension.settings.traceTokenHeaderName,
+            incomingContext.token)
+        responseWithTraceTokenHeader
+      } else {
+        response
+      }
+
+    incomingContext.finish()
+
+    recordAkkaHttpServerMetrics(response, incomingContext.name, akkaHttpServerExtension)
+
+    proceed
+  }
+}
+
+@Aspect
+class ServerInstrumentation {
+
+  @Pointcut("execution(akka.http.scaladsl.Http.ServerBinding.new(..)) && this(binding)")
+  def serverBindingCreation(binding: ServerBinding): Unit = {}
+
+  @After("serverBindingCreation(binding)")
+  def afterServerBindingCreation(binding: ServerBinding): Unit = {
+    val akkaHttpServerExtension = Kamon(AkkaHttpServer)
+    val serverMetrics = akkaHttpServerExtension.serverMetrics
+    val bindingAddress = binding.localAddress.toString
+  }
+
+  @Pointcut("execution(akka.http.scaladsl.Http.IncomingConnection.new(..)) && this(connection)")
+  def newIncomingConnection(connection: IncomingConnection): Unit = {}
+
+  @After("newIncomingConnection(connection)")
+  def afterNewIncomingConnection(connection: IncomingConnection): Unit = {
+    val bindingAddress = connection.localAddress.toString
+    val akkaHttpServerExtension = Kamon(AkkaHttpServer)
+    val serverMetrics = akkaHttpServerExtension.serverMetrics
+
+    if (Kamon.metrics.shouldTrack(bindingEntity(bindingAddress))) {
+      serverMetrics.recordConnection(bindingAddress)
+    }
+  }
+
+  private def bindingEntity(name: String): Entity =
+    Entity(name, AkkaHttpServerMetrics.category)
+}
+
+trait ServerInstrumentationUtils {
+  def recordAkkaHttpServerMetrics(request: HttpRequest, akkaHttpServerExtension: AkkaHttpServerExtension): Unit =
+    akkaHttpServerExtension.serverMetrics.openConnections.increment()
+
+  def recordAkkaHttpServerMetrics(response: HttpResponse, traceName: String, akkaHttpServerExtension: AkkaHttpServerExtension): Unit = {
+    akkaHttpServerExtension.serverMetrics.recordResponse(traceName, response.status.intValue().toString)
+    akkaHttpServerExtension.serverMetrics.openConnections.decrement()
+  }
+
+  def attachTraceTokenHeader(response: HttpResponse, traceTokenHeaderName: String, traceToken: String): HttpResponse =
+    response.withHeaders(response.headers :+ RawHeader(traceTokenHeaderName, traceToken))
+}
+
+object ServerInstrumentationUtils extends ServerInstrumentationUtils

--- a/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/instrumentation/ServerInstrumentation.scala
+++ b/kamon-akka-http-server/src/main/scala/kamon/akka/http/server/instrumentation/ServerInstrumentation.scala
@@ -90,7 +90,7 @@ class HttpResponseInstrumentation extends ServerInstrumentationUtils {
     val response: HttpResponse = pjp.proceed().asInstanceOf[HttpResponse]
 
     val proceed =
-      if (akkaHttpServerExtension.settings.includeTraceTokenHeader) {
+      if (!incomingContext.isEmpty && akkaHttpServerExtension.settings.includeTraceTokenHeader) {
         val responseWithTraceTokenHeader =
           attachTraceTokenHeader(
             response,
@@ -101,7 +101,9 @@ class HttpResponseInstrumentation extends ServerInstrumentationUtils {
         response
       }
 
-    incomingContext.finish()
+    if (incomingContext.isOpen) {
+      incomingContext.finish()
+    }
 
     recordAkkaHttpServerMetrics(response, incomingContext.name, akkaHttpServerExtension)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,6 +45,9 @@ object Dependencies {
   val akkaTestKit       = "com.typesafe.akka"         %%  "akka-testkit"          % akkaVersion
   val akkaRemote        = "com.typesafe.akka"         %%  "akka-remote"           % akkaVersion
   val akkaCluster       = "com.typesafe.akka"         %%  "akka-cluster"          % akkaVersion
+  val akkaStreams       = "com.typesafe.akka"         %%  "akka-stream-experimental"    % "1.0-RC3"
+  val akkaHttpCore      = "com.typesafe.akka"         %%  "akka-http-core-experimental" % "1.0-RC3"
+  val akkaHttp          = "com.typesafe.akka"         %%  "akka-http-experimental"      % "1.0-RC3"
   val play              = "com.typesafe.play"         %%  "play"                  % playVersion
   val playWS            = "com.typesafe.play"         %%  "play-ws"               % playVersion
   val playTest          = "org.scalatestplus"         %%  "play"                  % "1.2.0"

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -23,7 +23,7 @@ object Projects extends Build {
 
   lazy val kamon = Project("kamon", file("."))
     .aggregate(kamonCore, kamonScala, kamonAkka, kamonSpray, kamonNewrelic, kamonPlayground, kamonTestkit,
-      kamonPlay, kamonStatsD, kamonDatadog, kamonSystemMetrics, kamonLogReporter, kamonAkkaRemote, kamonJdbc, kamonAnnotation)
+      kamonPlay, kamonStatsD, kamonDatadog, kamonSystemMetrics, kamonLogReporter, kamonAkkaRemote, kamonAkkaHttp, kamonJdbc, kamonAnnotation)
     .settings(basicSettings: _*)
     .settings(formatSettings: _*)
     .settings(noPublishing: _*)
@@ -79,6 +79,16 @@ object Projects extends Build {
         provided(aspectJ) ++
         test(scalatest, akkaTestKit, akkaSlf4j, slf4Jul, slf4Log4j, logback))
 
+  lazy val kamonAkkaHttp = Project("kamon-akka-http-server", file("kamon-akka-http-server"))
+    .dependsOn(kamonScala)
+    .settings(basicSettings: _* )
+    .settings(formatSettings: _*)
+    .settings(aspectJSettings: _*)
+    .settings(
+      libraryDependencies ++=
+        compile(akkaHttpCore, akkaHttp) ++
+        provided(aspectJ) ++
+        test(scalatest, akkaTestKit, akkaSlf4j, slf4Jul, slf4Log4j, logback))
 
   lazy val kamonSpray = Project("kamon-spray", file("kamon-spray"))
     .dependsOn(kamonCore % "compile->compile;test->test", kamonAkka, kamonTestkit % "test")


### PR DESCRIPTION
As akka-http is close to release, I put some time in making a module for Kamon. Closely follows and extends #134.

- Depends on 1.0-RC3 of `akka-http-core` and `akka-http`
- Purely focussed on the *server-side* of akka-http for now
- Currently only works with the **[high-level server-side api](http://doc.akka.io/docs/akka-stream-and-http-experimental/1.0-RC3/scala/http/routing-dsl/index.html)**
- Close to feature-parity with the Spray module for the server side (I have not copied the `TraceLocal storeDiagnosticData` as I haven't completely figured out where that data is used. Implementing this would be easy though)
- The `AkkaHttpServerMetrics` extends the `HttpServerMetrics` and adds:
  - connection counts per server binding
  - an open connection MinMaxCounter that tracks the number of outstanding/open requests
- Updated the `LogReporter` to also report both of the above metrics

I have some tests ready, but they're currently a bit rough around the edges, and would like to get some feedback on this before completely fleshing them out.

Hope this one gets some love
@dpsoft & @ivantopo 