### PR TITLE
= core: don't throw an NPE during shutdown if Kamon hasn't been started

### DIFF
--- a/kamon-core/src/main/scala/kamon/Kamon.scala
+++ b/kamon-core/src/main/scala/kamon/Kamon.scala
@@ -68,8 +68,10 @@ object Kamon {
 
   def shutdown(): Unit = {
     _coreComponents = None
-    _system.shutdown()
-    _system = null
+    if (_system ne null) {
+      _system.shutdown()
+      _system = null
+    }
   }
 
   def metrics: MetricsModule =


### PR DESCRIPTION
if you don't start Kamon, but try to call Shutdown, it throws an NPE, while it can just do nothing