### PR TITLE
+ InfluxDB Support

### DIFF
--- a/kamon-influxdb/src/main/resources/reference.conf
+++ b/kamon-influxdb/src/main/resources/reference.conf
@@ -1,0 +1,47 @@
+kamon {
+  influxdb {
+    # Hostname and port in which your InfluxDB is running
+    hostname = "127.0.0.1"
+    port = 8086
+
+    # The maximum packet size for one POST request, set to 0 to disable batching
+    max-packet-size = 16384
+
+    # The database where to write in InfluxDB. Works only for HTTP protocol, if using UDP, change the database in your
+    # InfluxDB configuration
+    database = "mydb"
+
+    # The protocol, either http or udp
+    protocol = "http"
+
+    # The measurements will be named ${application-name}-timers and -counters
+    application-name = "kamon"
+
+    # For histograms, which percentiles to count
+    percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]
+
+    # Subscription patterns used to select which metrics will be pushed to InfluxDB. Note that first, metrics
+    # collection for your desired entities must be activated under the kamon.metrics.filters settings.
+    subscriptions {
+      histogram       = [ "**" ]
+      min-max-counter = [ "**" ]
+      gauge           = [ "**" ]
+      counter         = [ "**" ]
+      trace           = [ "**" ]
+      trace-segment   = [ "**" ]
+      akka-actor      = [ "**" ]
+      akka-dispatcher = [ "**" ]
+      akka-router     = [ "**" ]
+      system-metric   = [ "**" ]
+      http-server     = [ "**" ]
+    }
+  }
+
+  modules {
+    kamon-influxdb {
+      requires-aspectj = no
+      auto-start = yes
+      extension-class = "kamon.influxdb.InfluxDB"
+    }
+  }
+}

--- a/kamon-influxdb/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
@@ -1,0 +1,49 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import com.typesafe.config.Config
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.{ Counter, Histogram }
+
+trait TimestampGenerator {
+  def timestamp = System.currentTimeMillis()
+}
+
+case class BatchInfluxDBMetricsPacker(config: Config) extends InfluxDBMetricsPacker(config) with TagsGenerator with TimestampGenerator {
+  protected val maxPacketSizeInBytes = config.getBytes("max-packet-size")
+
+  protected def generateMetricsData(tick: TickMetricSnapshot, flushToDestination: String ⇒ Any): Unit = {
+    val packetBuilder = new MetricDataPacketBuilder(maxPacketSizeInBytes, flushToDestination)
+
+    for {
+      (entity, snapshot) ← tick.metrics
+      (metricKey, metricSnapshot) ← snapshot.metrics
+    } {
+      val tags = generateTags(entity, metricKey) ++ entity.tags
+
+      metricSnapshot match {
+        case hs: Histogram.Snapshot ⇒
+          packetBuilder.appendMeasurement(s"$application-timers", tags, histogramValues(hs), timestamp * 1000000)
+        case cs: Counter.Snapshot ⇒
+          packetBuilder.appendMeasurement(s"$application-counters", tags, Map("value" -> BigDecimal(cs.count)), timestamp * 1000000)
+      }
+    }
+
+    packetBuilder.flush()
+  }
+}

--- a/kamon-influxdb/src/main/scala/kamon/influxdb/InfluxDB.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/InfluxDB.scala
@@ -1,0 +1,50 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import akka.actor._
+import akka.event.Logging
+import kamon.Kamon
+import kamon.util.ConfigTools.Syntax
+
+import scala.collection.JavaConverters._
+
+object InfluxDB extends ExtensionId[InfluxDBExtension] with ExtensionIdProvider {
+  override def createExtension(system: ExtendedActorSystem): InfluxDBExtension = new InfluxDBExtension(system)
+  override def lookup(): ExtensionId[_ <: Extension] = InfluxDB
+}
+
+class InfluxDBExtension(system: ExtendedActorSystem) extends Kamon.Extension {
+  implicit val as = system
+
+  val log = Logging(system, classOf[InfluxDBExtension])
+  log.info("Starting the Kamon(InfluxDB) extension")
+
+  private val config = system.settings.config
+  private val influxDBConfig = config.getConfig("kamon.influxdb")
+  val metricsExtension = Kamon.metrics
+
+  protected val metricsListener = system.actorOf(InfluxDBMetricsPacker.props(influxDBConfig), "influxdb-metrics-sender")
+
+  protected val subscriptions = influxDBConfig.getConfig("subscriptions")
+
+  subscriptions.firstLevelKeys.foreach { subscriptionCategory ⇒
+    subscriptions.getStringList(subscriptionCategory).asScala.foreach { pattern ⇒
+      metricsExtension.subscribe(subscriptionCategory, pattern, metricsListener, permanently = true)
+    }
+  }
+}

--- a/kamon-influxdb/src/main/scala/kamon/influxdb/InfluxDBClient.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/InfluxDBClient.scala
@@ -1,0 +1,95 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import java.net.InetSocketAddress
+
+import akka.actor.{ Actor, ActorContext, ActorRef, ActorSystem }
+import akka.event.Logging
+import akka.io.{ IO, Udp }
+import akka.util.ByteString
+import com.typesafe.config.{ Config, ConfigFactory }
+import spray.can.Http
+import spray.client.pipelining._
+import spray.http._
+import spray.httpx.encoding.Deflate
+
+import scala.concurrent.duration._
+import scala.util.{ Failure, Success }
+
+trait InfluxDBClient extends Actor {
+  implicit protected val as = context.system
+}
+
+class InfluxDBHttpClient(config: Config, clientRef: ActorRef) extends InfluxDBClient {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  implicit protected val to = akka.util.Timeout(5 seconds)
+  protected val logger = Logging(context.system, classOf[InfluxDBHttpClient])
+  protected lazy val httpClient = encode(Deflate) ~> sendReceive(clientRef) ~> decode(Deflate)
+
+  protected val databaseUri = {
+    val baseConfig = Map("db" -> config.getString("database"))
+
+    val withAuth = if (config.hasPath("authentication")) {
+      val authConfig = config.getConfig("authentication")
+
+      baseConfig ++ Map(
+        "u" -> authConfig.getString("user"),
+        "p" -> authConfig.getString("password"))
+    } else {
+      baseConfig
+    }
+
+    val query = if (config.hasPath("retention-policy")) {
+      withAuth ++ Map("rp" -> config.getString("retention-policy"))
+    } else {
+      withAuth
+    }
+
+    Uri("/write").
+      withHost(config.getString("hostname")).
+      withPort(config.getInt("port")).
+      withScheme(config.getString("protocol")).
+      withQuery(query)
+  }
+
+  def receive = {
+    case payload: String ⇒
+      httpClient(Post(databaseUri, payload.getBytes)).onComplete {
+        case Success(response) ⇒ logger.info(response.status.toString())
+        case Failure(error)    ⇒ logger.error(error, s"Unable to send metrics to InfluxDB: ${error.getMessage}")
+      }
+  }
+}
+
+class InfluxDBUdpClient(config: Config, clientRef: ActorRef) extends InfluxDBClient {
+  lazy val socketAddress = new InetSocketAddress(config.getString("hostname"), config.getInt("port"))
+
+  clientRef ! Udp.SimpleSender
+
+  def receive = {
+    case Udp.SimpleSenderReady ⇒
+      context.become(ready(sender))
+  }
+
+  def ready(udpSender: ActorRef): Receive = {
+    case payload: String ⇒
+      udpSender ! Udp.Send(ByteString(payload), socketAddress)
+  }
+}
+

--- a/kamon-influxdb/src/main/scala/kamon/influxdb/InfluxDBMetricsPacker.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/InfluxDBMetricsPacker.scala
@@ -1,0 +1,50 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import akka.actor.{ Actor, ActorRef, Props }
+import akka.io.{ IO, Udp }
+import com.typesafe.config.Config
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import spray.can.Http
+
+object InfluxDBMetricsPacker {
+  def props(config: Config): Props = Props(BatchInfluxDBMetricsPacker(config))
+}
+
+abstract class InfluxDBMetricsPacker(config: Config) extends Actor {
+  implicit protected val actorSystem = context.system
+
+  protected def udpRef: ActorRef = IO(Udp)
+  protected def httpRef: ActorRef = IO(Http)
+
+  protected val client: ActorRef = config.getString("protocol") match {
+    case "udp" ⇒
+      context.actorOf(Props(new InfluxDBUdpClient(config, udpRef)))
+    case "http" ⇒
+      context.actorOf(Props(new InfluxDBHttpClient(config, httpRef)))
+    case unknownProtocol ⇒
+      throw new UnsupportedOperationException(s"Protocol $unknownProtocol is not supported by Kamon InfluxDB Client")
+  }
+
+  def receive = {
+    case tick: TickMetricSnapshot ⇒ generateMetricsData(tick, client !)
+  }
+
+  protected def generateMetricsData(tick: TickMetricSnapshot, flushTo: String ⇒ Any): Unit
+}
+

--- a/kamon-influxdb/src/main/scala/kamon/influxdb/MetricDataPacketBuilder.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/MetricDataPacketBuilder.scala
@@ -1,0 +1,42 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+class MetricDataPacketBuilder(maxPacketSizeInBytes: Long, flushToDestination: String ⇒ Any) {
+  protected val metricSeparator = "\n"
+  protected var buffer = new StringBuilder()
+
+  protected def createInfluxString(data: Map[String, Any]): String =
+    data.map { case (k, v) ⇒ s"$k=$v" }.mkString(",")
+
+  def appendMeasurement(key: String, tags: Map[String, String], measurementData: Map[String, BigDecimal], timeStamp: Long): Unit = {
+    val tagsString = createInfluxString(tags)
+    val valuesString = createInfluxString(measurementData)
+    val data = s"$key,$tagsString $valuesString $timeStamp$metricSeparator"
+
+    if (!fitsOnBuffer(data)) flush()
+
+    buffer.append(data)
+  }
+
+  protected def fitsOnBuffer(data: String): Boolean = (buffer.length + data.length) <= maxPacketSizeInBytes
+
+  def flush(): Unit = {
+    flushToDestination(buffer.toString())
+    buffer.clear()
+  }
+}

--- a/kamon-influxdb/src/main/scala/kamon/influxdb/TagsGenerator.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/TagsGenerator.scala
@@ -1,0 +1,83 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import java.lang.management.ManagementFactory
+
+import com.typesafe.config.Config
+import kamon.metric.instrument.Histogram
+import kamon.metric.{ Entity, MetricKey }
+import collection.JavaConversions._
+
+trait TagsGenerator {
+  protected val config: Config
+
+  protected val hostName = ManagementFactory.getRuntimeMXBean.getName.split('@')(1)
+  protected val application = config.getString("application-name")
+
+  protected val percentiles = config.getDoubleList("percentiles").toList
+
+  protected def generateTags(entity: Entity, metricKey: MetricKey): Map[String, String] =
+    entity.category match {
+      case "trace-segment" ⇒
+        Map(
+          "category" -> normalize(entity.tags("trace")),
+          "entity" -> normalize(entity.name),
+          "hostname" -> normalize(hostName),
+          "metric" -> normalize(metricKey.name))
+      case _ ⇒
+        Map(
+          "category" -> normalize(entity.category),
+          "entity" -> normalize(entity.name),
+          "hostname" -> normalize(hostName),
+          "metric" -> normalize(metricKey.name))
+    }
+
+  protected def histogramValues(hs: Histogram.Snapshot): Map[String, BigDecimal] = {
+    val defaults = Map(
+      "lower" -> BigDecimal(hs.min),
+      "mean" -> average(hs),
+      "upper" -> BigDecimal(hs.max))
+
+    percentiles.foldLeft(defaults) { (acc, p) ⇒
+      val fractional = p % 1
+      val integral = (p - fractional).toInt
+
+      val percentile = BigDecimal(hs.percentile(p))
+
+      if (fractional > 0.0) acc ++ Map(s"p$p" -> percentile)
+      else acc ++ Map(s"p$integral" -> percentile)
+    }
+  }
+
+  protected def normalize(s: String): String =
+    s
+      .replace(": ", "-")
+      .replace(":\\", "-")
+      .replace(":", "-")
+      .replace(" ", "-")
+      .replace("\\", "-")
+      .replace("/", "-")
+      .replace(".", "-")
+
+  private def average(histogram: Histogram.Snapshot): BigDecimal = {
+    if (histogram.numberOfMeasurements == 0) BigDecimal(0.0)
+    else BigDecimal(histogram.sum / histogram.numberOfMeasurements.toDouble)
+  }
+
+}
+

--- a/kamon-influxdb/src/test/resources/http_test.conf
+++ b/kamon-influxdb/src/test/resources/http_test.conf
@@ -1,0 +1,37 @@
+kamon {
+  metric {
+    tick-interval = 10 seconds
+    default-collection-context-buffer-size = 1000
+  }
+
+  influxdb {
+    hostname = "127.0.0.1"
+    port = 0
+    max-packet-size = 1024
+    database = "mydb"
+    protocol = "http"
+
+    application-name = "kamon"
+
+    percentiles = [50.0, 70.5]
+  }
+
+  influx-with-auth-and-rp {
+    hostname = "127.0.0.1"
+    port = 0
+    max-packet-size = 1024
+    database = "mydb"
+    protocol = "http"
+
+    application-name = "kamon"
+
+    percentiles = [50.0, 70.5]
+
+    authentication {
+      user = "test-user"
+      password = "test-password"
+    }
+
+    retention-policy = "six_month_rollup"
+  }
+}

--- a/kamon-influxdb/src/test/resources/udp_test.conf
+++ b/kamon-influxdb/src/test/resources/udp_test.conf
@@ -1,0 +1,31 @@
+kamon {
+  metric {
+    tick-interval = 10 seconds
+    default-collection-context-buffer-size = 1000
+  }
+
+  influxdb {
+    hostname = "127.0.0.1"
+    port = 0
+    max-packet-size = 1024
+    protocol = "udp"
+
+    application-name = "kamon"
+
+    percentiles = [50.0, 70.5]
+
+    subscriptions {
+      histogram       = [ "**" ]
+      min-max-counter = [ "**" ]
+      gauge           = [ "**" ]
+      counter         = [ "**" ]
+      trace           = [ "**" ]
+      trace-segment   = [ "**" ]
+      akka-actor      = [ "**" ]
+      akka-dispatcher = [ "**" ]
+      akka-router     = [ "**" ]
+      system-metric   = [ "**" ]
+      http-server     = [ "**" ]
+    }
+  }
+}

--- a/kamon-influxdb/src/test/scala/kamon/influxdb/HttpBasedInfluxDBMetricSenderSpec.scala
+++ b/kamon-influxdb/src/test/scala/kamon/influxdb/HttpBasedInfluxDBMetricSenderSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import akka.actor.{ ActorRef, Props }
+import akka.io.{ IO, Udp }
+import akka.testkit.TestProbe
+import com.typesafe.config.{ Config, ConfigFactory }
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.{ Entity, EntitySnapshot }
+import kamon.testkit.BaseKamonSpec
+import spray.http.HttpRequest
+import spray.httpx.RequestBuilding.Post
+import spray.httpx.encoding.Deflate
+
+class HttpBasedInfluxDBMetricSenderSpec extends BaseKamonSpec("udp-based-influxdb-metric-sender-spec") {
+  override lazy val config = ConfigFactory.load("http_test")
+
+  class HttpSenderFixture(influxDBConfig: Config) extends SenderFixture {
+    def setup(metrics: Map[Entity, EntitySnapshot]): TestProbe = {
+      val http = TestProbe()
+      val metricsSender = system.actorOf(newSender(http))
+
+      val fakeSnapshot = TickMetricSnapshot(from, to, metrics)
+      metricsSender ! fakeSnapshot
+      http
+    }
+
+    def getHttpRequest(http: TestProbe): HttpRequest = {
+      http.expectMsgType[HttpRequest]
+    }
+
+    def newSender(httpProbe: TestProbe) =
+      Props(new BatchInfluxDBMetricsPacker(influxDBConfig) {
+        override protected def httpRef: ActorRef = httpProbe.ref
+        override def timestamp = from.millis
+      })
+  }
+
+  "the HttpSender" should {
+    val influxDBConfig = config.getConfig("kamon.influxdb")
+    val configWithAuthAndRetention = config.getConfig("kamon.influx-with-auth-and-rp")
+
+    "connect to the correct database" in new HttpSenderFixture(influxDBConfig) {
+      val testrecorder = buildRecorder("user/kamon")
+      val http = setup(Map(testEntity -> testrecorder.collect(collectionContext)))
+      val request = getHttpRequest(http)
+
+      val query = request.uri.query.toMap
+
+      query("db") shouldBe influxDBConfig.getString("database")
+    }
+
+    "use authentication and retention policy are defined" in new HttpSenderFixture(configWithAuthAndRetention) {
+      val testrecorder = buildRecorder("user/kamon")
+      val http = setup(Map(testEntity -> testrecorder.collect(collectionContext)))
+      val request = getHttpRequest(http)
+
+      val query = request.uri.query.toMap
+
+      query("u") shouldBe configWithAuthAndRetention.getString("authentication.user")
+      query("p") shouldBe configWithAuthAndRetention.getString("authentication.password")
+      query("rp") shouldBe configWithAuthAndRetention.getString("retention-policy")
+    }
+
+    "send counters in a correct format" in new HttpSenderFixture(influxDBConfig) {
+      val testrecorder = buildRecorder("user/kamon")
+      (0 to 2).foreach(_ ⇒ testrecorder.counter.increment())
+
+      val http = setup(Map(testEntity -> testrecorder.collect(collectionContext)))
+      val expectedMessage = s"kamon-counters,category=test,entity=user-kamon,hostname=$hostName,metric=metric-two value=3 ${from.millis * 1000000}"
+
+      val request = getHttpRequest(http)
+      val requestData = request.entity.asString.split("\n")
+
+      requestData should contain(expectedMessage)
+    }
+
+    "send histograms in a correct format" in new HttpSenderFixture(influxDBConfig) {
+      val testRecorder = buildRecorder("user/kamon")
+
+      testRecorder.histogramOne.record(10L)
+      testRecorder.histogramOne.record(5L)
+
+      val http = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+      val expectedMessage = s"kamon-timers,category=test,entity=user-kamon,hostname=$hostName,metric=metric-one mean=7.5,lower=5,upper=10,p70.5=10,p50=5 ${from.millis * 1000000}"
+
+      val request = getHttpRequest(http)
+      val requestData = request.entity.asString.split("\n")
+
+      requestData should contain(expectedMessage)
+    }
+  }
+}
+

--- a/kamon-influxdb/src/test/scala/kamon/influxdb/SenderFixture.scala
+++ b/kamon-influxdb/src/test/scala/kamon/influxdb/SenderFixture.scala
@@ -1,0 +1,49 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import java.lang.management.ManagementFactory
+
+import akka.actor.{ ActorRef, Props }
+import akka.io.Udp
+import akka.testkit.TestProbe
+import kamon.Kamon
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.{ Counter, InstrumentFactory }
+import kamon.metric.{ Entity, EntityRecorderFactory, EntitySnapshot, GenericEntityRecorder }
+import kamon.util.MilliTimestamp
+
+trait SenderFixture {
+  val hostName = ManagementFactory.getRuntimeMXBean.getName.split('@')(1)
+
+  val testEntity = Entity("user/kamon", "test")
+  val from = MilliTimestamp.now
+  val to = MilliTimestamp.now
+
+  def buildRecorder(name: String): TestEntityRecorder =
+    Kamon.metrics.entity(TestEntityRecorder, name)
+}
+
+class TestEntityRecorder(instrumentFactory: InstrumentFactory) extends GenericEntityRecorder(instrumentFactory) {
+  val histogramOne = histogram("metric-one")
+  val counter: Counter = counter("metric-two")
+}
+
+object TestEntityRecorder extends EntityRecorderFactory[TestEntityRecorder] {
+  def category: String = "test"
+  def createRecorder(instrumentFactory: InstrumentFactory): TestEntityRecorder = new TestEntityRecorder(instrumentFactory)
+}

--- a/kamon-influxdb/src/test/scala/kamon/influxdb/UDPBasedInfluxDBMetricSenderSpec.scala
+++ b/kamon-influxdb/src/test/scala/kamon/influxdb/UDPBasedInfluxDBMetricSenderSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.influxdb
+
+import akka.actor.{ ActorRef, Props }
+import akka.io.Udp
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric._
+import kamon.testkit.BaseKamonSpec
+
+class UDPBasedInfluxDBMetricSenderSpec extends BaseKamonSpec("udp-based-influxdb-metric-sender-spec") {
+  override lazy val config = ConfigFactory.load("udp_test")
+
+  trait UdpSenderFixture extends SenderFixture {
+    val influxDBConfig = config.getConfig("kamon.influxdb")
+
+    def setup(metrics: Map[Entity, EntitySnapshot]): TestProbe = {
+      val udp = TestProbe()
+      val metricsSender = system.actorOf(newSender(udp))
+
+      // Setup the SimpleSender
+      udp.expectMsgType[Udp.SimpleSender]
+      udp.reply(Udp.SimpleSenderReady)
+
+      val fakeSnapshot = TickMetricSnapshot(from, to, metrics)
+      metricsSender ! fakeSnapshot
+      udp
+    }
+
+    def getUdpPackets(udp: TestProbe): Array[String] = {
+      val Udp.Send(data, _, _) = udp.expectMsgType[Udp.Send]
+
+      data.utf8String.split("\n")
+    }
+
+    def newSender(udpProbe: TestProbe) =
+      Props(new BatchInfluxDBMetricsPacker(influxDBConfig) {
+        override protected def udpRef: ActorRef = udpProbe.ref
+        override def timestamp = from.millis
+      })
+  }
+
+  "the UDPSender" should {
+    "send counters in a correct format" in new UdpSenderFixture {
+      val testRecorder = buildRecorder("user/kamon")
+      (0 to 2).foreach(_ ⇒ testRecorder.counter.increment())
+
+      val udp = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+      val expectedMessage = s"kamon-counters,category=test,entity=user-kamon,hostname=$hostName,metric=metric-two value=3 ${from.millis * 1000000}"
+
+      getUdpPackets(udp) should contain(expectedMessage)
+    }
+
+    "send histograms in a correct format" in new UdpSenderFixture {
+      val testRecorder = buildRecorder("user/kamon")
+
+      testRecorder.histogramOne.record(10L)
+      testRecorder.histogramOne.record(5L)
+
+      val udp = setup(Map(testEntity -> testRecorder.collect(collectionContext)))
+      val expectedMessage = s"kamon-timers,category=test,entity=user-kamon,hostname=$hostName,metric=metric-one mean=7.5,lower=5,upper=10,p70.5=10,p50=5 ${from.millis * 1000000}"
+
+      getUdpPackets(udp) should contain(expectedMessage)
+    }
+  }
+}

--- a/kamon-riemann/src/main/scala/kamon/riemann/Riemann.scala
+++ b/kamon-riemann/src/main/scala/kamon/riemann/Riemann.scala
@@ -82,8 +82,7 @@ class RiemannExtension(system: ExtendedActorSystem) extends Kamon.Extension {
     val metricsSender = system.actorOf(senderFactory.props(
       riemannConfig.getString("hostname"),
       riemannConfig.getInt("port"),
-      metricsMapper
-    ), senderFactory.name)
+      metricsMapper), senderFactory.name)
 
     if (flushInterval == tickInterval) {
       // No need to buffer the metrics, let's go straight to the metrics sender.

--- a/kamon-riemann/src/test/scala/kamon/riemann/MetricSenderSpec.scala
+++ b/kamon-riemann/src/test/scala/kamon/riemann/MetricSenderSpec.scala
@@ -39,8 +39,7 @@ abstract class MetricSenderSpec(actorSystemName: String) extends BaseKamonSpec(a
         |    port = 0
         |  }
         |}
-      """.stripMargin
-    )
+      """.stripMargin)
 
   val riemannConfig = config.getConfig("kamon.riemann")
   val riemannHost = riemannConfig.getString("hostname")

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -24,7 +24,7 @@ object Projects extends Build {
   lazy val kamon = Project("kamon", file("."))
     .aggregate(kamonCore, kamonScala, kamonAkka, kamonSpray, kamonNewrelic, kamonPlayground, kamonTestkit,
       kamonStatsD, kamonRiemann, kamonDatadog, kamonSPM, kamonSystemMetrics, kamonLogReporter, kamonAkkaRemote, kamonJdbc,
-      kamonAnnotation, kamonPlay23, kamonPlay24, kamonJMXReporter, kamonFluentd, kamonAutoweave)
+      kamonAnnotation, kamonPlay23, kamonPlay24, kamonJMXReporter, kamonFluentd, kamonAutoweave, kamonInfluxDB)
     .settings(basicSettings: _*)
     .settings(formatSettings: _*)
     .settings(noPublishing: _*)
@@ -147,6 +147,15 @@ object Projects extends Build {
         compile(play24, playWS24) ++
         provided(aspectJ, typesafeConfig) ++
         test(playTest24, akkaTestKit, slf4jApi))
+
+  lazy val kamonInfluxDB = Project("kamon-influxdb", file("kamon-influxdb"))
+    .dependsOn(kamonCore % "compile->compile;test->test")
+    .settings(basicSettings: _*)
+    .settings(formatSettings: _*)
+    .settings(
+      libraryDependencies ++=
+        compile(sprayCan, sprayClient, sprayRouting, akkaSlf4j, akkaActor, typesafeConfig) ++
+        test(scalatest, sprayCan, sprayClient, akkaTestKit, slf4jApi, slf4jnop, typesafeConfig))
 
   lazy val kamonStatsD = Project("kamon-statsd", file("kamon-statsd"))
     .dependsOn(kamonCore % "compile->compile;test->test")


### PR DESCRIPTION
Adds support for sending metrics to an InfluxDB database using either HTTP or UDP.

Configuration
------------------

```
  influxdb {
    # Hostname and port in which your InfluxDB is running
    hostname = "127.0.0.1"
    port = 8086

    # The maximum packet size for one POST request, set to 0 to disable batching
    max-packet-size = 16384

    # The database where to write in InfluxDB. Works only for HTTP protocol, if using UDP, change the database in your
    # InfluxDB configuration
    database = "mydb"

    # The protocol, either http or udp
    protocol = "http"

    # The measurements will be named ${application-name}-timers and -counters
    application-name = "kamon"

    # For histograms, which percentiles to count
    percentiles = [50.0, 70.0, 90.0, 95.0, 99.0, 99.9]

    # Subscription patterns used to select which metrics will be pushed to InfluxDB. Note that first, metrics
    # collection for your desired entities must be activated under the kamon.metrics.filters settings.
    subscriptions {
      histogram       = [ "**" ]
      min-max-counter = [ "**" ]
      gauge           = [ "**" ]
      counter         = [ "**" ]
      trace           = [ "**" ]
      trace-segment   = [ "**" ]
      akka-actor      = [ "**" ]
      akka-dispatcher = [ "**" ]
      akka-router     = [ "**" ]
      system-metric   = [ "**" ]
      http-server     = [ "**" ]
    }
  }
```

For counters, the measurement name is `"${application-name}-counters`, setting the `category`, `entity`, `metric` and `hostname` tags. The measurement value is stored to the `value` field.

For histograms, the measurement name is `"${application-name}-timers`, setting the `category`, `entity`, `metric` and `hostname` tags. The measurement values are stored to the `lower`, `mean`, `upper` and percentile fields depending on the configuration. The default percentiles are `p50`, `p70`, `p90`, `p99` and `p99.9`.