### PR TITLE
+ core: Allow creation of counters with units

### DIFF
--- a/kamon-core/src/main/scala/kamon/metric/EntityRecorder.scala
+++ b/kamon-core/src/main/scala/kamon/metric/EntityRecorder.scala
@@ -204,6 +204,9 @@ abstract class GenericEntityRecorder(instrumentFactory: InstrumentFactory) exten
   protected def counter(name: String): Counter =
     register(CounterKey(name, UnitOfMeasurement.Unknown), instrumentFactory.createCounter())
 
+  protected def counter(name: String, unitOfMeasurement: UnitOfMeasurement): Counter =
+    register(CounterKey(name, unitOfMeasurement), instrumentFactory.createCounter())
+
   protected def counter(key: CounterKey): Counter =
     register(key, instrumentFactory.createCounter())
 


### PR DESCRIPTION
Currently, the GenericEntityRecorder only allows two ways to create a
new counter:

1. Using a simple name, resulting in a counter with an Unknown unit of
   measure
2. Using a CounterKey, but that is not really helpful since that class
   is private to Kamon

This trivial patch adds a new counter method that accepts a unit of
measure.