### PR TITLE
+ core: support for regex path filters

### DIFF
--- a/kamon-core/src/main/java/kamon/util/GlobPathFilter.java
+++ b/kamon-core/src/main/java/kamon/util/GlobPathFilter.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  * @author John E. Bailey
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
-public final class GlobPathFilter  {
+public final class GlobPathFilter implements PathFilter  {
     private static final Pattern GLOB_PATTERN = Pattern.compile("(\\*\\*?)|(\\?)|(\\\\.)|(/+)|([^*?]+)");
 
     private final String glob;

--- a/kamon-core/src/main/scala/kamon/util/PathFilter.scala
+++ b/kamon-core/src/main/scala/kamon/util/PathFilter.scala
@@ -1,0 +1,5 @@
+package kamon.util
+
+trait PathFilter {
+  def accept(path: String): Boolean
+}

--- a/kamon-core/src/main/scala/kamon/util/RegexPathFilter.scala
+++ b/kamon-core/src/main/scala/kamon/util/RegexPathFilter.scala
@@ -1,0 +1,27 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2015 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.util
+
+case class RegexPathFilter(path: String) extends PathFilter {
+  private val pathRegex = path.r
+  override def accept(path: String): Boolean = {
+    path match {
+      case pathRegex(_*) ⇒ true
+      case _             ⇒ false
+    }
+  }
+}

--- a/kamon-core/src/test/scala/kamon/util/RegexPathFilterSpec.scala
+++ b/kamon-core/src/test/scala/kamon/util/RegexPathFilterSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2015 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.util
+
+import org.scalatest.{ Matchers, WordSpecLike }
+
+class RegexPathFilterSpec extends WordSpecLike with Matchers {
+  "The RegexPathFilter" should {
+
+    "match a single expression" in {
+      val filter = new RegexPathFilter("/user/actor")
+
+      filter.accept("/user/actor") shouldBe true
+
+      filter.accept("/user/actor/something") shouldBe false
+      filter.accept("/user/actor/somethingElse") shouldBe false
+    }
+
+    "match arbitray expressions ending with wildcard" in {
+      val filter = new RegexPathFilter("/user/.*")
+
+      filter.accept("/user/actor") shouldBe true
+      filter.accept("/user/otherActor") shouldBe true
+      filter.accept("/user/something/actor") shouldBe true
+      filter.accept("/user/something/otherActor") shouldBe true
+
+      filter.accept("/otheruser/actor") shouldBe false
+      filter.accept("/otheruser/otherActor") shouldBe false
+      filter.accept("/otheruser/something/actor") shouldBe false
+      filter.accept("/otheruser/something/otherActor") shouldBe false
+    }
+
+    "match numbers" in {
+      val filter = new RegexPathFilter("/user/actor-\\d")
+
+      filter.accept("/user/actor-1") shouldBe true
+      filter.accept("/user/actor-2") shouldBe true
+      filter.accept("/user/actor-3") shouldBe true
+
+      filter.accept("/user/actor-one") shouldBe false
+      filter.accept("/user/actor-two") shouldBe false
+      filter.accept("/user/actor-tree") shouldBe false
+    }
+  }
+}


### PR DESCRIPTION
In my application I had a rather complicated use case where I had to exclude anonymous actors (created for Akka asks) from generating Kamon metrics. I found this very cumbersome to do based on the GlobPathFilter so I created this PR.

Putting it up here for discussion (e.g. to see if you're interested). Obviously some things are left to be done (e.g. end-user documentation).
