### PR TITLE
Replace AspectJ Weaver error message

### DIFF
--- a/kamon-core/src/main/scala/kamon/ModuleLoader.scala
+++ b/kamon-core/src/main/scala/kamon/ModuleLoader.scala
@@ -58,14 +58,7 @@ private[kamon] class ModuleLoaderExtension(system: ExtendedActorSystem) extends 
     val weaverMissingMessage =
       """
         |
-        |  ___                           _      ___   _    _                                 ___  ___ _            _
-        | / _ \                         | |    |_  | | |  | |                                |  \/  |(_)          (_)
-        |/ /_\ \ ___  _ __    ___   ___ | |_     | | | |  | |  ___   __ _ __   __ ___  _ __  | .  . | _  ___  ___  _  _ __    __ _
-        ||  _  |/ __|| '_ \  / _ \ / __|| __|    | | | |/\| | / _ \ / _` |\ \ / // _ \| '__| | |\/| || |/ __|/ __|| || '_ \  / _` |
-        || | | |\__ \| |_) ||  __/| (__ | |_ /\__/ / \  /\  /|  __/| (_| | \ V /|  __/| |    | |  | || |\__ \\__ \| || | | || (_| |
-        |\_| |_/|___/| .__/  \___| \___| \__|\____/   \/  \/  \___| \__,_|  \_/  \___||_|    \_|  |_/|_||___/|___/|_||_| |_| \__, |
-        |            | |                                                                                                      __/ |
-        |            |_|                                                                                                     |___/
+        | AspectJ Weaver Missing!
         |
         | It seems like your application was not started with the -javaagent:/path-to-aspectj-weaver.jar option but Kamon detected
         | the following modules which require AspectJ to work properly:


### PR DESCRIPTION
I know it's bad if AspectJ Weaver isn't running when it should be, but I don't think it's cool to draw such big attention to it in the error logs.

```
  _______ _                 _        
 |__   __| |               | |       
    | |  | |__   __ _ _ __ | | _____ 
    | |  | '_ \ / _` | '_ \| |/ / __|
    | |  | | | | (_| | | | |   <\__ \
    |_|  |_| |_|\__,_|_| |_|_|\_\___/

```
