### PR TITLE
add support for environment tags, fixes #510

### DIFF
--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -11,6 +11,18 @@ kamon {
 
     # Identifier for a particular instance of this service. If set to `auto` Kamon will use the pattern service@host.
     instance = "auto"
+
+    # Arbitraty key-value pairs that further identify the environment where this service instance is running. Typically
+    # these tags will be used by the reporting modules as additional tags for all metrics or spans. Take a look at each
+    # reporter module's configuration to ensure these tags are supported and included in the reported data. Example:
+    #
+    # kamon.environment.tags {
+    #   env = "staging"
+    #   region = "us-east-1"
+    # }
+    tags {
+
+    }
   }
 
   # FQCN of the reporter instances that should be loaded when calling `Kamon.reporters.loadReportersFromConfig()`. All


### PR DESCRIPTION
Tags are read from the environment configuration but that's it, the decision to whether include them or not in reported data will be made by each reporting module. I think the default behavior in all reporters should be to include the environment tags and have a config setting to opt out of that behavior.