### PR TITLE
influxdb: don't send zeroes when histogram is empty

### DIFF
--- a/kamon-influxdb/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
+++ b/kamon-influxdb/src/main/scala/kamon/influxdb/BatchInfluxDBMetricsPacker.scala
@@ -38,7 +38,7 @@ case class BatchInfluxDBMetricsPacker(config: Config) extends InfluxDBMetricsPac
 
       metricSnapshot match {
         case hs: Histogram.Snapshot ⇒
-          packetBuilder.appendMeasurement(s"$application-timers", tags, histogramValues(hs), timestamp * 1000000)
+          if (!hs.isEmpty) packetBuilder.appendMeasurement(s"$application-timers", tags, histogramValues(hs), timestamp * 1000000)
         case cs: Counter.Snapshot ⇒
           packetBuilder.appendMeasurement(s"$application-counters", tags, Map("value" -> BigDecimal(cs.count)), timestamp * 1000000)
       }


### PR DESCRIPTION
Previous behavior: When a histogram has no records, Kamon sends zeroes.
It's not possible to differenciate between the absence of value, and a value of zero.

New behavior: Kamon doesn't send data for empty histograms.