### PR TITLE
+ akka: avoid runtime exceptions logged on ActorCell shutdown #165

### DIFF
--- a/kamon-akka/src/main/scala/kamon/akka/instrumentation/ActorCellInstrumentation.scala
+++ b/kamon-akka/src/main/scala/kamon/akka/instrumentation/ActorCellInstrumentation.scala
@@ -90,14 +90,16 @@ class ActorCellInstrumentation {
     }
   }
 
-  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell)")
-  def actorStop(cell: ActorCell): Unit = {}
+  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell) && args(lookupDataAware)")
+  def actorStop(cell: ActorCell, lookupDataAware: LookupDataAware): Unit = {}
 
-  @After("actorStop(cell)")
-  def afterStop(cell: ActorCell): Unit = {
+  @After("actorStop(cell, lookupDataAware)")
+  def afterStop(cell: ActorCell, lookupDataAware: LookupDataAware): Unit = {
+    import lookupDataAware.lookupData
+
     val cellMetrics = cell.asInstanceOf[ActorCellMetrics]
     cellMetrics.recorder.foreach { _ ⇒
-      Kamon.metrics.removeEntity(cellMetrics.entity)
+      lookupData.metrics.removeEntity(cellMetrics.entity)
     }
 
     // The Stop can't be captured from the RoutedActorCell so we need to put this piece of cleanup here.

--- a/kamon-akka/src/main/scala/kamon/akka/instrumentation/ActorCellInstrumentation.scala
+++ b/kamon-akka/src/main/scala/kamon/akka/instrumentation/ActorCellInstrumentation.scala
@@ -21,7 +21,7 @@ import akka.dispatch.{ Envelope, MessageDispatcher }
 import akka.routing.RoutedActorCell
 import kamon.Kamon
 import kamon.akka.{ RouterMetrics, ActorMetrics }
-import kamon.metric.Entity
+import kamon.metric.{ MetricsModule, Entity }
 import kamon.trace._
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
@@ -45,6 +45,7 @@ class ActorCellInstrumentation {
 
       cellMetrics.entity = actorEntity
       cellMetrics.recorder = Some(actorMetricsRecorder)
+      cellMetrics.metrics = Kamon.metrics
     }
   }
 
@@ -90,23 +91,22 @@ class ActorCellInstrumentation {
     }
   }
 
-  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell) && args(lookupDataAware)")
-  def actorStop(cell: ActorCell, lookupDataAware: LookupDataAware): Unit = {}
+  @Pointcut("execution(* akka.actor.ActorCell.stop()) && this(cell)")
+  def actorStop(cell: ActorCell): Unit = {}
 
-  @After("actorStop(cell, lookupDataAware)")
-  def afterStop(cell: ActorCell, lookupDataAware: LookupDataAware): Unit = {
-    import lookupDataAware.lookupData
+  @After("actorStop(cell)")
+  def afterActorStop(cell: ActorCell): Unit = {
 
     val cellMetrics = cell.asInstanceOf[ActorCellMetrics]
     cellMetrics.recorder.foreach { _ ⇒
-      lookupData.metrics.removeEntity(cellMetrics.entity)
+      cellMetrics.metrics.removeEntity(cellMetrics.entity)
     }
 
     // The Stop can't be captured from the RoutedActorCell so we need to put this piece of cleanup here.
     if (cell.isInstanceOf[RoutedActorCell]) {
       val routedCellMetrics = cell.asInstanceOf[RoutedActorCellMetrics]
       routedCellMetrics.routerRecorder.foreach { _ ⇒
-        Kamon.metrics.removeEntity(routedCellMetrics.routerEntity)
+        cellMetrics.metrics.removeEntity(routedCellMetrics.routerEntity)
       }
     }
   }
@@ -147,6 +147,7 @@ class RoutedActorCellInstrumentation {
     if (Kamon.metrics.shouldTrack(routerEntity)) {
       val cellMetrics = cell.asInstanceOf[RoutedActorCellMetrics]
 
+      cellMetrics.metrics = Kamon.metrics
       cellMetrics.routerEntity = routerEntity
       cellMetrics.routerRecorder = Some(Kamon.metrics.entity(RouterMetrics, routerEntity))
     }
@@ -177,12 +178,16 @@ class RoutedActorCellInstrumentation {
   }
 }
 
-trait ActorCellMetrics {
+trait ActorCellMetricModule {
+  var metrics: MetricsModule = _
+}
+
+trait ActorCellMetrics extends ActorCellMetricModule {
   var entity: Entity = _
   var recorder: Option[ActorMetrics] = None
 }
 
-trait RoutedActorCellMetrics {
+trait RoutedActorCellMetrics extends ActorCellMetricModule {
   var routerEntity: Entity = _
   var routerRecorder: Option[RouterMetrics] = None
 }
@@ -208,7 +213,6 @@ class MetricsIntoActorCellsMixin {
 
   @DeclareMixin("akka.routing.RoutedActorCell")
   def mixinActorCellMetricsToRoutedActorCell: RoutedActorCellMetrics = new RoutedActorCellMetrics {}
-
 }
 
 @Aspect


### PR DESCRIPTION
Fix for a similar 'Kamon has not been started yet.' exception thrown in the ActorLoggingInstrumentation. 

This exception surfaced after the original DispatcherInstrumentation reported in ticket #165 was fixed with 6354021533319790ba675c2b9e36fb439a8ea06f. 

Please note that I have no previous experience with AspectJ and am new to Scala. Runs on my machine :) 