### PR TITLE
Changes to make kamon-core OSGI ready

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,16 +16,29 @@
 parallelExecution in Test in Global := false
 
 lazy val kamon = (project in file("."))
+  .enablePlugins(SbtOsgi)
   .settings(moduleName := "root")
   .settings(noPublishing: _*)
   .aggregate(core, autoweave, testkit, bench)
 
 
 lazy val core = (project in file("kamon-core"))
+  .enablePlugins(SbtOsgi)
+  .settings(osgiSettings)
+  .settings(OsgiKeys.exportPackage := Seq("kamon.*", "org.HdrHistogram;-split-package:=merge-first"))
+  .settings(OsgiKeys.importPackage := Seq(
+          "kamon.autoweave;resolution:=optional",
+          "org.aspectj.lang;resolution:=optional",
+          "org.aspectj.lang.annotation;resolution:=optional",
+          "javax.xml.bind;resolution:=optional",
+          "sun.misc;resolution:=optional",
+          "ch.qos.logback.classic.pattern;resolution:=optional",
+          "ch.qos.logback.classic.spi;resolution:=optional",
+          "*"))
   .settings(moduleName := "kamon-core")
   .settings(
         libraryDependencies ++=
-          compileScope(akkaDependency("actor").value, hdrHistogram, slf4jApi) ++
+          compileScope(akkaDependency("actor").value, akkaDependency("osgi").value, hdrHistogram, slf4jApi) ++
           providedScope(aspectJ) ++
           optionalScope(logbackClassic) ++
           testScope(scalatest, akkaDependency("testkit").value, akkaDependency("slf4j").value, logbackClassic))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 resolvers += Resolver.bintrayIvyRepo("kamon-io", "sbt-plugins")
 addSbtPlugin("io.kamon" % "kamon-sbt-umbrella" % "0.0.12")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.1")
 


### PR DESCRIPTION
To make kamon-core OSGI ready I've added new dependency (to create OsgiActorSystem instead of ActorSystem), for that we need to have BundleContext, so I've created two new methods in the Kamon:
startWithinOsgi(context: BundleContext)
startWithinOsgi(conf: Config, context: BundleContext)

To make them working I also had to adjust Kamon class a bit.

Another required change - to generate proper OSGI manifest I've added SbtOsgi plugin + proper configuration.

This is done only for kamon-core module so far.

P.S. I've never used neither scala, nor sbt before, so code might be not the best. Fell free to adjust it if needed.