### PR TITLE
Use CAS for safer counter collection

### DIFF
--- a/kamon-core/src/main/java/kamon/jsr166/LongAdder.java
+++ b/kamon-core/src/main/java/kamon/jsr166/LongAdder.java
@@ -151,6 +151,21 @@ public class LongAdder extends Striped64 implements Serializable {
         return sum;
     }
 
+    public long sumAndReset() {
+        long sum = getAndSetBase(0L);
+        Cell[] as = cells;
+        if (as != null) {
+            int n = as.length;
+            for (int i = 0; i < n; ++i) {
+                Cell a = as[i];
+                if (a != null) {
+                    sum += a.getAndSet(0L);
+                }
+            }
+        }
+        return sum;
+    }
+
     /**
      * Returns the String representation of the {@link #sum}.
      * @return the String representation of the {@link #sum}

--- a/kamon-core/src/main/java/kamon/jsr166/Striped64.java
+++ b/kamon-core/src/main/java/kamon/jsr166/Striped64.java
@@ -105,6 +105,10 @@ abstract class Striped64 extends Number {
             return UNSAFE.compareAndSwapLong(this, valueOffset, cmp, val);
         }
 
+        final long getAndSet(long val) {
+            return UNSAFE.getAndSetLong(this, valueOffset, val);
+        }
+
         // Unsafe mechanics
         private static final sun.misc.Unsafe UNSAFE;
         private static final long valueOffset;
@@ -179,6 +183,13 @@ abstract class Striped64 extends Number {
      */
     final boolean casBase(long cmp, long val) {
         return UNSAFE.compareAndSwapLong(this, baseOffset, cmp, val);
+    }
+
+    /**
+     * CASes the base field.
+     */
+    final long getAndSetBase(long val) {
+        return UNSAFE.getAndSetLong(this, baseOffset, val);
     }
 
     /**

--- a/kamon-core/src/main/scala/kamon/metric/instrument/Counter.scala
+++ b/kamon-core/src/main/scala/kamon/metric/instrument/Counter.scala
@@ -48,7 +48,7 @@ class LongAdderCounter extends Counter {
     counter.add(times)
   }
 
-  def collect(context: CollectionContext): Counter.Snapshot = CounterSnapshot(counter.sumThenReset())
+  def collect(context: CollectionContext): Counter.Snapshot = CounterSnapshot(counter.sumAndReset())
 
   def cleanup: Unit = {}
 }


### PR DESCRIPTION
Note: this patch only fixes the scala counter. Other Kamon metrics have similar semantics which could benefit from CAS.

For #393 