### PR TITLE
Kamon 1.0 develop

### DIFF
--- a/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -158,7 +158,6 @@ class Span(spanContext: SpanContext, initialOperationName: String, initialTags: 
     }
 
     val refinedTags = if(isError) {
-      Span.Metrics.SpanErrorCount.refine(metricTags).increment()
       metricTags + ("error" -> Span.BooleanTagTrueValue)
     } else {
       metricTags

--- a/kamon-core/src/test/scala/kamon/trace/SpanMetrics.scala
+++ b/kamon-core/src/test/scala/kamon/trace/SpanMetrics.scala
@@ -1,0 +1,70 @@
+package kamon.trace
+
+import kamon.Kamon
+import kamon.Kamon.buildSpan
+import kamon.metric._
+import org.scalatest.{Matchers, WordSpecLike}
+
+class SpanMetrics extends WordSpecLike with Matchers {
+  import SpanMetricsTestHelper._
+
+  val errorTag = "error" -> Span.BooleanTagTrueValue
+  val histogramMetric: HistogramMetric = Kamon.histogram("span.elapsed-time")
+
+  "Span Metrics" should {
+    "be recorded for successeful execution" in {
+      val operation = "span-success"
+      val operationTag = "operation" -> operation
+
+      val span = buildSpan(operation).startManual()
+      span.finish()
+
+
+      val histogram = histogramMetric.refine(operationTag)
+      histogram.distribution().count === 1
+
+      val errorHistogram = histogramMetric.refine(operationTag, errorTag).distribution()
+      errorHistogram.count === 0
+
+      val errorCount = histogramMetric.refine(operationTag, errorTag).distribution()
+      errorCount === 0
+    }
+
+    "record correctly error latency and count" in {
+      val operation = "span-failure"
+      val operationTag = "operation" -> operation
+
+      val span = buildSpan(operation).startManual()
+      span.setTag("error", Span.BooleanTagTrueValue)
+      span.finish()
+
+      val histogram = histogramMetric.refine(operationTag)
+      histogram.distribution().count === 0
+
+      val errorHistogram = histogramMetric.refine(operationTag, errorTag).distribution()
+      errorHistogram.count === 1
+
+      val errorCount = histogramMetric.refine(operationTag, errorTag).distribution()
+      errorCount === 1
+    }
+  }
+
+}
+
+object SpanMetricsTestHelper {
+
+  implicit class HistogramMetricSyntax(histogram: Histogram) {
+    def distribution(resetState: Boolean = true): Distribution =
+      histogram match {
+        case hm: HistogramMetric    => hm.refine(Map.empty[String, String]).distribution(resetState)
+        case h: AtomicHdrHistogram  => h.snapshot(resetState).distribution
+        case h: HdrHistogram        => h.snapshot(resetState).distribution
+      }
+  }
+
+
+
+}
+
+
+

--- a/kamon-core/src/test/scala/kamon/trace/SpanMetrics.scala
+++ b/kamon-core/src/test/scala/kamon/trace/SpanMetrics.scala
@@ -26,8 +26,6 @@ class SpanMetrics extends WordSpecLike with Matchers {
       val errorHistogram = histogramMetric.refine(operationTag, errorTag).distribution()
       errorHistogram.count === 0
 
-      val errorCount = histogramMetric.refine(operationTag, errorTag).distribution()
-      errorCount === 0
     }
 
     "record correctly error latency and count" in {
@@ -44,8 +42,6 @@ class SpanMetrics extends WordSpecLike with Matchers {
       val errorHistogram = histogramMetric.refine(operationTag, errorTag).distribution()
       errorHistogram.count === 1
 
-      val errorCount = histogramMetric.refine(operationTag, errorTag).distribution()
-      errorCount === 1
     }
   }
 


### PR DESCRIPTION
For spans containing errors, separate metric needs to be tracked in order not to pollute successful span metrics