### PR TITLE
= system-metrics: apply metric filters

### DIFF
--- a/kamon-system-metrics/src/main/scala/kamon/system/jmx/GarbageCollectionMetrics.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/system/jmx/GarbageCollectionMetrics.scala
@@ -45,9 +45,11 @@ object GarbageCollectionMetrics {
     name.replaceAll("""[^\w]""", "-").toLowerCase
 
   def register(metricsExtension: MetricsModule): Unit = {
-    ManagementFactory.getGarbageCollectorMXBeans.asScala.filter(_.isValid) map { gc ⇒
+    ManagementFactory.getGarbageCollectorMXBeans.asScala.filter(_.isValid) foreach { gc ⇒
       val gcName = sanitizeCollectorName(gc.getName)
-      Kamon.metrics.entity(EntityRecorderFactory("system-metric", new GarbageCollectionMetrics(gc, _)), s"$gcName-garbage-collector")
+      val metricName = s"$gcName-garbage-collector"
+      if (metricsExtension.shouldTrack(metricName, "system-metric"))
+        Kamon.metrics.entity(EntityRecorderFactory("system-metric", new GarbageCollectionMetrics(gc, _)), metricName)
     }
   }
 }

--- a/kamon-system-metrics/src/main/scala/kamon/system/jmx/JmxSystemMetricRecorderCompanion.scala
+++ b/kamon-system-metrics/src/main/scala/kamon/system/jmx/JmxSystemMetricRecorderCompanion.scala
@@ -20,8 +20,10 @@ import kamon.metric.instrument.InstrumentFactory
 import kamon.metric.{ MetricsModule, EntityRecorderFactory, EntityRecorder }
 
 abstract class JmxSystemMetricRecorderCompanion(metricName: String) {
-  def register(metricsExtension: MetricsModule): EntityRecorder =
-    metricsExtension.entity(EntityRecorderFactory("system-metric", apply(_)), metricName)
+  def register(metricsExtension: MetricsModule): Unit = {
+    if (metricsExtension.shouldTrack(metricName, "system-metric"))
+      metricsExtension.entity(EntityRecorderFactory("system-metric", apply(_)), metricName)
+  }
 
   def apply(instrumentFactory: InstrumentFactory): EntityRecorder
 }


### PR DESCRIPTION
The metric filters regarding the `system-metric` entity category weren't being properly applied. This PR enables that by adding calls to the `shouldTrack` method before registering the recorders.