### PR TITLE
+ kamon-riemann: module for riemann

### DIFF
--- a/kamon-riemann/src/main/resources/reference.conf
+++ b/kamon-riemann/src/main/resources/reference.conf
@@ -1,0 +1,61 @@
+kamon {
+
+  riemann {
+
+    hostname = "127.0.0.1"
+    port = 5555
+
+    metrics-mapper = kamon.riemann.DefaultMetricsMapper
+
+    default-metrics-mapper {
+      host = "undefined"
+      service = "undefined"
+    }
+
+    udp {
+
+      flush-interval = 10 seconds
+
+      subscriptions {
+        histogram       = [ "**" ]
+        min-max-counter = [ "**" ]
+        gauge           = [ "**" ]
+        counter         = [ "**" ]
+        trace           = [ "**" ]
+        trace-segment   = [ "**" ]
+        akka-actor      = [ "**" ]
+        akka-dispatcher = [ "**" ]
+        akka-router     = [ "**" ]
+        system-metric   = [ "**" ]
+        http-server     = [ "**" ]
+      }
+    }
+
+    tcp {
+
+      flush-interval = 10 seconds
+
+      subscriptions {
+        histogram       = [ "" ]
+        min-max-counter = [ "" ]
+        gauge           = [ "" ]
+        counter         = [ "" ]
+        trace           = [ "" ]
+        trace-segment   = [ "" ]
+        akka-actor      = [ "" ]
+        akka-dispatcher = [ "" ]
+        akka-router     = [ "" ]
+        system-metric   = [ "" ]
+        http-server     = [ "" ]
+      }
+    }
+  }
+
+  modules {
+    kamon-riemann {
+      requires-aspectj = no
+      auto-start = yes
+      extension-class = "kamon.riemann.Riemann"
+    }
+  }
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/DefaultMetricsMapper.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/DefaultMetricsMapper.scala
@@ -1,0 +1,64 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import com.aphyr.riemann.Proto.{ Attribute, Event }
+import com.typesafe.config.Config
+import kamon.metric.instrument.{ Counter, Histogram, InstrumentSnapshot }
+import kamon.metric.{ Entity, MetricKey }
+import scala.collection.JavaConversions._
+
+class DefaultMetricsMapper(config: Config) extends MetricsMapper {
+
+  val configSettings = config.getConfig("kamon.riemann.default-metrics-mapper")
+  val host = configSettings.getString("host")
+  val service = configSettings.getString("service")
+
+  override def toEvents(entity: Entity, metricKey: MetricKey, snapshot: InstrumentSnapshot): Seq[Event] = {
+    val metrics = snapshot match {
+      case hs: Histogram.Snapshot ⇒
+        hs.recordsIterator.map(_.level)
+
+      case cs: Counter.Snapshot ⇒ Seq(cs.count)
+    }
+
+    val tags = entity.tags
+    val customTags = tags -- defaultTags
+    val attributes = customTags.foldLeft(List.empty[Attribute]) {
+      case (acc, (key, value)) ⇒
+        Attribute.newBuilder().setKey(key).setValue(value).build() :: acc
+    }
+
+    metrics.map { v ⇒
+      val b = Event.newBuilder
+
+      // mandatory
+      b.setHost(tags getOrElse (tagKeyHost, host))
+      b.setService(tags getOrElse (tagKeyService, service))
+      b.setMetricSint64(v)
+
+      // optional
+      tags.get(tagKeyState) foreach b.setState
+      tags.get(tagKeyDescription) foreach b.setDescription
+      tags.get(tagKeyTtl) map (_.toFloat) foreach b.setTtl
+      tags.get(tagKeyTime) map (_.toLong / 1000L) foreach b.setTime // Milisec -> Epoch sec
+
+      b.addAllAttributes(attributes)
+      b.build
+    }.toList
+  }
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/MetricsMapper.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/MetricsMapper.scala
@@ -1,0 +1,26 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import com.aphyr.riemann.Proto.Event
+import kamon.metric.instrument.InstrumentSnapshot
+import kamon.metric.{ Entity, MetricKey }
+
+trait MetricsMapper {
+
+  def toEvents(entity: Entity, key: MetricKey, snapshot: InstrumentSnapshot): Seq[Event]
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/MetricsSender.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/MetricsSender.scala
@@ -1,0 +1,41 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import java.net.InetSocketAddress
+
+import akka.actor.{ ActorRef, Actor }
+import com.aphyr.riemann.Proto.Event
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+
+abstract class MetricsSender(riemannHost: String, riemannPort: Int, metricsMapper: MetricsMapper) extends Actor {
+
+  lazy val socketAddress = new InetSocketAddress(riemannHost, riemannPort)
+
+  def send(tick: TickMetricSnapshot, createSender: () ⇒ ActorRef): Unit = {
+    val events = for (
+      (entity, snapshot) ← tick.metrics;
+      (metricKey, metricSnapshot) ← snapshot.metrics
+    ) yield {
+      metricsMapper.toEvents(entity, metricKey, metricSnapshot)
+    }
+
+    writeToRemote(events.flatten, createSender)
+  }
+
+  def writeToRemote(events: Iterable[Event], createSender: () ⇒ ActorRef): Unit
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/MetricsSenderFactory.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/MetricsSenderFactory.scala
@@ -1,0 +1,26 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import akka.actor.Props
+
+trait MetricsSenderFactory {
+
+  def name: String
+  def props(riemannHost: String, riemannPort: Int, metricsMapper: MetricsMapper): Props
+}
+

--- a/kamon-riemann/src/main/scala/kamon/riemann/Riemann.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/Riemann.scala
@@ -1,0 +1,95 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import akka.actor._
+import akka.event.Logging
+import com.typesafe.config.Config
+import kamon.Kamon
+import kamon.Kamon.Extension
+import kamon.metric.TickMetricSnapshotBuffer
+import kamon.util.ConfigTools.Syntax
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration._
+
+object Riemann extends ExtensionId[RiemannExtension] with ExtensionIdProvider {
+
+  override def lookup(): ExtensionId[_ <: Extension] = Riemann
+  override def createExtension(system: ExtendedActorSystem): RiemannExtension = new RiemannExtension(system)
+}
+
+class RiemannExtension(system: ExtendedActorSystem) extends Kamon.Extension {
+
+  implicit val as = system
+
+  private val log = Logging(system, classOf[RiemannExtension])
+  log.info("Starting the Kamon(Riemann) extension")
+
+  private val metricsExtension = Kamon.metrics
+  private val tickInterval = metricsExtension.settings.tickInterval
+
+  private val config = system.settings.config
+  private val riemannConfig = config.getConfig("kamon.riemann")
+  private val metricsMapper = riemannConfig.getString("metrics-mapper")
+
+  udpSubscriptions()
+
+  tcpSubscriptions()
+
+  private def udpSubscriptions(): Unit = {
+    val udpConfig = riemannConfig.getConfig("udp")
+    val udpFlushInterval = udpConfig.getFiniteDuration("flush-interval")
+    val udpSubscriptions = udpConfig.getConfig("subscriptions")
+    val udpMetricsListener = buildMetricsListener(tickInterval, udpFlushInterval, UdpMetricsSender, metricsMapper, config)
+    udpSubscriptions.firstLevelKeys.foreach { subscriptionCategory ⇒
+      udpSubscriptions.getStringList(subscriptionCategory).asScala.foreach { pattern ⇒
+        metricsExtension.subscribe(subscriptionCategory, pattern, udpMetricsListener, permanently = true)
+      }
+    }
+  }
+
+  private def tcpSubscriptions(): Unit = {
+    val tcpConfig = riemannConfig.getConfig("tcp")
+    val tcpFlushInterval = tcpConfig.getFiniteDuration("flush-interval")
+    val tcpSubscriptions = tcpConfig.getConfig("subscriptions")
+    val tcpMetricsListener = buildMetricsListener(tickInterval, tcpFlushInterval, TcpMetricsSender, metricsMapper, config)
+    tcpSubscriptions.firstLevelKeys.foreach { subscriptionCategory ⇒
+      tcpSubscriptions.getStringList(subscriptionCategory).asScala.foreach { pattern ⇒
+        metricsExtension.subscribe(subscriptionCategory, pattern, tcpMetricsListener, permanently = true)
+      }
+    }
+  }
+
+  private def buildMetricsListener(tickInterval: FiniteDuration, flushInterval: FiniteDuration, senderFactory: MetricsSenderFactory, mapperClass: String, config: Config): ActorRef = {
+    assert(flushInterval >= tickInterval, "Riemann flush-interval needs to be equal or greater to the tick-interval")
+
+    val metricsMapper = system.dynamicAccess.createInstanceFor[MetricsMapper](mapperClass, (classOf[Config], config) :: Nil).get
+    val metricsSender = system.actorOf(senderFactory.props(
+      riemannConfig.getString("hostname"),
+      riemannConfig.getInt("port"),
+      metricsMapper
+    ), senderFactory.name)
+
+    if (flushInterval == tickInterval) {
+      // No need to buffer the metrics, let's go straight to the metrics sender.
+      metricsSender
+    } else {
+      system.actorOf(TickMetricSnapshotBuffer.props(flushInterval, metricsSender), s"buffered-${senderFactory.name}")
+    }
+  }
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/TcpClient.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/TcpClient.scala
@@ -1,0 +1,115 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import java.net.InetSocketAddress
+
+import akka.actor._
+import akka.io.Tcp
+import akka.io.Tcp._
+import akka.util.ByteString
+import com.aphyr.riemann.Proto.Msg
+import com.aphyr.riemann.Proto.Event
+import kamon.riemann.TcpClient.Send
+import scala.concurrent.duration._
+
+class TcpClient(tcpManager: ActorRef, address: InetSocketAddress) extends Actor with ActorLogging with Stash {
+
+  private case object Ack extends Tcp.Event
+
+  private val connectionTimeout = Some(3 seconds)
+
+  tcpManager ! Connect(address, timeout = connectionTimeout)
+
+  private def writeInt(v: Int): Array[Byte] = {
+    Array(((v >>> 24) & 0xFF).toByte, ((v >>> 16) & 0xFF).toByte, ((v >>> 8) & 0xFF).toByte, ((v >>> 0) & 0xFF).toByte)
+  }
+
+  private def writePartially(remaining: Iterable[Msg], connection: ActorRef): Unit = {
+    if (remaining.nonEmpty) {
+      val msg = remaining.head.toByteArray
+      val payload = ByteString(writeInt(msg.length)).concat(ByteString(msg))
+      connection ! Write(payload, Ack)
+      context become ({
+        case Ack ⇒ {
+          context.unbecome()
+          writePartially(remaining.tail, connection)
+        }
+        case Received(resp) ⇒ // ignore
+        case CommandFailed(Write(_, Ack)) ⇒ {
+          // TODO: retry mechanism
+          log.error("Couldn't write an event to Riemann over TCP")
+          context.unbecome()
+          writePartially(remaining.tail, connection)
+        }
+      }, discardOld = false)
+    } else {
+      connection ! ConfirmedClose
+    }
+  }
+
+  private def shuttingDown: Receive = {
+    case Send(e) ⇒ // ignore
+  }
+
+  private def connecting(remainingConnectRetries: Int, backoff: Int): Receive = {
+    case CommandFailed(_: Connect) ⇒ {
+      if (remainingConnectRetries > 0) {
+        context.system.scheduler.scheduleOnce((Math.pow(2, backoff) * 200).millisecond) {
+          tcpManager ! Connect(address, timeout = connectionTimeout)
+        }(context.dispatcher)
+        context.become(connecting(remainingConnectRetries - 1, backoff + 1), discardOld = true)
+        log.warning(s"Problem with TCP connection to Riemann - reconnecting")
+      } else {
+        // unstash all messages before shutting down actor to avoid '...was not delivered. [1] dead letters encountered...'
+        context.become(shuttingDown, discardOld = true)
+        unstashAll()
+        log.error("Couldn't establish TCP connection to Riemann")
+        self ! PoisonPill
+      }
+    }
+
+    case Send(events) ⇒ stash()
+
+    case Connected(remote, local) ⇒ {
+      val connection = sender()
+      connection ! Register(self)
+      unstashAll()
+      context.become(connected(connection), discardOld = true)
+    }
+  }
+
+  private def connected(connection: ActorRef): Receive = {
+    case Received(resp) ⇒ // ignore
+    case Send(events) ⇒ {
+      val buffer = events.map(Msg.newBuilder().addEvents(_).build())
+      writePartially(buffer, connection)
+    }
+    case _: ConnectionClosed ⇒ context.stop(self)
+  }
+
+  override def receive: Receive = connecting(3, 1)
+}
+
+object TcpClient {
+
+  case class Send(events: Iterable[Event])
+
+  def props(tcpManager: ActorRef, addres: InetSocketAddress): Props = {
+    Props(new TcpClient(tcpManager, addres))
+  }
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/TcpMetricsSender.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/TcpMetricsSender.scala
@@ -1,0 +1,56 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.io.{ Tcp, IO }
+import com.aphyr.riemann.Proto.Event
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.riemann.TcpClient.Send
+
+class TcpMetricsSender(riemannHost: String, riemannPort: Int, metricsMapper: MetricsMapper)
+    extends MetricsSender(riemannHost, riemannPort, metricsMapper) with TcpExtensionProvider {
+
+  import context.system
+
+  def receive = {
+    case snapshot: TickMetricSnapshot ⇒ {
+      send(snapshot, () ⇒ {
+        system.actorOf(TcpClient.props(tcpExtension, socketAddress))
+      })
+    }
+  }
+
+  override def writeToRemote(events: Iterable[Event], createTcpSender: () ⇒ ActorRef): Unit = {
+    if (events.nonEmpty) {
+      val sender = createTcpSender()
+      sender ! Send(events)
+    }
+  }
+}
+
+object TcpMetricsSender extends MetricsSenderFactory {
+
+  override def name = "riemann-tcp-metrics-sender"
+  override def props(riemannHost: String, riemannPort: Int, metricsMapper: MetricsMapper): Props =
+    Props(new TcpMetricsSender(riemannHost, riemannPort, metricsMapper))
+}
+
+trait TcpExtensionProvider {
+
+  def tcpExtension(implicit system: ActorSystem): ActorRef = IO(Tcp)
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/UdpMetricsSender.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/UdpMetricsSender.scala
@@ -1,0 +1,63 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.io.{ IO, Udp }
+import akka.util.ByteString
+import com.aphyr.riemann.Proto
+import com.aphyr.riemann.Proto.Event
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+
+class UdpMetricsSender(riemannHost: String, riemannPort: Int, metricsMapper: MetricsMapper)
+    extends MetricsSender(riemannHost, riemannPort, metricsMapper) with UdpExtensionProvider {
+
+  import context.system
+
+  udpExtension ! Udp.SimpleSender
+
+  def receive = {
+    case Udp.SimpleSenderReady ⇒
+      val s = sender()
+      context.become(ready(s))
+  }
+
+  def ready(udpSender: ActorRef): Receive = {
+    case snapshot: TickMetricSnapshot ⇒ send(snapshot, () ⇒ udpSender)
+  }
+
+  override def writeToRemote(events: Iterable[Event], createUdpSender: () ⇒ ActorRef): Unit = {
+    val sender = createUdpSender()
+    events.foreach { e ⇒
+      val msg = Proto.Msg.newBuilder.addEvents(e).build
+      val data = msg.toByteArray
+      sender ! Udp.Send(ByteString(data), socketAddress)
+    }
+  }
+}
+
+object UdpMetricsSender extends MetricsSenderFactory {
+
+  override def name = "riemann-udp-metrics-sender"
+  override def props(riemannHost: String, riemannPort: Int, metricsMapper: MetricsMapper): Props =
+    Props(new UdpMetricsSender(riemannHost, riemannPort, metricsMapper))
+}
+
+trait UdpExtensionProvider {
+
+  def udpExtension(implicit system: ActorSystem): ActorRef = IO(Udp)
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/package.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/package.scala
@@ -1,0 +1,29 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon
+
+package object riemann {
+
+  val tagKeyHost = "host"
+  val tagKeyService = "service"
+  val tagKeyState = "state"
+  val tagKeyDescription = "description"
+  val tagKeyTtl = "ttl"
+  val tagKeyTime = "time"
+
+  val defaultTags = Set(tagKeyHost, tagKeyService, tagKeyState, tagKeyDescription, tagKeyTime, tagKeyTtl)
+}

--- a/kamon-riemann/src/test/scala/kamon/riemann/MetricSenderSpec.scala
+++ b/kamon-riemann/src/test/scala/kamon/riemann/MetricSenderSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import akka.actor.Props
+import akka.testkit.TestProbe
+import com.aphyr.riemann.Proto
+import com.aphyr.riemann.Proto.Event
+import com.typesafe.config.ConfigFactory
+import kamon.Kamon
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.{ Counter, Histogram, InstrumentSnapshot, InstrumentFactory }
+import kamon.metric._
+import kamon.testkit.BaseKamonSpec
+import kamon.util.MilliTimestamp
+
+abstract class MetricSenderSpec(actorSystemName: String) extends BaseKamonSpec(actorSystemName) {
+
+  override lazy val config =
+    ConfigFactory.parseString(
+      """
+        |kamon {
+        |  riemann {
+        |    hostname = "127.0.0.1"
+        |    port = 0
+        |  }
+        |}
+      """.stripMargin
+    )
+
+  val riemannConfig = config.getConfig("kamon.riemann")
+  val riemannHost = riemannConfig.getString("hostname")
+  val riemannPort = riemannConfig.getInt("port")
+
+  def event(metric: Long) =
+    Event.newBuilder
+      .setHost("test_host")
+      .setService("test_service")
+      .setMetricSint64(metric)
+      .setMetricF(metric)
+      .build
+
+  val metricsMapper = new MetricsMapper() {
+    override def toEvents(entity: Entity, key: MetricKey, snapshot: InstrumentSnapshot): Seq[Event] = {
+      val metrics = snapshot match {
+        case hs: Histogram.Snapshot ⇒
+          hs.recordsIterator.map(_.level)
+
+        case cs: Counter.Snapshot ⇒ Seq(cs.count)
+      }
+      metrics.map(event).toList
+    }
+  }
+
+  trait ListenerFixture {
+
+    val testEntity = Entity("user/kamon", "test")
+
+    def buildRecorder(name: String): TestEntityRecorder =
+      Kamon.metrics.entity(TestEntityRecorder, name)
+
+    def newSender(udpProbe: TestProbe): Props
+
+    def setup(metrics: Map[Entity, EntitySnapshot], postStart: (TestProbe) ⇒ Unit): TestProbe = {
+      val io = TestProbe()
+      val metricsSender = system.actorOf(newSender(io))
+
+      postStart(io)
+
+      val fakeSnapshot = TickMetricSnapshot(MilliTimestamp.now, MilliTimestamp.now, metrics)
+      metricsSender ! fakeSnapshot
+      io
+    }
+
+    def expectMetricsValue(tcp: TestProbe, expected: Proto.Event): Unit
+  }
+
+  class TestEntityRecorder(instrumentFactory: InstrumentFactory) extends GenericEntityRecorder(instrumentFactory) {
+
+    val metricOne = histogram("metric-one")
+    val metricTwo = histogram("metric-two")
+  }
+
+  object TestEntityRecorder extends EntityRecorderFactory[TestEntityRecorder] {
+
+    def category: String = "test"
+    def createRecorder(instrumentFactory: InstrumentFactory): TestEntityRecorder = new TestEntityRecorder(instrumentFactory)
+  }
+}

--- a/kamon-riemann/src/test/scala/kamon/riemann/TcpMetricsSenderSpec.scala
+++ b/kamon-riemann/src/test/scala/kamon/riemann/TcpMetricsSenderSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import java.net.InetSocketAddress
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.io.Tcp.{ CloseCommand, Register, Connect, Write }
+import akka.io.Tcp
+import akka.testkit.TestProbe
+import com.aphyr.riemann.Proto
+import com.aphyr.riemann.Proto.Msg
+
+class TcpMetricsSenderSpec extends MetricSenderSpec("tcp-metric-sender-spec") {
+
+  trait TcpSenderFixture extends ListenerFixture {
+
+    override def newSender(tcpProbe: TestProbe) =
+      Props(new TcpMetricsSender(riemannHost, riemannPort, metricsMapper) {
+        override def tcpExtension(implicit system: ActorSystem): ActorRef = tcpProbe.ref
+      })
+
+    override def expectMetricsValue(tcpProbe: TestProbe, expected: Proto.Event): Unit = {
+      val Tcp.Write(data, ack) = tcpProbe.expectMsgType[Write]
+      val msg = Msg.newBuilder().mergeFrom(data.drop(4).toArray).buildPartial()
+
+      msg.getEventsCount should be(1)
+      msg.getEvents(0) should be(expected)
+
+      tcpProbe.reply(ack)
+    }
+  }
+
+  "the TcpMetricsSender" should {
+    "flush the metrics data for each unique value it receives" in new TcpSenderFixture {
+
+      val testRecorder = buildRecorder("user/kamon")
+      testRecorder.metricOne.record(10L)
+      testRecorder.metricOne.record(30L)
+      testRecorder.metricTwo.record(20L)
+
+      val tcp = setup(Map(testEntity → testRecorder.collect(collectionContext)), { _ ⇒ })
+
+      tcp.expectMsgType[Connect]
+      tcp.reply(Tcp.Connected(new InetSocketAddress(0), new InetSocketAddress(0)))
+      tcp.expectMsgType[Register]
+      expectMetricsValue(tcp, event(10L))
+      expectMetricsValue(tcp, event(30L))
+      expectMetricsValue(tcp, event(20L))
+      tcp.expectMsgType[CloseCommand]
+      tcp.expectNoMsg()
+    }
+  }
+}

--- a/kamon-riemann/src/test/scala/kamon/riemann/UdpMetricsSenderSpec.scala
+++ b/kamon-riemann/src/test/scala/kamon/riemann/UdpMetricsSenderSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.riemann
+
+import akka.actor.{ ActorRef, ActorSystem, Props }
+import akka.io.Udp
+import akka.testkit.TestProbe
+import com.aphyr.riemann.Proto
+import com.aphyr.riemann.Proto.Msg
+
+class UdpMetricsSenderSpec extends MetricSenderSpec("udp-metric-sender-spec") {
+
+  trait UdpSenderFixture extends ListenerFixture {
+
+    override def newSender(udpProbe: TestProbe) =
+      Props(new UdpMetricsSender(riemannHost, riemannPort, metricsMapper) {
+        override def udpExtension(implicit system: ActorSystem): ActorRef = udpProbe.ref
+      })
+
+    override def expectMetricsValue(udpProbe: TestProbe, expected: Proto.Event): Unit = {
+      val Udp.Send(data, _, _) = udpProbe.expectMsgType[Udp.Send]
+      val msg = Msg.newBuilder().mergeFrom(data.toArray).buildPartial()
+
+      msg.getEventsCount should be(1)
+      msg.getEvents(0) should be(expected)
+    }
+  }
+
+  "the UdpMetricsSender" should {
+    "flush the metrics data for each unique value it receives" in new UdpSenderFixture {
+
+      val testRecorder = buildRecorder("user/kamon")
+      testRecorder.metricOne.record(10L)
+      testRecorder.metricOne.record(30L)
+      testRecorder.metricTwo.record(20L)
+
+      val udp = setup(Map(testEntity → testRecorder.collect(collectionContext)), { probe ⇒
+        probe.expectMsgType[Udp.SimpleSender]
+        probe.reply(Udp.SimpleSenderReady)
+      })
+
+      expectMetricsValue(udp, event(10L))
+      expectMetricsValue(udp, event(30L))
+      expectMetricsValue(udp, event(20L))
+      udp.expectNoMsg()
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,8 @@ object Dependencies {
 
   val resolutionRepos = Seq(
     "spray repo" at "http://repo.spray.io/",
-    "typesafe repo" at "http://repo.typesafe.com/typesafe/releases/"
+    "typesafe repo" at "http://repo.typesafe.com/typesafe/releases/",
+    "clojars repo" at "http://clojars.org/repo/"
   )
 
   val sprayVersion      = "1.3.3"
@@ -56,6 +57,7 @@ object Dependencies {
   val el                = "org.glassfish"             %   "javax.el"              % "3.0.0"
   val fluentdLogger     = "org.fluentd"               %%  "fluent-logger-scala"   % "0.5.1"
   val easyMock          = "org.easymock"              %   "easymock"              % "3.2"
+  val riemannClient     = "com.aphyr"                 %   "riemann-java-client"   % "0.4.1"
 
   //play 2.3.x
   val play23            = "com.typesafe.play"         %%  "play"                  % play23Version

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -23,7 +23,7 @@ object Projects extends Build {
 
   lazy val kamon = Project("kamon", file("."))
     .aggregate(kamonCore, kamonScala, kamonAkka, kamonSpray, kamonNewrelic, kamonPlayground, kamonTestkit,
-      kamonStatsD, kamonDatadog, kamonSPM, kamonSystemMetrics, kamonLogReporter, kamonAkkaRemote, kamonJdbc,
+      kamonStatsD, kamonRiemann, kamonDatadog, kamonSPM, kamonSystemMetrics, kamonLogReporter, kamonAkkaRemote, kamonJdbc,
       kamonAnnotation, kamonPlay23, kamonPlay24, kamonJMXReporter, kamonFluentd, kamonAutoweave)
     .settings(basicSettings: _*)
     .settings(formatSettings: _*)
@@ -156,6 +156,15 @@ object Projects extends Build {
       libraryDependencies ++=
         compile(akkaActor) ++
         test(scalatest, akkaTestKit, slf4jApi, slf4jnop))
+
+  lazy val kamonRiemann = Project("kamon-riemann", file("kamon-riemann"))
+    .dependsOn(kamonCore % "compile->compile;test->test")
+    .settings(basicSettings: _*)
+    .settings(formatSettings: _*)
+    .settings(
+      libraryDependencies ++=
+        compile(akkaActor) ++ compile(riemannClient) ++
+          test(scalatest, akkaTestKit, slf4jApi, slf4jnop))
 
   lazy val kamonDatadog = Project("kamon-datadog", file("kamon-datadog"))
     .dependsOn(kamonCore % "compile->compile;test->test")


### PR DESCRIPTION
This is a module for Riemann, supports TCP and UDP. The module is based on the kamon-stastd.
Documentation is in a PR in kamon.io project.