### PR TITLE
= build: upgrade to sbt 0.13.9

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.9


### PR DESCRIPTION
The previous version of sbt has a bug which prevents publishM2 from overwriting artifacts. This fixes that.