### PR TITLE
= statsd, datadog: fix time unit naming in reference.conf

### DIFF
--- a/kamon-datadog/src/main/resources/reference.conf
+++ b/kamon-datadog/src/main/resources/reference.conf
@@ -40,8 +40,8 @@ kamon {
 
     # All time values are collected in nanoseconds,
     # to scale before sending to datadog set "time-units" to "s" or "ms" or "µs".
-    # Value "ns" is equivalent to omitting the setting
-    # time-units = "ns"
+    # Value "n" is equivalent to omitting the setting
+    # time-units = "n"
 
     # All memory values are collected in bytes,
     # to scale before sending to datadog set "memory-units" to "gb" or "mb" or "kb".

--- a/kamon-statsd/src/main/resources/reference.conf
+++ b/kamon-statsd/src/main/resources/reference.conf
@@ -77,8 +77,8 @@ kamon {
 
     # All time values are collected in nanoseconds,
     # to scale before sending to StatsD set "time-units" to "s" or "ms" or "µs".
-    # Value "ns" is equivalent to omitting the setting
-    # time-units = "ns"
+    # Value "n" is equivalent to omitting the setting
+    # time-units = "n"
 
     # All memory values are collected in bytes,
     # to scale before sending to StatsD set "memory-units" to "gb" or "mb" or "kb".


### PR DESCRIPTION
while updating docs for kamon.io I noticed that I have used `ns` instead of `n` for nano seconds in #294 . This patch fixes the issue