### PR TITLE
disable akka-remote

### DIFF
--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -146,11 +146,14 @@ kamon {
   # system and Spray facilities used by Kamon.
   internal-config {
 
-    akka.actor.default-dispatcher {
-      fork-join-executor {
-        parallelism-min = 2
-        parallelism-factor = 2.0
-        parallelism-max = 10
+    akka.actor {
+      provider = "local"
+      default-dispatcher {
+        fork-join-executor {
+          parallelism-min = 2
+          parallelism-factor = 2.0
+          parallelism-max = 10
+        }
       }
     }
 


### PR DESCRIPTION
Akka remote gets configured if dependency is on the class path.
This can be annoying because it binds to the default port, often the same used by application actor system.

Remote can be disabled by setting provider = "local".
This change makes sure that kamon's akka system won't start akka-remote inadvertently.