### PR TITLE
+ statsd: scale statsd time and memory values to values from config

### DIFF
--- a/kamon-core/src/main/scala/kamon/metric/EntityRecorder.scala
+++ b/kamon-core/src/main/scala/kamon/metric/EntityRecorder.scala
@@ -89,7 +89,7 @@ case class GaugeRecorder(key: MetricKey, instrument: Gauge) extends SingleInstru
 
 /**
  *  Base class with plenty of utility methods to facilitate the creation of [[EntityRecorder]] implementations.
- *  It is not required to use this base class for defining custom a custom [[EntityRecorder]], but it is certainly
+ *  It is not required to use this base class for defining a custom [[EntityRecorder]], but it is certainly
  *  the most convenient way to do it and the preferred approach throughout the Kamon codebase.
  */
 abstract class GenericEntityRecorder(instrumentFactory: InstrumentFactory) extends EntityRecorder {

--- a/kamon-core/src/main/scala/kamon/metric/instrument/InstrumentSettings.scala
+++ b/kamon-core/src/main/scala/kamon/metric/instrument/InstrumentSettings.scala
@@ -1,7 +1,5 @@
 package kamon.metric.instrument
 
-import java.util.concurrent.TimeUnit
-
 import com.typesafe.config.Config
 import kamon.metric.instrument.Histogram.DynamicRange
 

--- a/kamon-core/src/main/scala/kamon/metric/instrument/UnitOfMeasurement.scala
+++ b/kamon-core/src/main/scala/kamon/metric/instrument/UnitOfMeasurement.scala
@@ -58,6 +58,12 @@ object Time {
   val Microseconds = Time(1E-6, "µs")
   val Milliseconds = Time(1E-3, "ms")
   val Seconds = Time(1, "s")
+
+  val units = List(Nanoseconds, Microseconds, Milliseconds, Seconds)
+
+  def apply(time: String): Time = units.find(_.label.toLowerCase == time.toLowerCase) getOrElse {
+    throw new IllegalArgumentException(s"Can't recognize time unit '$time'")
+  }
 }
 
 /**
@@ -73,7 +79,12 @@ case class Memory(factor: Double, label: String) extends UnitOfMeasurement {
 object Memory {
   val Bytes = Memory(1, "b")
   val KiloBytes = Memory(1024, "Kb")
-  val MegaBytes = Memory(1024E2, "Mb")
-  val GigaBytes = Memory(1024E3, "Gb")
-}
+  val MegaBytes = Memory(1024 * 1024, "Mb")
+  val GigaBytes = Memory(1024 * 1024 * 1024, "Gb")
 
+  val units = List(Bytes, KiloBytes, MegaBytes, GigaBytes)
+
+  def apply(memory: String): Memory = units.find(_.label.toLowerCase == memory.toLowerCase) getOrElse {
+    throw new IllegalArgumentException(s"Can't recognize memory unit '$memory'")
+  }
+}

--- a/kamon-core/src/main/scala/kamon/util/ConfigTools.scala
+++ b/kamon-core/src/main/scala/kamon/util/ConfigTools.scala
@@ -22,6 +22,8 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration.FiniteDuration
 
+import kamon.metric.instrument.{ Memory, Time }
+
 object ConfigTools {
   implicit class Syntax(val config: Config) extends AnyVal {
     // We are using the deprecated .getNanoseconds option to keep Kamon source code compatible with
@@ -37,6 +39,10 @@ object ConfigTools {
         case entry ⇒ entry.getKey.takeWhile(_ != '.')
       } toSet
     }
+
+    def time(path: String): Time = Time(config.getString(path))
+
+    def memory(path: String): Memory = Memory(config.getString(path))
   }
 
 }

--- a/kamon-core/src/main/scala/kamon/util/ScaleUnits.scala
+++ b/kamon-core/src/main/scala/kamon/util/ScaleUnits.scala
@@ -1,0 +1,25 @@
+package kamon.util
+
+import com.typesafe.config.Config
+import kamon.metric.instrument.{ Memory, Time, UnitOfMeasurement }
+import kamon.util.ConfigTools._
+
+class ScaleUnits(config: Config) {
+
+  val TimeUnits = "time-units"
+  val MemoryUnits = "memory-units"
+
+  lazy val scaleTimeTo: Option[Time] =
+    if (config.hasPath(TimeUnits)) Some(config.time(TimeUnits)) else None
+
+  lazy val scaleMemoryTo: Option[Memory] =
+    if (config.hasPath(MemoryUnits)) Some(config.memory(MemoryUnits)) else None
+
+  def scale(unit: UnitOfMeasurement, value: Long): Long = (unit, scaleTimeTo, scaleMemoryTo) match {
+    case (from: Time, Some(to), _)   ⇒ from.scale(to)(value).toLong
+    case (from: Memory, _, Some(to)) ⇒ from.scale(to)(value).toLong
+    case _                           ⇒ value
+  }
+
+}
+

--- a/kamon-core/src/test/scala/kamon/metric/instrument/UnitOfMeasurementSpec.scala
+++ b/kamon-core/src/test/scala/kamon/metric/instrument/UnitOfMeasurementSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2015 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.metric.instrument
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class UnitOfMeasurementSpec extends WordSpec with Matchers {
+
+  "Time unit campanion" should {
+    "resolve Time Unit by valid name" in {
+      Time("s") should be(Time.Seconds)
+      Time("n") should be(Time.Nanoseconds)
+      Time("ms") should be(Time.Milliseconds)
+      Time("µs") should be(Time.Microseconds)
+    }
+    "fail to resolve Time Unit by invalid name" in {
+      val ex = intercept[IllegalArgumentException](Time("boo"))
+      ex.getMessage should be("Can't recognize time unit 'boo'")
+    }
+    "scale time properly" in {
+      val epsilon = 0.0001
+
+      Time.Nanoseconds.scale(Time.Nanoseconds)(1000000D) should be(1000000D +- epsilon)
+      Time.Nanoseconds.scale(Time.Microseconds)(1000000D) should be(1000D +- epsilon)
+      Time.Nanoseconds.scale(Time.Milliseconds)(1000000D) should be(1D +- epsilon)
+      Time.Nanoseconds.scale(Time.Seconds)(1000000D) should be(0.001D +- epsilon)
+      Time.Seconds.scale(Time.Nanoseconds)(1D) should be(1000000000D +- epsilon)
+    }
+  }
+
+  "Memory unit campanion" should {
+    "resolve Memory Unit by valid name" in {
+      Memory("b") should be(Memory.Bytes)
+      Memory("Kb") should be(Memory.KiloBytes)
+      Memory("Mb") should be(Memory.MegaBytes)
+      Memory("Gb") should be(Memory.GigaBytes)
+    }
+    "fail to resolve Memory Unit by invalid name" in {
+      val ex = intercept[IllegalArgumentException](Memory("boo"))
+      ex.getMessage should be("Can't recognize memory unit 'boo'")
+    }
+    "scale memory properly" in {
+      val epsilon = 0.0001
+
+      Memory.Bytes.scale(Memory.Bytes)(1000000D) should be(1000000D +- epsilon)
+      Memory.Bytes.scale(Memory.KiloBytes)(1000000D) should be(976.5625D +- epsilon)
+      Memory.Bytes.scale(Memory.MegaBytes)(1000000D) should be(0.9536D +- epsilon)
+      Memory.Bytes.scale(Memory.GigaBytes)(1000000D) should be(9.3132E-4D +- epsilon)
+      Memory.MegaBytes.scale(Memory.Bytes)(1D) should be(1048576D +- epsilon)
+    }
+  }
+}

--- a/kamon-core/src/test/scala/kamon/util/ScaleUnitsSpec.scala
+++ b/kamon-core/src/test/scala/kamon/util/ScaleUnitsSpec.scala
@@ -1,0 +1,36 @@
+package kamon.util
+
+import com.typesafe.config.ConfigFactory
+import kamon.metric.instrument.{ Memory, Time }
+import org.scalatest.{ Matchers, WordSpec }
+
+class ScaleUnitsSpec extends WordSpec with Matchers {
+
+  "ScaleUnits" should {
+    "read time unit to scale to from config and scale properly" in {
+      val scaler = new ScaleUnits(
+        ConfigFactory.parseString("""
+                                     |time-units = "ms"
+                                   """.stripMargin))
+
+      scaler.scaleMemoryTo should be(None)
+      scaler.scaleTimeTo should be(Some(Time.Milliseconds))
+
+      scaler.scale(Time.Nanoseconds, 1000000) should be(1)
+      scaler.scale(Memory.Bytes, 1000000) should be(1000000)
+    }
+    "read memory unit to scale to from config and scale properly" in {
+      val scaler = new ScaleUnits(
+        ConfigFactory.parseString("""
+                                     |memory-units = "kb"
+                                   """.stripMargin))
+
+      scaler.scaleMemoryTo should be(Some(Memory.KiloBytes))
+      scaler.scaleTimeTo should be(None)
+
+      scaler.scale(Time.Nanoseconds, 1000000) should be(1000000)
+      scaler.scale(Memory.Bytes, 10240) should be(10)
+    }
+  }
+
+}

--- a/kamon-statsd/src/main/resources/reference.conf
+++ b/kamon-statsd/src/main/resources/reference.conf
@@ -74,6 +74,16 @@ kamon {
       # Max packet size for UDP metrics data sent to StatsD.
       max-packet-size = 1024 bytes
     }
+
+    # All time values are collected in nanoseconds,
+    # to scale before sending to StatsD set "time-units" to "s" or "ms" or "µs".
+    # Value "ns" is equivalent to omitting the setting
+    # time-units = "ns"
+
+    # All memory values are collected in bytes,
+    # to scale before sending to StatsD set "memory-units" to "gb" or "mb" or "kb".
+    # Value "b" is equivalent to omitting the setting
+    # memory-units = "b"
   }
 
   modules {

--- a/kamon-statsd/src/main/scala/kamon/statsd/BatchStatsDMetricsSender.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/BatchStatsDMetricsSender.scala
@@ -55,11 +55,13 @@ class BatchStatsDMetricsSender(statsDConfig: Config, metricKeyGenerator: MetricK
       metricSnapshot match {
         case hs: Histogram.Snapshot ⇒
           hs.recordsIterator.foreach { record ⇒
-            packetBuilder.appendMeasurement(key, encodeStatsDTimer(record.level, record.count))
+            val scaled: Long = scaler.scale(metricKey.unitOfMeasurement, record.level)
+            packetBuilder.appendMeasurement(key, encodeStatsDTimer(scaled, record.count))
           }
 
         case cs: Counter.Snapshot ⇒
-          packetBuilder.appendMeasurement(key, encodeStatsDCounter(cs.count))
+          val scaled: Long = scaler.scale(metricKey.unitOfMeasurement, cs.count)
+          packetBuilder.appendMeasurement(key, encodeStatsDCounter(scaled))
       }
     }
 

--- a/kamon-statsd/src/main/scala/kamon/statsd/SimpleStatsDMetricsSender.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/SimpleStatsDMetricsSender.scala
@@ -51,11 +51,13 @@ class SimpleStatsDMetricsSender(statsDConfig: Config, metricKeyGenerator: Metric
       metricSnapshot match {
         case hs: Histogram.Snapshot ⇒
           hs.recordsIterator.foreach { record ⇒
-            flushToUDP(keyPrefix + encodeStatsDTimer(record.level, record.count))
+            val scaled: Long = scaler.scale(metricKey.unitOfMeasurement, record.level)
+            flushToUDP(keyPrefix + encodeStatsDTimer(scaled, record.count))
           }
 
         case cs: Counter.Snapshot ⇒
-          flushToUDP(keyPrefix + encodeStatsDCounter(cs.count))
+          val scaled: Long = scaler.scale(metricKey.unitOfMeasurement, cs.count)
+          flushToUDP(keyPrefix + encodeStatsDCounter(scaled))
       }
     }
   }

--- a/kamon-statsd/src/main/scala/kamon/statsd/UDPBasedStatsDMetricsSender.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/UDPBasedStatsDMetricsSender.scala
@@ -19,11 +19,30 @@ package kamon.statsd
 import java.net.InetSocketAddress
 import java.text.{ DecimalFormat, DecimalFormatSymbols }
 import java.util.Locale
+
 import akka.actor.{ Actor, ActorRef, ActorSystem }
 import akka.io.{ IO, Udp }
 import akka.util.ByteString
 import com.typesafe.config.Config
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.util.ScaleUnits
+
+trait StatsDValueFormatters {
+
+  val symbols = DecimalFormatSymbols.getInstance(Locale.US)
+  symbols.setDecimalSeparator('.')
+  // Just in case there is some weird locale config we are not aware of.
+
+  // Absurdly high number of decimal digits, let the other end lose precision if it needs to.
+  val samplingRateFormat = new DecimalFormat("#.################################################################", symbols)
+
+  def encodeStatsDTimer(level: Long, count: Long): String = {
+    val samplingRate: Double = 1D / count
+    level.toString + "|ms" + (if (samplingRate != 1D) "|@" + samplingRateFormat.format(samplingRate) else "")
+  }
+
+  def encodeStatsDCounter(count: Long): String = count.toString + "|c"
+}
 
 /**
  * Base class for different StatsD senders utilizing UDP protocol. It implies use of one statsd server.
@@ -31,18 +50,13 @@ import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
  * @param metricKeyGenerator Key generator for all metrics sent by this sender
  */
 abstract class UDPBasedStatsDMetricsSender(statsDConfig: Config, metricKeyGenerator: MetricKeyGenerator)
-    extends Actor with UdpExtensionProvider {
+    extends Actor with UdpExtensionProvider with StatsDValueFormatters {
 
   import context.system
 
   val statsDHost = statsDConfig.getString("hostname")
   val statsDPort = statsDConfig.getInt("port")
-
-  val symbols = DecimalFormatSymbols.getInstance(Locale.US)
-  symbols.setDecimalSeparator('.') // Just in case there is some weird locale config we are not aware of.
-
-  // Absurdly high number of decimal digits, let the other end lose precision if it needs to.
-  val samplingRateFormat = new DecimalFormat("#.################################################################", symbols)
+  val scaler = new ScaleUnits(statsDConfig)
 
   udpExtension ! Udp.SimpleSender
 
@@ -60,13 +74,6 @@ abstract class UDPBasedStatsDMetricsSender(statsDConfig: Config, metricKeyGenera
   }
 
   def writeMetricsToRemote(tick: TickMetricSnapshot, flushToUDP: String ⇒ Unit): Unit
-
-  def encodeStatsDTimer(level: Long, count: Long): String = {
-    val samplingRate: Double = 1D / count
-    level.toString + "|ms" + (if (samplingRate != 1D) "|@" + samplingRateFormat.format(samplingRate) else "")
-  }
-
-  def encodeStatsDCounter(count: Long): String = count.toString + "|c"
 
 }
 

--- a/kamon-statsd/src/test/scala/kamon/statsd/SimpleStatsDMetricsSenderSpec.scala
+++ b/kamon-statsd/src/test/scala/kamon/statsd/SimpleStatsDMetricsSenderSpec.scala
@@ -16,7 +16,7 @@
 
 package kamon.statsd
 
-import akka.actor.{ ActorSystem, Props, ActorRef }
+import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 
@@ -29,6 +29,8 @@ class SimpleStatsDMetricsSenderSpec extends UDPBasedStatsDMetricSenderSpec("simp
         |  statsd {
         |    hostname = "127.0.0.1"
         |    port = 0
+        |    time-units = "ms"
+        |    memory-units = "kb"
         |    simple-metric-key-generator {
         |      application = kamon
         |      hostname-override = kamon-host
@@ -71,6 +73,32 @@ class SimpleStatsDMetricsSenderSpec extends UDPBasedStatsDMetricSenderSpec("simp
 
       val udp = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
       expectUDPPacket(s"$testMetricKey:10|ms|@0.5", udp)
+    }
+
+    "scale time metrics according to config " in new SimpleSenderFixture {
+      val testRecorder: TestEntityRecorder = buildRecorder("user/kamon")
+      val nanoMetricKey = buildMetricKey(testEntity, "nano-metric")
+      val nanoPattern = s"$nanoMetricKey:(\\d+)\\|ms".r
+
+      testRecorder.nanoMetric.record(1000000000L)
+
+      val udp = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+
+      val nanoPattern(nanoToMilli) = expectUDPPacket(udp)
+      nanoToMilli.toLong should be(1000L +- 10)
+    }
+
+    "scale memory metrics according to config " in new SimpleSenderFixture {
+      val testRecorder: TestEntityRecorder = buildRecorder("user/kamon")
+      val byteMetricKey = buildMetricKey(testEntity, "byte-metric")
+      val bytePattern = s"$byteMetricKey:(\\d+)\\|ms".r
+
+      testRecorder.byteMetric.record(1024000L)
+
+      val udp = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+
+      val bytePattern(byteToKilobyte) = expectUDPPacket(udp)
+      byteToKilobyte.toLong should be(1000L +- 10)
     }
   }
 }

--- a/kamon-statsd/src/test/scala/kamon/statsd/UDPBasedStatsDMetricSenderSpec.scala
+++ b/kamon-statsd/src/test/scala/kamon/statsd/UDPBasedStatsDMetricSenderSpec.scala
@@ -21,7 +21,7 @@ import akka.io.Udp
 import akka.testkit.TestProbe
 import kamon.Kamon
 import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
-import kamon.metric.instrument.{ InstrumentFactory, UnitOfMeasurement }
+import kamon.metric.instrument.{ Memory, Time, InstrumentFactory, UnitOfMeasurement }
 import kamon.metric._
 import kamon.testkit.BaseKamonSpec
 import kamon.util.MilliTimestamp
@@ -61,14 +61,20 @@ abstract class UDPBasedStatsDMetricSenderSpec(actorSystemName: String) extends B
     }
 
     def expectUDPPacket(expected: String, udp: TestProbe): Unit = {
+      expectUDPPacket(udp) should be(expected)
+    }
+
+    def expectUDPPacket(udp: TestProbe): String = {
       val Udp.Send(data, _, _) = udp.expectMsgType[Udp.Send]
-      data.utf8String should be(expected)
+      data.utf8String
     }
   }
 
   class TestEntityRecorder(instrumentFactory: InstrumentFactory) extends GenericEntityRecorder(instrumentFactory) {
     val metricOne = histogram("metric-one")
     val metricTwo = histogram("metric-two")
+    val nanoMetric = histogram("nano-metric", Time.Nanoseconds)
+    val byteMetric = histogram("byte-metric", Memory.Bytes)
   }
 
   object TestEntityRecorder extends EntityRecorderFactory[TestEntityRecorder] {


### PR DESCRIPTION
this is an attempt to fix part of #111 

@ivantopo @dpsoft please review
please note changes to Memory UnitOfMeasurement

if this looks okay, i can send another PR for datadog module