### PR TITLE
= kamon-core: add context name and token to MDC

### DIFF
--- a/kamon-core/src/test/scala/kamon/trace/logging/MdcKeysSupportSpec.scala
+++ b/kamon-core/src/test/scala/kamon/trace/logging/MdcKeysSupportSpec.scala
@@ -1,0 +1,44 @@
+package kamon.trace.logging
+
+import kamon.testkit.BaseKamonSpec
+import kamon.trace.{ EmptyTraceContext, Tracer }
+import org.slf4j.MDC
+
+class MdcKeysSupportSpec extends BaseKamonSpec("mdc-keys-support-spec") {
+
+  "Running code with MDC support" should {
+    "add nothing to the MDC" when {
+      "the trace context is empty" in {
+        // Given an empty trace context.
+        Tracer.withContext(EmptyTraceContext) {
+          // When some code is executed with MDC support.
+          MdcKeysSupport.withMdc {
+            // Then the MDC should not contain the trace token.
+            Option(MDC.get(MdcKeysSupport.traceTokenKey)) should be(None)
+            // Or name
+            Option(MDC.get(MdcKeysSupport.traceNameKey)) should be(None)
+          }
+        }
+      }
+    }
+    "add the trace token and name to the context" when {
+      "the trace context is not empty" in {
+        // Given a trace context.
+        Tracer.withNewContext("name", Some("token")) {
+          // When some code is executed with MDC support.
+          MdcKeysSupport.withMdc {
+            // Then the MDC should contain the trace token.
+            Option(MDC.get(MdcKeysSupport.traceTokenKey)) should be(Some("token"))
+            // And name
+            Option(MDC.get(MdcKeysSupport.traceNameKey)) should be(Some("name"))
+          }
+
+          // Then after code is executed the MDC should have been cleared.
+          Option(MDC.get(MdcKeysSupport.traceTokenKey)) should be(None)
+          Option(MDC.get(MdcKeysSupport.traceNameKey)) should be(None)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This change pushes the trace name and token into the MDC. This means that they can be accessed in async appenders using the normal mechanism - without using the LogbackTraceTokenConverter.