### PR TITLE
More flexible kamon configuration

### DIFF
--- a/kamon-jmx/src/main/resources/reference.conf
+++ b/kamon-jmx/src/main/resources/reference.conf
@@ -26,5 +26,10 @@ kamon {
       requires-aspectj = no
       extension-class = "kamon.jmx.JMXReporter"
     }
+    kamon-mxbeans {
+      auto-start = yes
+      requires-aspectj = no
+      extension-class = "kamon.jmx.extension.JMXMetricImporter"
+    }
   }
 }

--- a/kamon-jmx/src/main/scala/kamon/jmx/extension/ExportedMBeanQuery.scala
+++ b/kamon-jmx/src/main/scala/kamon/jmx/extension/ExportedMBeanQuery.scala
@@ -1,0 +1,362 @@
+
+package kamon.jmx.extension
+
+import java.lang.Thread
+import java.lang.management.ManagementFactory
+import java.util.concurrent.{ Executors, ScheduledExecutorService, TimeUnit }
+import java.util.logging.Level
+
+import scala.concurrent.ExecutionContext
+import scala.collection.mutable.Buffer
+import scala.collection.immutable.Set
+import scala.concurrent.duration.FiniteDuration
+
+import akka.actor.{ Actor, ActorSystem, ExtendedActorSystem, Props }
+import akka.event.Logging
+
+import javax.management._
+
+import com.typesafe.config.{ Config, ConfigValueType }
+
+import kamon.metric.{
+  GenericEntityRecorder,
+  MetricsModule,
+  EntityRecorderFactory
+}
+import kamon.metric.SubscriptionsDispatcher.TickMetricSnapshot
+import kamon.metric.instrument._
+import kamon.metric.instrument.Gauge.CurrentValueCollector
+import kamon.jmx.extension.MetricDefinition._
+
+class AcceptAllPredicate extends QueryExp {
+
+  def apply(name: ObjectName): Boolean = true
+
+  def setMBeanServer(s: MBeanServer): Unit = {}
+}
+
+object ExportedMBeanQuery {
+
+  val server: MBeanServer = ManagementFactory.getPlatformMBeanServer()
+  val pred: QueryExp = new AcceptAllPredicate()
+
+  /**
+   * register queries to find new dynamic mbeans
+   * @param system actor system used by kamon
+   * @param metricsExtension kamon object for registering metrics
+   * @param config configuration of this kamon extension
+   */
+  def register(
+    system: ExtendedActorSystem, metricsExtension: MetricsModule,
+    config: Config): Unit = {
+
+    Thread.currentThread().setName("JMX exporting thread")
+    import collection.JavaConverters._
+    val identifyDelayInterval: Long =
+      config.getLong("identify-delay-interval-ms")
+    val identifyInterval: Long = config.getLong("identify-interval-ms")
+    val checkInterval: Long = config.getLong("value-check-interval-ms")
+
+    config.getObjectList("mbeans").asScala.foreach { confObj ⇒
+      val nameObj = confObj.get("name")
+      val queryObj = confObj.get("jmxQuery")
+      val attrListObj = confObj.get("attributes")
+
+      require(
+        nameObj.valueType() == ConfigValueType.STRING, "name must be a string")
+      require(
+        queryObj.valueType() == ConfigValueType.STRING,
+        "jmxQuery must be a string")
+      require(
+        attrListObj.valueType() == ConfigValueType.LIST,
+        "mbeans must be an array")
+
+      val name: String = nameObj.unwrapped().asInstanceOf[String]
+      val query: String = queryObj.unwrapped().asInstanceOf[String]
+      val attrList: Seq[Map[String, Any]] =
+        attrListObj.unwrapped().asInstanceOf[java.util.List[Any]].asScala.map {
+          import scala.collection.JavaConversions._
+          attr ⇒ attr.asInstanceOf[java.util.HashMap[String, Any]].toMap
+        }
+
+      val jmxQuery: ObjectName = new ObjectName(query)
+      if (metricsExtension.shouldTrack(name, "kamon-mxbeans")) {
+
+        val subscriber = system.actorOf(
+          Props(classOf[ExportedMBeanQuery], system, jmxQuery, attrList,
+            identifyDelayInterval, identifyInterval, checkInterval),
+          name)
+      }
+    }
+  }
+
+  /**
+   * @param system actor system used by kamon
+   * @param jmxQuery query to lookup dynamic mbeans from the JVM
+   * @param attributeConfigs configuration for each attribute
+   * @param identifyDelayInterval how long to wait to look for mbeans the
+   * first time
+   * @param identifyInterval how often to look for new mbeans
+   * @param checkInterval how often to check for new values for metrics
+   */
+  def apply(
+    system: ExtendedActorSystem,
+    jmxQuery: ObjectName, attributeConfigs: Seq[Map[String, Any]],
+    identifyDelayInterval: Long, identifyInterval: Long,
+    checkInterval: Long): ExportedMBeanQuery =
+    new ExportedMBeanQuery(
+      system, jmxQuery, attributeConfigs,
+      identifyDelayInterval, identifyInterval, checkInterval)
+}
+
+/**
+ * Uses a jmx query to find dynamic mbeans and registers them to be listened
+ * to by kamon
+ * @param system actor system used by kamon
+ * @param jmxQuery query to use to look for new dynamic mbeans
+ * @param attributeConfig configuration of each metric for this kind of
+ * mbean
+ * @param identifyDelayInterval how long to wait to look for mbeans the
+ * first time
+ * @param identifyInterval how often to look for new mbeans
+ * @param checkInterval how often to check for new values for metrics
+ */
+class ExportedMBeanQuery(
+    val system: ExtendedActorSystem,
+    val jmxQuery: ObjectName, val attributeConfigs: Seq[Map[String, Any]],
+    val identifyDelayInterval: Long, val identifyInterval: Long,
+    val checkInterval: Long) extends Actor {
+
+  import context.dispatcher // ExecutionContext for the futures and scheduler
+  val log = Logging(system, getClass)
+
+  require(
+    identifyInterval >= checkInterval,
+    "not checking JMX values often enough: " +
+      identifyInterval + " < " + checkInterval)
+  import ExportedMBeanQuery.{ server, pred }
+  import ExportedMBean.{ apply }
+
+  val monitoredBeanNames: collection.mutable.Set[ObjectName] =
+    collection.mutable.Set[ObjectName]()
+  var lastCheck: Long = 0
+
+  val attributeNames: Array[String] = attributeConfigs.map { m ⇒
+    m("name").asInstanceOf[String]
+  }.toArray
+  val configMap: Map[String, Map[String, Any]] = attributeConfigs.map { conf ⇒
+    (conf("name").asInstanceOf[String], conf)
+  }.toMap
+
+  // queries the current set of dynamic mbeans and returns their identifing
+  // names
+  def getMBeanNames(): Set[ObjectName] = {
+    import collection.JavaConverters._
+    server.queryNames(jmxQuery, pred).asScala.toSet
+  }
+
+  /**
+   * looks for new dynamic mbeans and registers an object to watch those
+   * new mbeans for changes in their metric values and send them into kamon
+   * metrics
+   */
+  def rebuildRecorders(): Unit = {
+
+    import collection.JavaConverters._
+    val names: Set[ObjectName] = getMBeanNames()
+    log.debug("found JMX ObjectNames " + names)
+    names.filterNot { name ⇒
+      monitoredBeanNames.exists(_.equals(name))
+    }.foreach { name ⇒
+      val attrList: AttributeList =
+        server.getAttributes(name, attributeNames)
+      val attrs: Seq[Attribute] = attrList.asList().asScala
+      val values: Map[String, Attribute] =
+        attrs.map { attr ⇒ (attr.getName(), attr) }.toMap
+
+      val definitions: Seq[MetricDefinition] = values.map {
+        case (name, attr) ⇒
+          val config: Map[String, Any] = configMap(name)
+          if ("gauge".equalsIgnoreCase(
+            config("type").asInstanceOf[String])) {
+            new MetricDefinition(
+              config, null, new CurrentValueCollector {
+                def currentValue: Long = attr.getValue().asInstanceOf[Long]
+              })
+          } else {
+            new MetricDefinition(config, null, null)
+          }
+      }.toSeq
+
+      val metricsExtension = kamon.Kamon.metrics
+      metricsExtension.entity(
+        EntityRecorderFactory(
+          "kamon-mxbeans",
+          apply(
+            system, _, definitions, name, attributeNames, checkInterval)),
+        name.getKeyProperty("name"))
+
+      monitoredBeanNames += name
+    }
+  }
+
+  def receive: PartialFunction[Any, Unit] = {
+    case tick: TickMetricSnapshot ⇒ rebuildRecorders()
+  }
+
+  system.scheduler.schedule(
+    FiniteDuration(identifyDelayInterval, TimeUnit.MILLISECONDS),
+    FiniteDuration(identifyInterval, TimeUnit.MILLISECONDS),
+    new Runnable() {
+      def run(): Unit = rebuildRecorders()
+    })
+}
+
+/**
+ * An object that manages a specific dynamic mbean for kamon.
+ * @param system actor system used by kamon
+ * @param instrumentFactory kamon facade for making metrics
+ * @param definitions representations of each kamon metric in this mbean
+ * @param objName name of the JMX object to monitor
+ * @param attrNames jmx attributes to query for metric values
+ * @param checkInterval how often to check for new metric values from this
+ *  mbean
+ */
+class ExportedMBean(
+  val system: ExtendedActorSystem,
+  val instrumentFactory: InstrumentFactory,
+  val definitions: Seq[MetricDefinition], val objName: ObjectName,
+  val attrNames: Array[String], val checkInterval: Long)(
+    implicit ec: ExecutionContext)
+    extends GenericEntityRecorder(instrumentFactory) {
+
+  val log = Logging(system, getClass)
+  import kamon.jmx.extension.ExportedMBeanQuery.server
+
+  // metrics we created for this mbean
+  val counters: Map[String, Counter] =
+    definitions.filter(_.metricType == MetricTypeEnum.COUNTER).map(mdef ⇒
+      (mdef.name, makeCounter(mdef))).toMap
+  val histograms: Map[String, Histogram] =
+    definitions.filter(_.metricType == MetricTypeEnum.HISTOGRAM).map(mdef ⇒
+      (mdef.name, makeHistogram(mdef))).toMap
+  val minMaxCounters: Map[String, MinMaxCounter] =
+    definitions.filter(_.metricType == MetricTypeEnum.MIN_MAX_COUNTER).map(
+      mdef ⇒ (mdef.name, makeMinMaxCounter(mdef))).toMap
+  val gauges: Map[String, Gauge] =
+    definitions.filter(_.metricType == MetricTypeEnum.GAUGE).map(
+      mdef ⇒ (mdef.name, makeGauge(mdef))).toMap
+
+  def gatherMetrics(): Unit = {
+    import collection.JavaConverters._
+
+    try {
+      val attrList: AttributeList = server.getAttributes(objName, attrNames)
+      attrList.asList().asScala.foreach { attr ⇒
+        val attrName: String = attr.getName()
+        if (counters.contains(attrName)) {
+          counters(attrName).increment(attr.getValue().asInstanceOf[Long])
+        } else if (histograms.contains(attrName)) {
+          histogram(attrName).record(attr.getValue().asInstanceOf[Long])
+        } else if (minMaxCounters.contains(attrName)) {
+          val value: Long = attr.getValue().asInstanceOf[Long]
+          minMaxCounters(attrName).increment(value)
+        }
+      }
+    } catch {
+      case e: javax.management.JMException ⇒ log.error(e, e.getMessage())
+      case e1: Throwable                   ⇒ log.error(e1, e1.getMessage())
+    }
+  }
+
+  protected def makeCounter(mdef: MetricDefinition): Counter = {
+    require(mdef.metricType == MetricTypeEnum.COUNTER)
+    require(mdef.name != null, "a metric should have a name")
+    require(null == mdef.range, "a counter can't define a range")
+    require(
+      null == mdef.refreshInterval, "a counter can't define a refresh interval")
+    require(
+      null == mdef.valueCollector, "a counter can't define a value collector")
+    counter(mdef.name, mdef.unitOfMeasure)
+  }
+
+  protected def makeHistogram(mdef: MetricDefinition): Histogram = {
+    require(mdef.metricType == MetricTypeEnum.HISTOGRAM)
+    require(mdef.name != null, "a histogram should have a name")
+    require(
+      null == mdef.refreshInterval, "a histogram can't have a refresh interval")
+    require(
+      null == mdef.valueCollector, "a histogram can't have a value collector")
+    if (null == mdef.range) {
+      histogram(mdef.name, mdef.unitOfMeasure)
+    } else {
+      histogram(mdef.name, mdef.range, mdef.unitOfMeasure)
+    }
+  }
+
+  protected def makeMinMaxCounter(mdef: MetricDefinition): MinMaxCounter = {
+    require(mdef.metricType == MetricTypeEnum.MIN_MAX_COUNTER)
+    require(mdef.name != null, "a min-max counter must have a name")
+    require(
+      null == mdef.valueCollector,
+      "a min-max counter can't define a value collector")
+    if (null == mdef.range && null == mdef.refreshInterval) {
+      minMaxCounter(mdef.name, mdef.unitOfMeasure)
+    } else if (null == mdef.refreshInterval) {
+      minMaxCounter(mdef.name, mdef.range, mdef.unitOfMeasure)
+    } else if (null == mdef.range) {
+      minMaxCounter(mdef.name, mdef.refreshInterval, mdef.unitOfMeasure)
+    } else {
+      minMaxCounter(
+        mdef.name, mdef.range, mdef.refreshInterval, mdef.unitOfMeasure)
+    }
+  }
+
+  protected def makeGauge(mdef: MetricDefinition): Gauge = {
+    require(mdef.metricType == MetricTypeEnum.GAUGE)
+    require(mdef.name != null, "a gauge must have a name")
+    require(mdef.valueCollector != null, "a gauge must have a value collector")
+    if (null == mdef.range && null == mdef.refreshInterval) {
+      gauge(mdef.name, mdef.unitOfMeasure, mdef.valueCollector)
+    } else if (null == mdef.range) {
+      gauge(
+        mdef.name, mdef.refreshInterval, mdef.unitOfMeasure,
+        mdef.valueCollector)
+    } else if (null == mdef.refreshInterval) {
+      gauge(mdef.name, mdef.range, mdef.unitOfMeasure, mdef.valueCollector)
+    } else {
+      gauge(
+        mdef.name, mdef.range, mdef.refreshInterval, mdef.unitOfMeasure,
+        mdef.valueCollector)
+    }
+  }
+
+  system.scheduler.schedule(
+    FiniteDuration(checkInterval, TimeUnit.MILLISECONDS),
+    FiniteDuration(checkInterval, TimeUnit.MILLISECONDS),
+    new Runnable() {
+      def run(): Unit = gatherMetrics()
+    })
+  log.debug("scheduled reading of JMX metrics from " + objName)
+}
+
+object ExportedMBean {
+
+  /**
+   * @param system actor system used by kamon
+   * @param instrumentFactory kamon facade for making metrics
+   * @param definitions the configuration of metrics to push into kamon
+   * @param objName the name of the jmx object we are monitoring
+   * @param attrNames the names of the attributes we are monitoring
+   * @param checkInterval how often to check for new mbeans
+   */
+  def apply(
+    system: ExtendedActorSystem,
+    instrumentFactory: InstrumentFactory,
+    definitions: Seq[MetricDefinition],
+    objName: ObjectName, attrNames: Array[String],
+    checkInterval: Long)(implicit ec: ExecutionContext): ExportedMBean =
+    new ExportedMBean(
+      system, instrumentFactory, definitions, objName, attrNames,
+      checkInterval)
+}

--- a/kamon-jmx/src/main/scala/kamon/jmx/extension/JMXExtension.scala
+++ b/kamon-jmx/src/main/scala/kamon/jmx/extension/JMXExtension.scala
@@ -1,0 +1,34 @@
+
+package kamon.jmx.extension
+
+import java.io.File
+
+import scala.concurrent.duration.FiniteDuration
+
+import akka.actor._
+import akka.event.Logging
+
+import kamon.Kamon
+import kamon.util.ConfigTools.Syntax
+
+object JMXMetricImporter
+    extends ExtensionId[JMXMetricsExtension] with ExtensionIdProvider {
+
+  override def lookup(): ExtensionId[_ <: Extension] = JMXMetricImporter
+  override def createExtension(
+    system: ExtendedActorSystem): JMXMetricsExtension =
+    new JMXMetricsExtension(system)
+}
+
+/**
+ * A Kamon extension for reading metrics from JMX dynamic mbeans
+ */
+class JMXMetricsExtension(system: ExtendedActorSystem) extends Kamon.Extension {
+  val log = Logging(system, getClass)
+  log.info(s"Starting the Kamon(JMXMetrics) extension")
+
+  val config = system.settings.config.getConfig("kamon.kamon-mxbeans")
+  val metricsExtension = Kamon.metrics
+
+  ExportedMBeanQuery.register(system, metricsExtension, config)
+}

--- a/kamon-jmx/src/main/scala/kamon/jmx/extension/MetricDefinition.scala
+++ b/kamon-jmx/src/main/scala/kamon/jmx/extension/MetricDefinition.scala
@@ -1,0 +1,111 @@
+
+package kamon.jmx.extension
+
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import com.typesafe.config.Config
+
+import kamon.metric.{
+  GenericEntityRecorder,
+  MetricsModule,
+  EntityRecorderFactory
+}
+import kamon.metric.instrument._
+import kamon.metric.instrument.Histogram.DynamicRange
+import kamon.metric.instrument.Gauge.CurrentValueCollector
+
+case object MetricDefinition {
+
+  // enum of different types of kamon metrics
+  object MetricTypeEnum extends Enumeration {
+    type MetricType = Value
+    val COUNTER, HISTOGRAM, MIN_MAX_COUNTER, GAUGE = Value
+  }
+
+  import MetricTypeEnum._
+
+  def toMetricType(tpe: String): MetricType = tpe.toLowerCase match {
+    case "counter"         ⇒ MetricTypeEnum.COUNTER
+    case "histogram"       ⇒ MetricTypeEnum.HISTOGRAM
+    case "min_max_counter" ⇒ MetricTypeEnum.MIN_MAX_COUNTER
+    case "gauge"           ⇒ MetricTypeEnum.GAUGE
+    case _                 ⇒ throw new Exception("unknown metric type " + tpe)
+  }
+
+  // gets a kamon dynamic range from a config
+  def getDynamicRange(metricConfig: Map[String, Any]): DynamicRange =
+    if (metricConfig.contains("lowest") && metricConfig.contains("highest") &&
+      metricConfig.contains("precision")) {
+      DynamicRange(
+        metricConfig("lowest").asInstanceOf[Long],
+        metricConfig("highest").asInstanceOf[Long],
+        metricConfig("precision").asInstanceOf[Int])
+    } else {
+      null
+    }
+
+  // gets a unit of measure from a config
+  def getUnitOfMeasure(metricConfig: Map[String, Any]): UnitOfMeasurement =
+    if (metricConfig.contains("unit")) {
+      metricConfig("unit").asInstanceOf[String] match {
+        // memory based
+        case "b"  ⇒ Memory.Bytes
+        case "Kb" ⇒ Memory.KiloBytes
+        case "Mb" ⇒ Memory.MegaBytes
+        case "Gb" ⇒ Memory.GigaBytes
+        // time based
+        case "n"  ⇒ Time.Nanoseconds
+        case "µs" ⇒ Time.Microseconds
+        case "ms" ⇒ Time.Milliseconds
+        case "s"  ⇒ Time.Seconds
+      }
+    } else {
+      UnitOfMeasurement.Unknown
+    }
+
+  // gets a duration from a config
+  def getFiniteDuration(metricConfig: Map[String, Any]): FiniteDuration =
+    if (metricConfig.contains("interval")) {
+      val millis: Long = metricConfig("interval").asInstanceOf[Long]
+      new FiniteDuration(millis, TimeUnit.MILLISECONDS)
+    } else {
+      null
+    }
+}
+
+// scala sillyness
+import kamon.jmx.extension.MetricDefinition._
+
+/**
+ * This call represents one kamon metric which can be a counter, gauge,
+ * histogram or min-max counter.  It allows a metric to be represented
+ * in a config file.
+ */
+case class MetricDefinition(
+    val metricType: MetricTypeEnum.MetricType, val name: String,
+    unitOfMeasure: UnitOfMeasurement, // = UnitOfMeasurement.Unknown,
+    range: DynamicRange = null,
+    refreshInterval: FiniteDuration = null,
+    valueCollector: CurrentValueCollector = null) {
+
+  /**
+   * constructor that works from the values extracted from a config file
+   * @param metricConfig the metric's representation properties extracted
+   * from a config object
+   * @param name the name of this metric
+   * @param valueCollector if this metric is a gauge, then this class is used
+   * to get values from the instrumentation class (ie mbean)
+   */
+  def this(
+    metricConfig: Map[String, Any], name: String,
+    valueCollector: CurrentValueCollector) =
+    this(
+      toMetricType(metricConfig("type").asInstanceOf[String]),
+      if (name != null) name else metricConfig("name").asInstanceOf[String],
+      getUnitOfMeasure(metricConfig),
+      getDynamicRange(metricConfig),
+      getFiniteDuration(metricConfig),
+      valueCollector)
+}


### PR DESCRIPTION
Adding back a method to allow passing of a configuration into kamon but still allows for kamon's internal config to control the actor system responsible for metrics