### PR TITLE
= core: apply metric filters to traces

### DIFF
--- a/kamon-core/src/main/scala/kamon/trace/MetricsOnlyContext.scala
+++ b/kamon-core/src/main/scala/kamon/trace/MetricsOnlyContext.scala
@@ -52,7 +52,8 @@ private[kamon] class MetricsOnlyContext(traceName: String, val token: String, iz
     val traceElapsedTime = NanoInterval.since(startTimestamp)
     _elapsedTime = traceElapsedTime
 
-    Kamon.metrics.entity(TraceMetrics, name).elapsedTime.record(traceElapsedTime.nanos)
+    if (Kamon.metrics.shouldTrack(name, TraceMetrics.category))
+      Kamon.metrics.entity(TraceMetrics, name).elapsedTime.record(traceElapsedTime.nanos)
     drainFinishedSegments()
   }
 
@@ -67,7 +68,8 @@ private[kamon] class MetricsOnlyContext(traceName: String, val token: String, iz
         "category" -> segment.category,
         "library" -> segment.library)
 
-      Kamon.metrics.entity(SegmentMetrics, segment.name, segmentTags).elapsedTime.record(segment.duration.nanos)
+      if (Kamon.metrics.shouldTrack(segment.name, SegmentMetrics.category))
+        Kamon.metrics.entity(SegmentMetrics, segment.name, segmentTags).elapsedTime.record(segment.duration.nanos)
       drainFinishedSegments()
     }
   }


### PR DESCRIPTION
The metric filters defined in `kamon.metric.filters.trace` weren't being properly applied to traces. This PR enables the application of filters by not recording metrics that shouldn't be tracked. This still leaves the traces' measurement enabled though. I'd be open to work on disabling them if the filters exclude them. However, since a trace can change its name during its lifetime, I'm not sure if it's possible to leave the measurement out altogether.