### PR TITLE
Add warning when no reporters are loaded

### DIFF
--- a/kamon-core/src/main/scala/kamon/ReporterRegistry.scala
+++ b/kamon-core/src/main/scala/kamon/ReporterRegistry.scala
@@ -200,7 +200,7 @@ object ReporterRegistry {
       if(newConfig.metricTickInterval != registryConfiguration.metricTickInterval && metricReporters.nonEmpty)
         reStartMetricTicker()
 
-      if(newConfig.traceTickInterval != registryConfiguration.metricTickInterval && spanReporters.nonEmpty)
+      if(newConfig.traceTickInterval != registryConfiguration.traceTickInterval && spanReporters.nonEmpty)
         reStartTraceTicker()
 
       // Reconfigure all registered reporters


### PR DESCRIPTION
While adding a warning about nothing to collect, I think I noticed a bug with the comparison about `traceTickInterval`.

The warning is good when people don't even know if Kamon is loading. They'll at least see something in their logs this way.