### PR TITLE
more-flexible-kamon-config: adding back a method to allow passing of …

### DIFF
--- a/kamon-core/src/main/scala/kamon/Kamon.scala
+++ b/kamon-core/src/main/scala/kamon/Kamon.scala
@@ -42,14 +42,16 @@ object Kamon {
 
   trait Extension extends actor.Extension
 
+  def defaultConfig = ConfigFactory.load(this.getClass.getClassLoader, ConfigParseOptions.defaults(), ConfigResolveOptions.defaults().setAllowUnresolved(true))
+
   class KamonDefaultConfigProvider extends ConfigProvider {
     def config = resolveConfiguration
 
     private def resolveConfiguration: Config = {
-      val defaultConfig = ConfigFactory.load(this.getClass.getClassLoader, ConfigParseOptions.defaults(), ConfigResolveOptions.defaults().setAllowUnresolved(true))
+      val defaultConf = defaultConfig
 
-      defaultConfig.getString("kamon.config-provider") match {
-        case "default" ⇒ defaultConfig
+      defaultConf.getString("kamon.config-provider") match {
+        case "default" ⇒ defaultConf
         case fqcn ⇒
           val dynamic = new ReflectiveDynamicAccess(getClass.getClassLoader)
           dynamic.createInstanceFor[ConfigProvider](fqcn, Nil).get.config

--- a/kamon-core/src/main/scala/kamon/Kamon.scala
+++ b/kamon-core/src/main/scala/kamon/Kamon.scala
@@ -24,23 +24,59 @@ import kamon.util.logger.LazyLogger
 import _root_.scala.util.control.NonFatal
 import _root_.scala.util.{ Failure, Success, Try }
 
+trait ConfigProvider {
+  def config: Config
+
+  final def patchedConfig: Config = {
+    val internalConfig = config.getConfig("kamon.internal-config")
+    config
+      .withoutPath("akka")
+      .withoutPath("spray")
+      .withFallback(internalConfig)
+  }
+}
+
 object Kamon {
 
   private val log = LazyLogger("Kamon")
 
   trait Extension extends actor.Extension
 
-  val config = resolveConfiguration
-  val metrics = MetricsModuleImpl(config)
-  val tracer = TracerModuleImpl(metrics, config)
+  class KamonDefaultConfigProvider extends ConfigProvider {
+    def config = resolveConfiguration
+
+    private def resolveConfiguration: Config = {
+      val defaultConfig = ConfigFactory.load(this.getClass.getClassLoader, ConfigParseOptions.defaults(), ConfigResolveOptions.defaults().setAllowUnresolved(true))
+
+      defaultConfig.getString("kamon.config-provider") match {
+        case "default" ⇒ defaultConfig
+        case fqcn ⇒
+          val dynamic = new ReflectiveDynamicAccess(getClass.getClassLoader)
+          dynamic.createInstanceFor[ConfigProvider](fqcn, Nil).get.config
+      }
+    }
+  }
+
+  class KamonConfigProvider(_config: Config) extends ConfigProvider {
+    def config = _config
+  }
+
+  private[kamon] var configProvider: Option[ConfigProvider] = None
+  def config: Config =
+    configProvider match {
+      case Some(provider) ⇒ provider.config
+      case None           ⇒ throw new Exception("Kamon.start() not called yet")
+    }
+  lazy val metrics = MetricsModuleImpl(config)
+  lazy val tracer = TracerModuleImpl(metrics, config)
 
   private lazy val _system = {
-    val internalConfig = config.getConfig("kamon.internal-config")
-
-    val patchedConfig = config
-      .withoutPath("akka")
-      .withoutPath("spray")
-      .withFallback(internalConfig)
+    val patchedConfig =
+      configProvider match {
+        case Some(provider) ⇒ provider.patchedConfig
+        case None ⇒
+          throw new Exception("Kamon.start() not called yet")
+      }
 
     log.info("Initializing Kamon...")
 
@@ -55,7 +91,20 @@ object Kamon {
     _system.registerExtension(ModuleLoader)
   }
 
-  def start(): Unit = _start
+  def start(): Unit = {
+    configProvider = Some(new KamonDefaultConfigProvider())
+    _start
+  }
+
+  def start(conf: Config): Unit = {
+    configProvider = Some(new KamonConfigProvider(conf))
+    _start
+  }
+
+  def start(provider: ConfigProvider): Unit = {
+    configProvider = Some(provider)
+    _start
+  }
 
   def shutdown(): Unit = {
     _system.shutdown()
@@ -74,20 +123,4 @@ object Kamon {
       case Failure(NonFatal(reason)) ⇒ log.debug(s"Kamon-autoweave failed to load. Reason: ${reason.getMessage}.")
     }
   }
-
-  private def resolveConfiguration: Config = {
-    val defaultConfig = ConfigFactory.load(this.getClass.getClassLoader, ConfigParseOptions.defaults(), ConfigResolveOptions.defaults().setAllowUnresolved(true))
-
-    defaultConfig.getString("kamon.config-provider") match {
-      case "default" ⇒ defaultConfig.resolve()
-      case fqcn ⇒
-        val dynamic = new ReflectiveDynamicAccess(getClass.getClassLoader)
-        dynamic.createInstanceFor[ConfigProvider](fqcn, Nil).get.config
-    }
-  }
 }
-
-trait ConfigProvider {
-  def config: Config
-}
-

--- a/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
+++ b/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
@@ -34,7 +34,7 @@ abstract class BaseKamonSpec(actorSystemName: String) extends TestKitBase with W
 
   def config: Config = Kamon.defaultConfig
 
-  def mergedConfig: Config = ConfigFactory.load().withFallback(config)
+  def mergedConfig: Config = config.withFallback(Kamon.defaultConfig)
 
   def newContext(name: String): TraceContext =
     Kamon.tracer.newContext(name)

--- a/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
+++ b/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
@@ -18,7 +18,7 @@ package kamon.testkit
 
 import akka.actor.ActorSystem
 import akka.testkit.{ ImplicitSender, TestKitBase }
-import com.typesafe.config.Config
+import com.typesafe.config.{ Config, ConfigFactory }
 import kamon.Kamon
 import kamon.metric.{ Entity, EntitySnapshot, SubscriptionsDispatcher }
 import kamon.trace.TraceContext
@@ -28,12 +28,13 @@ import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 abstract class BaseKamonSpec(actorSystemName: String) extends TestKitBase with WordSpecLike with Matchers with ImplicitSender with BeforeAndAfterAll {
   lazy val collectionContext = Kamon.metrics.buildDefaultCollectionContext
   implicit lazy val system: ActorSystem = {
-    Kamon.start(config)
-    ActorSystem(actorSystemName, config)
+    Kamon.start(mergedConfig)
+    ActorSystem(actorSystemName, mergedConfig)
   }
 
-  def config: Config =
-    Kamon.config
+  def config: Config = ConfigFactory.load()
+
+  def mergedConfig: Config = ConfigFactory.load().withFallback(config)
 
   def newContext(name: String): TraceContext =
     Kamon.tracer.newContext(name)

--- a/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
+++ b/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
@@ -32,7 +32,7 @@ abstract class BaseKamonSpec(actorSystemName: String) extends TestKitBase with W
     ActorSystem(actorSystemName, mergedConfig)
   }
 
-  def config: Config = ConfigFactory.load()
+  def config: Config = Kamon.defaultConfig
 
   def mergedConfig: Config = ConfigFactory.load().withFallback(config)
 

--- a/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
+++ b/kamon-core/src/test/scala/kamon/testkit/BaseKamonSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 abstract class BaseKamonSpec(actorSystemName: String) extends TestKitBase with WordSpecLike with Matchers with ImplicitSender with BeforeAndAfterAll {
   lazy val collectionContext = Kamon.metrics.buildDefaultCollectionContext
   implicit lazy val system: ActorSystem = {
-    Kamon.start()
+    Kamon.start(config)
     ActorSystem(actorSystemName, config)
   }
 


### PR DESCRIPTION
adding back a method to allow passing of a configuration into kamon but still allows for kamon's internal config to control the actor system responsible for metrics
