### PR TITLE
Khronus metrics reporter

### DIFF
--- a/kamon-khronus/src/main/resources/reference.conf
+++ b/kamon-khronus/src/main/resources/reference.conf
@@ -1,0 +1,23 @@
+# ===================================== #
+# Kamon-Khronus Reference Configuration #
+# ===================================== #
+
+kamon {
+  khronus {
+    host = "127.0.0.1:1173"
+    app-name = "kamon-khronus"
+    # Time interval in milliseconds to flush the buffer and send the accumulated metrics.
+    # It must be less than the smallest time window configured in Khronus.
+    interval = 3000
+    # Maximum number of measures to hold in memory within intervals.
+    # Past this threshold, metrics will be discarded.
+    max-measures = 500000
+  }
+  modules {
+    kamon-khronus {
+      requires-aspectj = no
+      auto-start = yes
+      extension-class = "kamon.khronus.MetricReporter"
+    }
+  }
+}

--- a/kamon-khronus/src/main/scala/kamon/khronus/MetricReporter.scala
+++ b/kamon-khronus/src/main/scala/kamon/khronus/MetricReporter.scala
@@ -1,0 +1,174 @@
+package kamon.khronus
+
+import akka.actor._
+import akka.event.Logging
+import com.despegar.khronus.jclient.KhronusClient
+import kamon.Kamon
+import kamon.metric.{ Entity, EntitySnapshot }
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument.{ Counter, Histogram }
+
+import scala.util.Try
+
+object MetricReporter extends ExtensionId[MetricReporterExtension] with ExtensionIdProvider {
+  override def lookup(): ExtensionId[_ <: Extension] = MetricReporter
+  override def createExtension(system: ExtendedActorSystem): MetricReporterExtension = new MetricReporterExtension(system)
+}
+
+class MetricReporterExtension(system: ExtendedActorSystem) extends Kamon.Extension {
+  val log = Logging(system, classOf[MetricReporterExtension])
+
+  log.info("Starting the Kamon(Khronus) extension")
+  val subscriber = system.actorOf(Props[MetricReporterSubscriber], "kamon-khronus")
+
+  Kamon.metrics.subscribe("histogram", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("counter", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("gauge", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("trace", "**", subscriber, permanently = true)
+  Kamon.metrics.subscribe("executor-service", "**", subscriber, permanently = true)
+}
+
+class MetricReporterSubscriber extends Actor with ActorLogging {
+  import context._
+
+  lazy val khronusClient: Try[KhronusClient] = {
+    val kc =
+      for {
+        config ← Try(Kamon.config.getConfig("kamon.khronus"))
+        host ← Try(config.getString("host"))
+        appName ← Try(config.getString("app-name"))
+        interval ← Try(config.getLong("interval"))
+        measures ← Try(config.getInt("max-measures"))
+        kc ← Try(new KhronusClient.Builder()
+          .withApplicationName(appName)
+          .withSendIntervalMillis(interval)
+          .withMaximumMeasures(measures)
+          .withHosts(host)
+          .build)
+      } yield kc
+    kc.failed.foreach(ex ⇒ log.error(s"Khronus metrics reporting inoperative: {}", ex))
+    kc
+  }
+
+  override def preStart() = khronusClient.foreach(_ ⇒ become(operative))
+
+  def receive = { case _ ⇒ }
+
+  val operative: Receive = {
+    case tick: TickMetricSnapshot ⇒ reportMetrics(tick)
+  }
+
+  def reportMetrics(tick: TickMetricSnapshot): Unit = {
+
+    // Group all the user metrics together.
+    val histograms = Map.newBuilder[String, Option[Histogram.Snapshot]]
+    val traces = Map.newBuilder[String, Option[Histogram.Snapshot]]
+    val counters = Map.newBuilder[String, Option[Counter.Snapshot]]
+    val gauges = Map.newBuilder[String, Option[Histogram.Snapshot]]
+
+    tick.metrics foreach {
+      case (entity, snapshot) if entity.category == "histogram"        ⇒ histograms += (entity.name -> snapshot.histogram("histogram"))
+      case (entity, snapshot) if entity.category == "counter"          ⇒ counters += (entity.name -> snapshot.counter("counter"))
+      case (entity, snapshot) if entity.category == "gauge"            ⇒ gauges += (entity.name -> snapshot.gauge("gauge"))
+      case (entity, snapshot) if entity.category == "trace"            ⇒ traces += (entity.name -> snapshot.histogram("elapsed-time"))
+      case (entity, snapshot) if entity.category == "executor-service" ⇒ pushExecutorMetrics(entity, snapshot)
+      case ignoreEverythingElse                                        ⇒
+    }
+
+    pushToKhronus(histograms.result(), counters.result(), gauges.result(), traces.result())
+  }
+
+  def pushToKhronus(histograms: Map[String, Option[Histogram.Snapshot]],
+    counters: Map[String, Option[Counter.Snapshot]],
+    gauges: Map[String, Option[Histogram.Snapshot]],
+    traces: Map[String, Option[Histogram.Snapshot]]): Unit = {
+
+    counters.foreach {
+      case (name, Some(snapshot)) ⇒
+        pushCounter(name, snapshot)
+      case _ ⇒
+    }
+
+    gauges.foreach {
+      case (name, Some(snapshot)) ⇒
+        pushGauge(name, snapshot)
+      case _ ⇒
+    }
+
+    histograms.foreach {
+      case (name, Some(snapshot)) ⇒
+        pushSnapshot(name, snapshot)
+      case _ ⇒
+    }
+
+    traces.foreach {
+      case (name, Some(snapshot)) ⇒
+        pushSnapshot(name, snapshot)
+      case _ ⇒
+    }
+
+  }
+
+  def pushExecutorMetrics(entity: Entity, snapshot: EntitySnapshot): Unit = entity.tags.get("executor-type") match {
+    case Some("fork-join-pool")       ⇒ pushForkJoinPoolMetrics(entity.name, snapshot)
+    case Some("thread-pool-executor") ⇒ pushThreadPoolExecutorMetrics(entity.name, snapshot)
+    case ignoreOthers                 ⇒
+  }
+
+  def pushForkJoinPoolMetrics(name: String, forkJoinMetrics: EntitySnapshot): Unit = {
+    for {
+      paralellism ← forkJoinMetrics.minMaxCounter("parallelism")
+      poolSize ← forkJoinMetrics.gauge("pool-size")
+      activeThreads ← forkJoinMetrics.gauge("active-threads")
+      runningThreads ← forkJoinMetrics.gauge("running-threads")
+      queuedTaskCount ← forkJoinMetrics.gauge("queued-task-count")
+    } {
+      pushSnapshot(s"$name.parallelism", paralellism)
+      pushSnapshot(s"$name.pool-size", poolSize)
+      pushSnapshot(s"$name.active-threads", activeThreads)
+      pushSnapshot(s"$name.running-threads", runningThreads)
+      pushSnapshot(s"$name.queued-task-count", queuedTaskCount)
+    }
+  }
+
+  def pushThreadPoolExecutorMetrics(name: String, threadPoolMetrics: EntitySnapshot): Unit = {
+    for {
+      corePoolSize ← threadPoolMetrics.gauge("core-pool-size")
+      maxPoolSize ← threadPoolMetrics.gauge("max-pool-size")
+      poolSize ← threadPoolMetrics.gauge("pool-size")
+      activeThreads ← threadPoolMetrics.gauge("active-threads")
+      processedTasks ← threadPoolMetrics.gauge("processed-tasks")
+    } {
+      pushSnapshot(s"$name.core-pool-size", corePoolSize)
+      pushSnapshot(s"$name.max-pool-size", maxPoolSize)
+      pushSnapshot(s"$name.pool-size", poolSize)
+      pushSnapshot(s"$name.active-threads", activeThreads)
+      pushSnapshot(s"$name.processed-tasks", processedTasks)
+    }
+  }
+
+  def pushSnapshot(name: String, snapshot: Histogram.Snapshot): Unit = {
+    khronusClient.foreach { kc ⇒
+      snapshot.recordsIterator.foreach { record ⇒
+        for (i ← 1L to record.count)
+          kc.recordTime(name, record.level)
+      }
+    }
+  }
+
+  def pushGauge(name: String, snapshot: Histogram.Snapshot): Unit = {
+    khronusClient.foreach { kc ⇒
+      snapshot.recordsIterator.foreach { record ⇒
+        for (i ← 1L to record.count)
+          kc.recordGauge(name, record.level)
+      }
+    }
+  }
+
+  def pushCounter(name: String, snapshot: Counter.Snapshot): Unit = {
+    khronusClient.foreach { kc ⇒
+      kc.recordGauge(name, snapshot.count)
+    }
+  }
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,6 +59,7 @@ object Dependencies {
   val fluentdLogger     = "org.fluentd"               %%  "fluent-logger-scala"   % "0.5.1"
   val easyMock          = "org.easymock"              %   "easymock"              % "3.2"
   val riemannClient     = "com.aphyr"                 %   "riemann-java-client"   % "0.4.1"
+  val khronusClient     = "com.despegar"              %   "khronus-java-client"   % "0.0.5"
 
   //play 2.3.x
   val play23            = "com.typesafe.play"         %%  "play"                  % play23Version

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -26,7 +26,8 @@ object Projects extends Build {
     .enablePlugins(CrossPerProjectPlugin)
     .aggregate(kamonCore, kamonScala, kamonAkka, kamonSpray, kamonNewrelic, kamonPlayground, kamonTestkit,
       kamonStatsD, kamonRiemann, kamonDatadog, kamonSPM, kamonSystemMetrics, kamonLogReporter, kamonAkkaRemote, kamonJdbc,
-      kamonAnnotation, kamonPlay23, kamonPlay24, kamonPlay25, kamonJMXReporter, kamonFluentd, kamonAutoweave, kamonInfluxDB)
+      kamonAnnotation, kamonPlay23, kamonPlay24, kamonPlay25, kamonJMXReporter, kamonFluentd, kamonKhronus,
+      kamonAutoweave, kamonInfluxDB)
     .settings(basicSettings: _*)
     .settings(formatSettings: _*)
     .settings(noPublishing: _*)
@@ -286,6 +287,15 @@ object Projects extends Build {
       libraryDependencies ++=
         compile(akkaActor) ++ compile(fluentdLogger) ++
           test(scalatest, akkaTestKit, easyMock, slf4jApi, slf4jnop))
+
+  lazy val kamonKhronus = Project("kamon-khronus", file("kamon-khronus"))
+    .dependsOn(kamonCore % "compile->compile;test->test")
+    .settings(basicSettings: _*)
+    .settings(formatSettings: _*)
+    .settings(
+      libraryDependencies ++=
+        compile(khronusClient) ++
+          test(scalatest, easyMock))
 
   val noPublishing = Seq(publish := (), publishLocal := (), publishArtifact := false)
 }


### PR DESCRIPTION
This adds a new reporter to send `histogram`, `counter`, `gauge`, `trace` metrics to Khronus. 

Currently, this uses `com.despegar:khronus-java-client` which has a dependency on Apache's HttpClient. Perhaps in a future release the underlying Khronus client can be swapped.

The `reference.conf` file has sensible defaults pointing to a Khronus instance running on localhost. To make this baby work in a service, this is the minimum configuration required:

```
kamon {
  khronus {
    host = "1.2.3.4:5678"
    app-name = "your-service-name-here"
  }
  modules {
    kamon-khronus.auto-start = yes
  }
}
```