### PR TITLE
Add support for twitter-util Futures

### DIFF
--- a/kamon-scala/src/main/resources/META-INF/aop.xml
+++ b/kamon-scala/src/main/resources/META-INF/aop.xml
@@ -6,12 +6,14 @@
     <!-- Futures -->
     <aspect name="kamon.scala.instrumentation.FutureInstrumentation"/>
     <aspect name="kamon.scalaz.instrumentation.FutureInstrumentation"/>
+    <aspect name="kamon.twitter.instrumentation.FutureInstrumentation"/>
 
   </aspects>
 
   <weaver>
     <include within="scala.concurrent..*"/>
     <include within="scalaz.concurrent..*"/>
+    <include within="com.twitter.util..*"/>
   </weaver>
 
 </aspectj>

--- a/kamon-scala/src/main/scala/kamon/twitter/instrumentation/FutureInstrumentation.scala
+++ b/kamon-scala/src/main/scala/kamon/twitter/instrumentation/FutureInstrumentation.scala
@@ -1,6 +1,6 @@
 /*
  * =========================================================================================
- * Copyright © 2013-2014 the kamon project <http://kamon.io/>
+ * Copyright © 2016 the kamon project <http://kamon.io/>
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -14,20 +14,20 @@
  * =========================================================================================
  */
 
-package kamon.scala.instrumentation
+package kamon.twitter.instrumentation
 
-import kamon.trace.{ Tracer, TraceContextAware }
+import kamon.trace.{ TraceContextAware, Tracer }
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation._
 
 @Aspect
 class FutureInstrumentation {
 
-  @DeclareMixin("scala.concurrent.impl.CallbackRunnable || scala.concurrent.impl.Future.PromiseCompletingRunnable")
+  @DeclareMixin("com.twitter.util..* && java.lang.Runnable+")
   def mixinTraceContextAwareToFutureRelatedRunnable: TraceContextAware =
     TraceContextAware.default
 
-  @Pointcut("execution((scala.concurrent.impl.CallbackRunnable || scala.concurrent.impl.Future.PromiseCompletingRunnable).new(..)) && this(runnable)")
+  @Pointcut("execution((com.twitter.util..* && java.lang.Runnable+).new(..)) && this(runnable)")
   def futureRelatedRunnableCreation(runnable: TraceContextAware): Unit = {}
 
   @After("futureRelatedRunnableCreation(runnable)")
@@ -36,7 +36,7 @@ class FutureInstrumentation {
     runnable.traceContext
   }
 
-  @Pointcut("execution(* (scala.concurrent.impl.CallbackRunnable || scala.concurrent.impl.Future.PromiseCompletingRunnable).run()) && this(runnable)")
+  @Pointcut("execution(* (com.twitter.util..* && java.lang.Runnable+).run()) && this(runnable)")
   def futureRelatedRunnableExecution(runnable: TraceContextAware) = {}
 
   @Around("futureRelatedRunnableExecution(runnable)")

--- a/kamon-scala/src/test/scala/kamon/twitter/instrumentation/FutureInstrumentationSpec.scala
+++ b/kamon-scala/src/test/scala/kamon/twitter/instrumentation/FutureInstrumentationSpec.scala
@@ -1,0 +1,63 @@
+/* ===================================================
+ * Copyright © 2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.twitter.instrumentation
+
+import java.util.concurrent.Executors
+
+import kamon.testkit.BaseKamonSpec
+import kamon.trace.Tracer
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
+import com.twitter.util.{ Await, FuturePool }
+
+class FutureInstrumentationSpec extends BaseKamonSpec("future-instrumentation-spec") with ScalaFutures
+    with PatienceConfiguration with OptionValues {
+
+  implicit val execContext = Executors.newCachedThreadPool()
+
+  "a Future created with FutureTracing" should {
+    "capture the TraceContext available when created" which {
+      "must be available when executing the future's body" in {
+
+        val (future, testTraceContext) = Tracer.withContext(newContext("future-body")) {
+          val future = FuturePool(execContext)(Tracer.currentContext)
+
+          (future, Tracer.currentContext)
+        }
+
+        val ctxInFuture = Await.result(future)
+        ctxInFuture should equal(testTraceContext)
+      }
+
+      "must be available when executing callbacks on the future" in {
+
+        val (future, testTraceContext) = Tracer.withContext(newContext("future-body")) {
+          val future = FuturePool.unboundedPool("Hello Kamon!")
+            // The TraceContext is expected to be available during all intermediate processing.
+            .map(_.length)
+            .flatMap(len ⇒ FuturePool.unboundedPool(len.toString))
+            .map(s ⇒ Tracer.currentContext)
+
+          (future, Tracer.currentContext)
+        }
+
+        val ctxInFuture = Await.result(future)
+        ctxInFuture should equal(testTraceContext)
+      }
+    }
+  }
+}
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,6 +53,7 @@ object Dependencies {
   val slf4jJul          = "org.slf4j"                 %   "jul-to-slf4j"          % slf4jVersion
   val slf4jLog4j        = "org.slf4j"                 %   "log4j-over-slf4j"      % slf4jVersion
   val scalazConcurrent  = "org.scalaz"                %%  "scalaz-concurrent"     % "7.1.0"
+  val twitterUtilCore   = "com.twitter"               %%  "util-core"             % "6.34.0"
   val sigarLoader       = "io.kamon"                  %   "sigar-loader"          % "1.6.5-rev002"
   val h2                = "com.h2database"            %   "h2"                    % "1.4.182"
   val el                = "org.glassfish"             %   "javax.el"              % "3.0.0"

--- a/project/Projects.scala
+++ b/project/Projects.scala
@@ -68,7 +68,7 @@ object Projects extends Build {
       libraryDependencies ++=
         compile() ++
         provided(aspectJ) ++
-        optional(scalazConcurrent) ++
+        optional(scalazConcurrent, twitterUtilCore) ++
         test(scalatest, akkaTestKit, akkaSlf4j, slf4jJul, slf4jLog4j, logback))
 
   lazy val kamonAkkaRemote = Project("kamon-akka-remote", file("kamon-akka-remote"))


### PR DESCRIPTION
I searched a conversation about twitter-util Futures in the kamon-user mailing list, but I couldn't find it. So I implemented the support for them.