### PR TITLE
+ autoweave: start agent if necessary

### DIFF
--- a/kamon-autoweave/src/main/resources/reference.conf
+++ b/kamon-autoweave/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ kamon {
     options {
        verbose = false
        show-weave-info = false
-       enabled = false
+       enabled = true
        enabled = ${?AUTO_WEAVE_ENABLED}
     }
   }

--- a/kamon-autoweave/src/main/resources/reference.conf
+++ b/kamon-autoweave/src/main/resources/reference.conf
@@ -7,6 +7,8 @@ kamon {
     options {
        verbose = false
        showWeaveInfo = false
+       shouldStart = true
+       shouldStart = ${?AUTOWEAVE_SHOULD_START}
     }
   }
 }

--- a/kamon-autoweave/src/main/resources/reference.conf
+++ b/kamon-autoweave/src/main/resources/reference.conf
@@ -6,9 +6,9 @@ kamon {
   autowave {
     options {
        verbose = false
-       showWeaveInfo = false
-       shouldStart = true
-       shouldStart = ${?AUTOWEAVE_SHOULD_START}
+       show-weave-info = false
+       enabled = false
+       enabled = ${?AUTO_WEAVE_ENABLED}
     }
   }
 }

--- a/kamon-autoweave/src/main/scala/kamon/autoweave/Autoweave.scala
+++ b/kamon-autoweave/src/main/scala/kamon/autoweave/Autoweave.scala
@@ -26,11 +26,12 @@ class Autoweave {
   val config = Kamon.config.getConfig("kamon.autowave.options")
   val verbose = config.getBoolean("verbose")
   val showWeaveInfo = config.getBoolean("showWeaveInfo")
-
-  def attach(): Unit = {
+  val shouldStart = config.getBoolean("shouldStart")
+  
+  def attach(): Unit = if (shouldStart) {
     Try(Agent.getInstrumentation) match {
-      case Success(_) => throw new RuntimeException("AspectJ weaving agent was started via '-javaagent'") with NoStackTrace
-      case Failure(NonFatal(_)) =>
+      case Success(_) ⇒ throw new RuntimeException("AspectJ weaving agent was started via '-javaagent'") with NoStackTrace
+      case Failure(NonFatal(_)) ⇒
         System.setProperty("aj.weaving.verbose", verbose.toString)
         System.setProperty("org.aspectj.weaver.showWeaveInfo", showWeaveInfo.toString)
 

--- a/kamon-autoweave/src/main/scala/kamon/autoweave/Autoweave.scala
+++ b/kamon-autoweave/src/main/scala/kamon/autoweave/Autoweave.scala
@@ -17,18 +17,20 @@ package kamon.autoweave
 
 import kamon.Kamon
 import kamon.autoweave.loader.AgentLoader
+import kamon.util.logger.LazyLogger
 import org.aspectj.weaver.loadtime.Agent
 
 import scala.util.control.{NoStackTrace, NonFatal}
 import scala.util.{Failure, Success, Try}
 
 class Autoweave {
+  val log = LazyLogger(classOf[Agent])
   val config = Kamon.config.getConfig("kamon.autowave.options")
   val verbose = config.getBoolean("verbose")
-  val showWeaveInfo = config.getBoolean("showWeaveInfo")
-  val shouldStart = config.getBoolean("shouldStart")
-  
-  def attach(): Unit = if (shouldStart) {
+  val showWeaveInfo = config.getBoolean("show-weave-info")
+  val enabled = config.getBoolean("enabled")
+
+  def attach(): Unit = if (enabled) {
     Try(Agent.getInstrumentation) match {
       case Success(_) ⇒ throw new RuntimeException("AspectJ weaving agent was started via '-javaagent'") with NoStackTrace
       case Failure(NonFatal(_)) ⇒
@@ -37,5 +39,5 @@ class Autoweave {
 
         AgentLoader.attachAgentToJVM(classOf[Agent])
     }
-  }
+  } else log.warn("Autoweave disabled by configuration.")
 }

--- a/kamon-autoweave/src/main/scala/kamon/autoweave/Autoweave.scala
+++ b/kamon-autoweave/src/main/scala/kamon/autoweave/Autoweave.scala
@@ -24,7 +24,7 @@ import scala.util.control.{NoStackTrace, NonFatal}
 import scala.util.{Failure, Success, Try}
 
 class Autoweave {
-  val log = LazyLogger(classOf[Agent])
+  val log = LazyLogger(classOf[Autoweave])
   val config = Kamon.config.getConfig("kamon.autowave.options")
   val verbose = config.getBoolean("verbose")
   val showWeaveInfo = config.getBoolean("show-weave-info")


### PR DESCRIPTION
* The autoweave module should only try to start the agent only if not was neither started via '-javaagent' (preMain) nor attached via 'VirtualMachine.loadAgent' (agentMain)