### PR TITLE
newrelic: de-tokenise the app name, fixes #255

### DIFF
--- a/kamon-newrelic/src/main/scala/kamon/newrelic/JsonProtocol.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/JsonProtocol.scala
@@ -21,15 +21,17 @@ import spray.json._
 object JsonProtocol extends DefaultJsonProtocol {
 
   implicit object ConnectJsonWriter extends RootJsonWriter[AgentSettings] {
-    def write(obj: AgentSettings): JsValue =
+    def write(obj: AgentSettings): JsValue = {
+      val appNames = obj.appName.split(";")
       JsArray(
         JsObject(
           "agent_version" -> JsString("3.1.0"),
-          "app_name" -> JsArray(JsString(obj.appName)),
+          "app_name" -> JsArray(appNames.map(n ⇒ JsString(n)).toVector),
           "host" -> JsString(obj.hostname),
-          "identifier" -> JsString(s"java:${obj.appName}"),
+          "identifier" -> JsString(s"java:${appNames(0)}"),
           "language" -> JsString("java"),
           "pid" -> JsNumber(obj.pid)))
+    }
   }
 
   implicit def seqWriter[T: JsonFormat] = new JsonFormat[Seq[T]] {

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/ConnectJsonWriterSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/ConnectJsonWriterSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.newrelic
+
+import akka.util.Timeout
+import org.scalatest.{ Matchers, WordSpecLike }
+import scala.concurrent.duration.DurationInt
+import spray.json.JsValue
+
+class ConnectJsonWriterSpec extends WordSpecLike with Matchers {
+  import kamon.newrelic.JsonProtocol._
+
+  "the ConnectJsonWriter" should {
+    "produce the correct Json when a single app name is configured" in {
+      ConnectJsonWriter.write(agentSettings("app1")).compactPrint shouldBe expectedJson(""""app1"""")
+    }
+
+    "produce the correct Json when multiple app names are configured" in {
+      ConnectJsonWriter.write(agentSettings("app1;app2;app3")).compactPrint shouldBe expectedJson(""""app1","app2","app3"""");
+    }
+  }
+
+  def agentSettings(appName: String) = AgentSettings("1111111111", appName, "test-host", 1, Timeout(5 seconds), 1, 30 seconds, 1D)
+
+  def expectedJson(appName: String) = s"""[{"identifier":"java:app1","agent_version":"3.1.0","host":"test-host","pid":1,"language":"java","app_name":[$appName]}]"""
+}


### PR DESCRIPTION
To see the benefit of this change you need at least two applications running and reporting to new relic. Configure their app_name properties like this:

- "app1;parent"
- "app2;parent"

This will create the "app1", "app2" and "parent" applications in new relic, where "parent" is the aggregate of "app1" and "app2".



