### PR TITLE
Use instant for spans

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/trace/LocalSpanSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/LocalSpanSpec.scala
@@ -15,6 +15,8 @@
 
 package kamon.trace
 
+import java.time.Instant
+
 import kamon.testkit.{MetricInspection, Reconfigure, TestSpanReporter}
 import kamon.util.Registration
 import kamon.Kamon
@@ -31,17 +33,17 @@ class LocalSpanSpec extends WordSpec with Matchers with BeforeAndAfterAll with E
       "be sent to the Span reporters" in {
         Kamon.buildSpan("test-span")
           .withTag("test", "value")
-          .withStartTimestamp(100)
+          .withFrom(Instant.EPOCH.plusSeconds(1))
           .disableMetrics()
           .enableMetrics()
           .start()
-          .finish(200)
+          .finish(Instant.EPOCH.plusSeconds(10))
 
         eventually(timeout(2 seconds)) {
           val finishedSpan = reporter.nextSpan().value
           finishedSpan.operationName shouldBe("test-span")
-          finishedSpan.startTimestampMicros shouldBe 100
-          finishedSpan.endTimestampMicros shouldBe 200
+          finishedSpan.from shouldBe Instant.EPOCH.plusSeconds(1)
+          finishedSpan.to shouldBe Instant.EPOCH.plusSeconds(10)
           finishedSpan.tags should contain("test" -> TagValue.String("value"))
         }
       }
@@ -52,22 +54,22 @@ class LocalSpanSpec extends WordSpec with Matchers with BeforeAndAfterAll with E
           .withTag("builder-boolean-tag-true", true)
           .withTag("builder-boolean-tag-false", false)
           .withTag("builder-number-tag", 42)
-          .withStartTimestamp(100)
+          .withFrom(Instant.EPOCH.plusSeconds(1))
           .start()
           .tag("span-string-tag", "value")
           .tag("span-boolean-tag-true", true)
           .tag("span-boolean-tag-false", false)
           .tag("span-number-tag", 42)
           .mark("my-mark")
-          .mark(100, "my-custom-timetamp-mark")
+          .mark(Instant.EPOCH.plusSeconds(4), "my-custom-timetamp-mark")
           .setOperationName("fully-populated-span")
-          .finish(200)
+          .finish(Instant.EPOCH.plusSeconds(10))
 
         eventually(timeout(2 seconds)) {
           val finishedSpan = reporter.nextSpan().value
           finishedSpan.operationName shouldBe ("fully-populated-span")
-          finishedSpan.startTimestampMicros shouldBe 100
-          finishedSpan.endTimestampMicros shouldBe 200
+          finishedSpan.from shouldBe Instant.EPOCH.plusSeconds(1)
+          finishedSpan.to shouldBe Instant.EPOCH.plusSeconds(10)
           finishedSpan.tags should contain allOf(
             "builder-string-tag" -> TagValue.String("value"),
             "builder-boolean-tag-true" -> TagValue.True,
@@ -82,7 +84,7 @@ class LocalSpanSpec extends WordSpec with Matchers with BeforeAndAfterAll with E
             "my-mark",
             "my-custom-timetamp-mark"
           )
-          finishedSpan.marks.find(_.key == "my-custom-timetamp-mark").value.timestampMicros should be(100)
+          finishedSpan.marks.find(_.key == "my-custom-timetamp-mark").value.instant should be(Instant.EPOCH.plusSeconds(4))
 
         }
       }

--- a/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
@@ -15,6 +15,8 @@
 
 package kamon.trace
 
+import java.time.Instant
+
 import com.typesafe.config.ConfigFactory
 import kamon.Kamon
 import kamon.context.Context
@@ -85,9 +87,9 @@ class TracerSpec extends WordSpec with Matchers with SpanBuilding with SpanInspe
     }
 
     "allow overriding the start timestamp for a Span" in {
-      val span = tracer.buildSpan("myOperation").withStartTimestamp(100).start()
+      val span = tracer.buildSpan("myOperation").withFrom(Instant.EPOCH.plusMillis(321)).start()
       val spanData = inspect(span)
-      spanData.startTimestamp() shouldBe 100
+      spanData.from() shouldBe Instant.EPOCH.plusMillis(321)
     }
 
     "preserve the same Span and Parent identifier when creating a Span with a remote parent if join-remote-parents-with-same-span-id is enabled" in {

--- a/kamon-testkit/src/main/scala/kamon/testkit/SpanInspection.scala
+++ b/kamon-testkit/src/main/scala/kamon/testkit/SpanInspection.scala
@@ -15,10 +15,11 @@
 
 package kamon.testkit
 
+import java.time.Instant
+
 import kamon.Kamon
 import kamon.trace.{Span, SpanContext}
 import kamon.trace.Span.FinishedSpan
-import kamon.util.Clock
 
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -38,7 +39,7 @@ object SpanInspection {
         case other => sys.error(s"Only Span.Local can be inspected but got [${other.getClass.getName}]" )
       }
 
-      val spanData = invoke[Span.Local, FinishedSpan](realSpan, "toFinishedSpan", classOf[Long] -> Long.box(Kamon.clock().micros()))
+      val spanData = invoke[Span.Local, FinishedSpan](realSpan, "toFinishedSpan", classOf[Instant] -> Kamon.clock().instant())
       (realSpan, spanData)
     }.getOrElse((null, null))
 
@@ -54,8 +55,8 @@ object SpanInspection {
     def metricTags(): Map[String, String] =
       getField[Span.Local, Map[String, String]](realSpan, "customMetricTags")
 
-    def startTimestamp(): Long =
-      getField[Span.Local, Long](realSpan, "startTimestampMicros")
+    def from(): Instant =
+      getField[Span.Local, Instant](realSpan, "from")
 
     def context(): SpanContext =
       spanData.context

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-RC5"
+version in ThisBuild := "1.0.0-RC6-SNAPSHOT"


### PR DESCRIPTION
Stop using plain Long values and use java.util.Instant instead. Even though Java 8 doesn't support nanosecond precision in the default clocks, the data structure supports it and we extended the trick we had in our clock to work with relative nanos so that it works now with Instant, then changed the timestamps in the tracer to use Instant.

Using plain calls to System.nanoTime() is about 23 ns/ops and this new Instant creation is about 30 ns/ops. Need to formalize the JMH project and push it up. It's a bit more expensive but nothing really noticeable when compared to actual work done in a given Span.