### PR TITLE
in "normalize" strategy - add replace(":", "-") after replace(": ", "-") to cover the remotely deployed actors case

### DIFF
--- a/kamon-statsd/src/main/scala/kamon/statsd/SimpleMetricKeyGenerator.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/SimpleMetricKeyGenerator.scala
@@ -58,7 +58,7 @@ class SimpleMetricKeyGenerator(config: Config) extends MetricKeyGenerator {
 
   def createNormalizer(strategy: String): Normalizer = strategy match {
     case "percent-encode" ⇒ PercentEncoder.encode
-    case "normalize"      ⇒ (s: String) ⇒ s.replace(":", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
+    case "normalize"      ⇒ (s: String) ⇒ s.replace(": ", "-").replace(":", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
   }
 }
 

--- a/kamon-statsd/src/main/scala/kamon/statsd/SimpleMetricKeyGenerator.scala
+++ b/kamon-statsd/src/main/scala/kamon/statsd/SimpleMetricKeyGenerator.scala
@@ -58,7 +58,7 @@ class SimpleMetricKeyGenerator(config: Config) extends MetricKeyGenerator {
 
   def createNormalizer(strategy: String): Normalizer = strategy match {
     case "percent-encode" ⇒ PercentEncoder.encode
-    case "normalize"      ⇒ (s: String) ⇒ s.replace(": ", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
+    case "normalize"      ⇒ (s: String) ⇒ s.replace(":", "-").replace(" ", "_").replace("/", "_").replace(".", "_")
   }
 }
 


### PR DESCRIPTION
Hi,

I have a cluster with a master and 2 slaves, and I couldn't see the metrics of the remotely deployed actors in the Grafana UI. I tried following what @ivantopo said in https://groups.google.com/forum/#!searchin/kamon-user/remote/kamon-user/OhF4opREL_0/m7ky1e80mfsJ but this didn't help, so I tried to change the normalize strategy and then I could finally see the metrics.

I hope this gets merged :-)

Remote actors paths look like
akka.tcp://ActorSystemName@Slavehost1:2551/remote/akka.tcp/ActorSystemName@Masterhost:2551/user/master/myRouter/c10

Before the change the remote actor's metrics didn't get through because
the ':' after the Masterhost and everything that followed it was cut off.
A metric name in grafana would look like
ActorSystemName.slavehost1.akka-actor.ActorSystemName_remote_akka_tcp_ActorSystemNameMasterhostIP,
now it looks like
ActorSystemName.slavehost1.akka-actor.ActorSystemName_remote_akka_tcp_ActorSystemNameMasterhostIP-2551_user_master_myRouter_c4.errors

Regards,
Uri