### PR TITLE
Add cross-compile to travis build

### DIFF
--- a/kamon-core/src/main/scala-2.10/kamon/ActorSystemTools.scala
+++ b/kamon-core/src/main/scala-2.10/kamon/ActorSystemTools.scala
@@ -19,12 +19,7 @@ import scala.util.control.NonFatal
 import akka.actor.ActorSystem
 
 object ActorSystemTools {
-  //first try akka 2.4 system terminate() and then failover to akka 2.3 system shutdown()
   private[kamon] def terminateActorSystem(system: ActorSystem): Unit = {
-    try {
-      system.terminate()
-    } catch {
-      case NonFatal(e) => system.shutdown()
-    }
+    system.shutdown()
   }
 }

--- a/kamon-core/src/main/scala-2.11/kamon/ActorSystemTools.scala
+++ b/kamon-core/src/main/scala-2.11/kamon/ActorSystemTools.scala
@@ -1,0 +1,25 @@
+/* =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package kamon
+
+import scala.util.control.NonFatal
+
+import akka.actor.ActorSystem
+
+object ActorSystemTools {
+  private[kamon] def terminateActorSystem(system: ActorSystem): Unit = {
+    system.shutdown()
+  }
+}

--- a/kamon-core/src/main/scala-2.12/kamon/ActorSystemTools.scala
+++ b/kamon-core/src/main/scala-2.12/kamon/ActorSystemTools.scala
@@ -1,0 +1,25 @@
+/* =========================================================================================
+ * Copyright © 2013-2016 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+package kamon
+
+import akka.actor.ActorSystem
+
+import scala.util.control.NonFatal
+
+object ActorSystemTools {
+  private[kamon] def terminateActorSystem(system: ActorSystem): Unit = {
+    system.terminate()
+  }
+}

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -6,6 +6,7 @@ runTests () {
   sbt -Dakka.test.timefactor=1.5                                                                              \
       'set concurrentRestrictions in Global += Tags.limit(Tags.Compile, 2)'                                   \
       'set testOptions in test in Global := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-oUNCXHELPOQRM"))'  \
+      '+ compile' \
       test || exit 1
 
   echo "[info] $(date) - finished sbt test"


### PR DESCRIPTION
This should prevent build failures from alternate Scala versions from being merged into master. 