### PR TITLE
Log warn when Entity with name=null is created / if dispatching entities fails

### DIFF
--- a/kamon-core/src/main/scala/kamon/metric/Entity.scala
+++ b/kamon-core/src/main/scala/kamon/metric/Entity.scala
@@ -16,6 +16,8 @@
 
 package kamon.metric
 
+import org.slf4j.LoggerFactory
+
 /**
  *  Identify a `thing` that is being monitored by Kamon. A [[kamon.metric.Entity]] is used to identify tracked `things`
  *  in both the metrics recording and reporting sides. Only the name and category fields are used with determining
@@ -23,9 +25,14 @@ package kamon.metric
  *
  *  // TODO: Find a better word for `thing`.
  */
-case class Entity(name: String, category: String, tags: Map[String, String])
+case class Entity(name: String, category: String, tags: Map[String, String]) {
+  if(name == null) Entity.log.warn("Entity with name=null created (category: {}), your monitoring will not work as expected!", category)
+}
 
 object Entity {
+
+  private lazy val log = LoggerFactory.getLogger(classOf[Entity])
+
   def apply(name: String, category: String): Entity =
     apply(name, category, Map.empty)
 


### PR DESCRIPTION
An application that creates a metric while passing `null` as metrics name
will not receive the expected `TickMetricSnapshot` (if it subscribes for
metrics).

As log level _warn_ (instead of error) is chosen, because from an application
perspective the app's functionality is not affected, i.e. there's no _immediate_
action required, but it's ok if this gets solved eventually.