### PR TITLE
= autoweave: BsdVirtualMachine is attached from AgentLoader properly 

### DIFF
--- a/kamon-autoweave/src/main/scala/kamon/autoweave/loader/AgentLoader.scala
+++ b/kamon-autoweave/src/main/scala/kamon/autoweave/loader/AgentLoader.scala
@@ -154,7 +154,7 @@ object AgentLoader {
   }
 
   /**
-    * `BsdVirtualMachine` has the constructor as `protected` (no modifier defined), so `AgentLoader` can not instance it,
+    * `BsdVirtualMachine` has the constructor without modifier (by default is `package-private`), so `AgentLoader` can not instance it,
     * for that reason we need to set accessible that constructor via reflection.
     *
     * @param vmClass

--- a/kamon-autoweave/src/main/scala/kamon/autoweave/loader/AgentLoader.scala
+++ b/kamon-autoweave/src/main/scala/kamon/autoweave/loader/AgentLoader.scala
@@ -154,8 +154,9 @@ object AgentLoader {
   }
 
   /**
-    * `BsdVirtualMachine` has the constructor without modifier (by default is `package-private`), so `AgentLoader` can not instance it,
-    * for that reason we need to set accessible that constructor via reflection.
+    * `BsdVirtualMachine`, used when your platform is Mac - vmClass parameter, has the constructor
+    * without modifier (by default is `package-private`), so `AgentLoader` can not instance it, for that reason
+    * we need to set accessible that constructor via reflection.
     *
     * @param vmClass
     * @return

--- a/kamon-autoweave/src/main/scala/kamon/autoweave/loader/AgentLoader.scala
+++ b/kamon-autoweave/src/main/scala/kamon/autoweave/loader/AgentLoader.scala
@@ -154,9 +154,8 @@ object AgentLoader {
   }
 
   /**
-    * Why this dirty method? For some reason `BsdVirtualMachine` for MacOS doesn't return the public constructors when
-    * the `getConstructor` is invoked via reflection, however `getDeclaredConstructors` works properly (this constructor
-    * should marked as public then). Probably this thing could be a bug in the JDK, pending to raise an issue there.
+    * `BsdVirtualMachine` has the constructor as `protected` (no modifier defined), so `AgentLoader` can not instance it,
+    * for that reason we need to set accessible that constructor via reflection.
     *
     * @param vmClass
     * @return


### PR DESCRIPTION
This PR is just to fix an issue found when `AgentLoader` is trying to attach the `HotSpotVirtualMachine` when the platform is `Mac OS`. All details are in #307 

Fixes #307