### PR TITLE
+ kamon-play-25: AspectJ weaving for Play's Java logging API

### DIFF
--- a/kamon-play-2.5.x/src/main/resources/META-INF/aop.xml
+++ b/kamon-play-2.5.x/src/main/resources/META-INF/aop.xml
@@ -5,9 +5,11 @@
     <aspect name="kamon.play.instrumentation.RequestInstrumentation"/>
     <aspect name="kamon.play.instrumentation.WSInstrumentation"/>
     <aspect name="kamon.play.instrumentation.LoggerLikeInstrumentation"/>
+    <aspect name="kamon.play.instrumentation.ALoggerInstrumentation"/>
   </aspects>
 
    <weaver>
+       <include within="play.Logger..*"/>
        <include within="play.api..*"/>
    </weaver>
 </aspectj>

--- a/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/ALoggerInstrumentation.scala
+++ b/kamon-play-2.5.x/src/main/scala/kamon/play/instrumentation/ALoggerInstrumentation.scala
@@ -1,0 +1,45 @@
+/* =========================================================================================
+ * Copyright © 2013-2015 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.play.instrumentation
+
+import kamon.trace.logging.MdcKeysSupport
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation._
+
+@Aspect
+class ALoggerInstrumentation extends MdcKeysSupport {
+
+  @Pointcut("execution(* play.Logger..*.info(..))")
+  def infoPointcut(): Unit = {}
+
+  @Pointcut("execution(* play.Logger..*.debug(..))")
+  def debugPointcut(): Unit = {}
+
+  @Pointcut("execution(* play.Logger..*.warn(..))")
+  def warnPointcut(): Unit = {}
+
+  @Pointcut("execution(* play.Logger..*.error(..))")
+  def errorPointcut(): Unit = {}
+
+  @Pointcut("execution(* play.Logger..*.trace(..))")
+  def tracePointcut(): Unit = {}
+
+  @Around("(infoPointcut() || debugPointcut() || warnPointcut() || errorPointcut() || tracePointcut())")
+  def aroundLog(pjp: ProceedingJoinPoint): Any = withMdc {
+    pjp.proceed()
+  }
+}
+


### PR DESCRIPTION
The Kamon tracing token didn't work for logging in Play projects using the Java API because the Java API uses a different logging wrapper class.
This PR adds aspectj weaving for this class from the Java API.