### PR TITLE
+ spray: check for trace-token header in case-insensitive manner.

### DIFF
--- a/kamon-spray/src/main/scala/kamon/spray/instrumentation/ServerRequestInstrumentation.scala
+++ b/kamon-spray/src/main/scala/kamon/spray/instrumentation/ServerRequestInstrumentation.scala
@@ -38,7 +38,7 @@ class ServerRequestInstrumentation {
 
     val defaultTraceName = SprayExtension.generateTraceName(request)
     val token = if (SprayExtension.settings.includeTraceTokenHeader) {
-      request.headers.find(_.name == SprayExtension.settings.traceTokenHeaderName).map(_.value)
+      request.headers.find(_.name.equalsIgnoreCase(SprayExtension.settings.traceTokenHeaderName)).map(_.value)
     } else None
 
     val newContext = tracer.newContext(defaultTraceName, token)

--- a/kamon-spray/src/test/scala/kamon/spray/SprayServerTracingSpec.scala
+++ b/kamon-spray/src/test/scala/kamon/spray/SprayServerTracingSpec.scala
@@ -69,6 +69,20 @@ class SprayServerTracingSpec extends BaseKamonSpec("spray-server-tracing-spec") 
 
       response.headers should not contain traceTokenHeader("propagation-disabled")
     }
+
+    "check for the trace-token header in a case-insensitive manner" in {
+      enableAutomaticTraceTokenPropagation()
+
+      val (connection, server) = buildClientConnectionAndServer
+      val client = TestProbe()
+
+      client.send(connection, Get("/").withHeaders(RawHeader(SprayExtension.settings.traceTokenHeaderName.toLowerCase, "case-insensitive")))
+      server.expectMsgType[HttpRequest]
+      server.reply(HttpResponse(entity = "ok"))
+      val response = client.expectMsgType[HttpResponse]
+
+      response.headers should contain(traceTokenHeader("case-insensitive"))
+    }
   }
 
   def traceTokenHeader(token: String): RawHeader =


### PR DESCRIPTION
To comply with http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2