### PR TITLE
allow arbitrary header names for automatic broadcast string keys, fixes #505

### DIFF
--- a/kamon-core-tests/src/test/resources/reference.conf
+++ b/kamon-core-tests/src/test/resources/reference.conf
@@ -1,0 +1,5 @@
+kamon {
+  context.codecs.string-keys {
+    request-id = "X-Request-ID"
+  }
+}

--- a/kamon-core-tests/src/test/scala/kamon/context/ContextCodecSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/context/ContextCodecSpec.scala
@@ -48,6 +48,14 @@ class ContextCodecSpec extends WordSpec with Matchers with ContextTesting with O
         decodedContext.get(StringKey) shouldBe empty
         decodedContext.get(StringBroadcastKey).value shouldBe "this-should-be-round-tripped"
       }
+
+      "read string broadcast keys using the configured header name" in {
+        val textMap = TextMap.Default()
+        textMap.put("X-Request-ID", "123456")
+        val decodedContext = ContextCodec.HttpHeaders.decode(textMap)
+
+        decodedContext.get(Key.broadcastString("request-id")).value shouldBe "123456"
+      }
     }
 
     "encoding/decoding to Binary" should {

--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -150,7 +150,24 @@ kamon {
       # Size of the encoding buffer for the Binary Codec.
       binary-buffer-size = 256
 
-      string-keys = [ ]
+      # Declarative definition of broadcast context keys with type Option[String]. The setting key represents the actual
+      # key name and the value is the HTTP header name to be used to encode/decode the context key. The key name will
+      # be used when coding for binary transport. The most common use case for string keys is effortless propagation of
+      # correlation keys or request related data (locale, user ID, etc). E.g. if wanting to propagate a "X-Request-ID"
+      # header this config should suffice:
+      #
+      # kamon.context.codecs.string-keys {
+      #   request-id = "X-Request-ID"
+      # }
+      #
+      # If the application must read this context key they can define key with a matching name and read the value from
+      # the context:
+      #   val requestIDKey = Key.broadcastString("request-id") // Do this only once, keep a reference.
+      #   val requestID = Kamon.currentContext().get(requestIDKey)
+      #
+      string-keys {
+
+      }
 
       # Codecs to be used when propagating a Context through a HTTP Headers transport.
       http-headers-keys {

--- a/kamon-testkit/src/main/resources/reference.conf
+++ b/kamon-testkit/src/main/resources/reference.conf
@@ -1,5 +1,7 @@
 kamon {
   context.codecs {
-    string-keys = [ "string-broadcast-key" ]
+    string-keys {
+      string-broadcast-key = "X-string-broadcast-key"
+    }
   }
 }


### PR DESCRIPTION
This PR is changing the way `kamon.context.codecs.string-keys` is read from a regular string list to a object. The object allows to have a key name and the correspondent HTTP header name for it. This should make it extremely simple to integrate with things like LinkerD or Envoy, plus the typical cases of correlation fields and external request ids.

Fixes #505 