### PR TITLE
Add default metrics loaded from config

### DIFF
--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -167,4 +167,15 @@ kamon {
     # Just a place holder to ensure that the key is always available. Non-core Kamon modules should provide their
     # settings in a module-info section.
   }
+
+  # Add tags to all reported metrics. Can be useful to identify the source of metrics from a particluar JVM instance.
+  # Example:
+  #
+  # default-tags {
+  #   host: ${?HOSTNAME}
+  #   container-name: ${?CONTAINER_NAME}
+  # }
+  default-tags {
+
+  }
 }

--- a/kamon-core/src/test/resources/application.conf
+++ b/kamon-core/src/test/resources/application.conf
@@ -12,4 +12,15 @@ kamon {
     level-of-detail = simple-trace
     sampling = all
   }
+
+  default-tags = {
+    name = "jason"
+    number = 42
+    username = ${USER}
+    list = [1, 2, 3] // lists do not make sense for a tag
+    object = {
+      nested-bool = true
+      nested-string = "a string"
+    }
+  }
 }


### PR DESCRIPTION
We are using Kubernetes for our apps, and there is currently no way to add tags to the jmx stats. This means that all of the JMX metrics have no tags for the container (aka pod in k8) they are running on, and thus you can only see aggregate java metrics for groups of containers. This is at least *a* solution to the problem mentioned in #210. 

I'm not 100% sure if this will do what I want, but thought it would be a good starting place and perhaps you would have a better idea about how to solve this problem. 