### PR TITLE
fix "configuration not public" on local test->test dependency if the …

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11


### PR DESCRIPTION
…same version has been resolved out of a public Maven repository
->upgrades sbt to latest stable which enables withInterProjectFirst resolution option

If I checkout this branch and try to run sbt test I get zillions of: 
```
[warn] Run 'evicted' to see detailed eviction warnings
[info] Updating {file:/Users/dsc/git/Kamon/}kamon-autoweave...
[info] Resolving jline#jline;2.12.1 ...
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: io.kamon#kamon-core_2.11;0.6.2: configuration not public in io.kamon#kamon-core_2.11;0.6.2: 'test'. It was required from io.kamon#kamon-autoweave_2.11;0.6.2 test
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn]  Note: Unresolved dependencies path:
[warn]          io.kamon:kamon-core_2.11:0.6.2
[warn]            +- io.kamon:kamon-autoweave_2.11:0.6.2
[info] Updating {file:/Users/dsc/git/Kamon/}kamon-jmx...
```

->upgrading sbt fixes this
see https://github.com/sbt/sbt/pull/2345