### PR TITLE
+ newrelic: add ssl support to agent

### DIFF
--- a/kamon-newrelic/src/main/resources/reference.conf
+++ b/kamon-newrelic/src/main/resources/reference.conf
@@ -33,6 +33,9 @@ kamon {
       akka-dispatcher = [ "**" ]
       akka-router     = [ "**" ]
     }
+
+    # if true send metrics over SSL
+    ssl = false
   }
 
   modules {

--- a/kamon-newrelic/src/main/scala/kamon/newrelic/ApiMethodClient.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/ApiMethodClient.scala
@@ -31,7 +31,8 @@ class ApiMethodClient(host: String, val runID: Option[Long], agentSettings: Agen
   }
 
   val httpClient = encode(Deflate) ~> sendReceive(httpTransport) ~> decode(Deflate) ~> unmarshal[JsValue]
-  val baseCollectorUri = Uri("/agent_listener/invoke_raw_method").withHost(host).withScheme("http")
+  val scheme = if (agentSettings.ssl) "https" else "http"
+  val baseCollectorUri = Uri("/agent_listener/invoke_raw_method").withHost(host).withScheme(scheme)
 
   def invokeMethod[T: Marshaller](method: String, payload: T): Future[JsValue] = {
     val methodQuery = ("method" -> method) +: baseQuery

--- a/kamon-newrelic/src/main/scala/kamon/newrelic/JsonProtocol.scala
+++ b/kamon-newrelic/src/main/scala/kamon/newrelic/JsonProtocol.scala
@@ -30,6 +30,7 @@ object JsonProtocol extends DefaultJsonProtocol {
           "host" -> JsString(obj.hostname),
           "identifier" -> JsString(s"java:${appNames(0)}"),
           "language" -> JsString("java"),
+          "ssl" -> JsString(obj.ssl.toString),
           "pid" -> JsNumber(obj.pid)))
     }
   }

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/AgentSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/AgentSpec.scala
@@ -48,6 +48,7 @@ class AgentSpec extends BaseKamonSpec("metric-reporter-spec") with RequestBuildi
         |    license-key = 1111111111
         |    connect-retry-delay = 1 second
         |    max-connect-retries = 3
+        |    ssl = true
         |  }
         |
         |  modules.kamon-newrelic.auto-start = no
@@ -85,14 +86,15 @@ class AgentSpec extends BaseKamonSpec("metric-reporter-spec") with RequestBuildi
           |     "host": "$host",
           |     "identifier": "java:kamon",
           |     "language": "java",
-          |     "pid": $pid
+          |     "pid": $pid,
+          |     "ssl": "true"
           |   }
           | ]
         """.stripMargin.parseJson)(sprayJsonMarshaller(JsValueFormat))
       })
 
       // Receive the runID
-      EventFilter.info(message = "Configuring New Relic reporters to use runID: [161221111] and collector: [collector-8.newrelic.com]", occurrences = 1).intercept {
+      EventFilter.info(message = "Configuring New Relic reporters to use runID: [161221111] and collector: [collector-8.newrelic.com] over: [https]", occurrences = 1).intercept {
         httpManager.reply(jsonResponse(
           """
           | {
@@ -143,7 +145,8 @@ class AgentSpec extends BaseKamonSpec("metric-reporter-spec") with RequestBuildi
           |     "host": "$host",
           |     "identifier": "java:kamon",
           |     "language": "java",
-          |     "pid": $pid
+          |     "pid": $pid,
+          |     "ssl": "true"
           |   }
           | ]
         """.stripMargin.parseJson)(sprayJsonMarshaller(JsValueFormat))
@@ -151,7 +154,7 @@ class AgentSpec extends BaseKamonSpec("metric-reporter-spec") with RequestBuildi
 
       // Receive the runID
       EventFilter.info(
-        message = "Configuring New Relic reporters to use runID: [161221112] and collector: [collector-8.newrelic.com]", occurrences = 1).intercept {
+        message = "Configuring New Relic reporters to use runID: [161221112] and collector: [collector-8.newrelic.com] over: [https]", occurrences = 1).intercept {
 
           httpManager.reply(jsonResponse(
             """
@@ -202,7 +205,7 @@ class AgentSpec extends BaseKamonSpec("metric-reporter-spec") with RequestBuildi
   }
 
   def rawMethodUri(host: String, methodName: String): Uri = {
-    Uri(s"http://$host/agent_listener/invoke_raw_method").withQuery(
+    Uri(s"https://$host/agent_listener/invoke_raw_method").withQuery(
       "method" -> methodName,
       "license_key" -> "1111111111",
       "marshal_format" -> "json",

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/ConnectJsonWriterSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/ConnectJsonWriterSpec.scala
@@ -34,7 +34,7 @@ class ConnectJsonWriterSpec extends WordSpecLike with Matchers {
     }
   }
 
-  def agentSettings(appName: String) = AgentSettings("1111111111", appName, "test-host", 1, Timeout(5 seconds), 1, 30 seconds, 1D)
+  def agentSettings(appName: String) = AgentSettings("1111111111", appName, "test-host", 1, Timeout(5 seconds), 1, 30 seconds, 1D, false)
 
-  def expectedJson(appName: String) = s"""[{"identifier":"java:app1","agent_version":"3.1.0","host":"test-host","pid":1,"language":"java","app_name":[$appName]}]"""
+  def expectedJson(appName: String) = s"""[{"identifier":"java:app1","agent_version":"3.1.0","host":"test-host","ssl":"false","pid":1,"language":"java","app_name":[$appName]}]"""
 }

--- a/kamon-newrelic/src/test/scala/kamon/newrelic/MetricReporterSpec.scala
+++ b/kamon-newrelic/src/test/scala/kamon/newrelic/MetricReporterSpec.scala
@@ -55,7 +55,7 @@ class MetricReporterSpec extends BaseKamonSpec("metric-reporter-spec") with Spra
         |
       """.stripMargin)
 
-  val agentSettings = AgentSettings("1111111111", "kamon", "test-host", 1, Timeout(5 seconds), 1, 30 seconds, 1D)
+  val agentSettings = AgentSettings("1111111111", "kamon", "test-host", 1, Timeout(5 seconds), 1, 30 seconds, 1D, false)
   val baseQuery = Query(
     "license_key" -> agentSettings.licenseKey,
     "marshal_format" -> "json",


### PR DESCRIPTION
Use kamon.newrelic.ssl = true to send metrics over https