### PR TITLE
Fix heap metrics update

### DIFF
--- a/kamon-system-metrics/src/test/scala/kamon/metrics/SystemMetricsSpec.scala
+++ b/kamon-system-metrics/src/test/scala/kamon/metrics/SystemMetricsSpec.scala
@@ -74,6 +74,20 @@ class SystemMetricsSpec extends BaseKamonSpec("system-metrics-spec") with Redire
       memoryMetrics.gauge("non-heap-committed").get.numberOfMeasurements should be > 0L
     }
 
+    "record correctly updatable values for heap metrics" in {
+      Thread.sleep(3000)
+
+      val data = new Array[Byte](20 * 1024 * 1024) // 20 Mb of data
+
+      Thread.sleep(3000)
+
+      val memoryMetrics = takeSnapshotOf("jmx-memory", "system-metric")
+      val heapUsed = memoryMetrics.gauge("heap-used").get
+
+      heapUsed.max should be > heapUsed.min
+      data.size should be > 0 // Just for data usage
+    }
+
     "record daemon, count and peak jvm threads metrics" in {
       val threadsMetrics = takeSnapshotOf("threads", "system-metric")
 


### PR DESCRIPTION
For now `MemoryUsageMetrics` stores a direct reference to `MemoryUsage` object, got from MemoryMXBean on initialization. However, `MemoryUsage` is immutable object representing some snapshot and not being updated by `MemoryMXBean` (see http://docs.oracle.com/javase/7/docs/api/java/lang/management/MemoryUsage.html) - so heap usage metrics always report the same value.

Instead it's required to get new `MemoryUsage` instance each time we want to record heap usage.

In my patch I replaced reference to `MemoryUsage` with reference to function extracting it.