### PR TITLE
add the EnvironmentTagBuilder utility class

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagBuilderSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagBuilderSpec.scala
@@ -1,0 +1,104 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon
+package util
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{Matchers, WordSpec}
+
+class EnvironmentTagBuilderSpec extends WordSpec with Matchers {
+  private val testEnv = Environment.fromConfig(ConfigFactory.parseString(
+    """
+      |kamon.environment {
+      |  service = environment-spec
+      |  host = my-hostname
+      |  instance = my-instance-name
+      |
+      |  tags {
+      |    env = staging
+      |    region = asia-1
+      |  }
+      |}
+    """.stripMargin
+  ).withFallback(ConfigFactory.defaultReference()))
+
+  "the EnvironmentTagBuilder" should {
+
+    "build the tags from a configuration using the current Environment" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = yes
+          |host = yes
+          |instance = yes
+          |blacklisted-tags = []
+        """.stripMargin)
+
+      val env = Kamon.environment
+      val tags = EnvironmentTagBuilder.create(config)
+      tags("service") shouldBe env.service
+      tags("host") shouldBe env.host
+      tags("instance") shouldBe env.instance
+    }
+
+    "build tags from a custom Environment" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = yes
+          |host = yes
+          |instance = yes
+          |blacklisted-tags = []
+        """.stripMargin)
+
+      val tags = EnvironmentTagBuilder.create(testEnv, config)
+      tags("service") shouldBe testEnv.service
+      tags("host") shouldBe testEnv.host
+      tags("instance") shouldBe testEnv.instance
+      tags("env") shouldBe "staging"
+      tags("region") shouldBe "asia-1"
+
+    }
+
+    "remove blacklisted tags" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = yes
+          |host = yes
+          |instance = yes
+          |blacklisted-tags = [ "region" ]
+        """.stripMargin)
+
+      val tags = EnvironmentTagBuilder.create(testEnv, config)
+      tags("service") shouldBe testEnv.service
+      tags("host") shouldBe testEnv.host
+      tags("instance") shouldBe testEnv.instance
+      tags("env") shouldBe "staging"
+      tags.get("region") shouldBe empty
+    }
+
+    "remove all disabled elements" in {
+      val config = ConfigFactory.parseString(
+        """
+          |service = no
+          |host = no
+          |instance = no
+          |blacklisted-tags = [ "region", "env" ]
+        """.stripMargin)
+
+      val tags = EnvironmentTagBuilder.create(testEnv, config)
+      tags shouldBe empty
+    }
+  }
+}

--- a/kamon-core/src/main/scala/kamon/util/EnvironmentTagBuilder.scala
+++ b/kamon-core/src/main/scala/kamon/util/EnvironmentTagBuilder.scala
@@ -1,0 +1,43 @@
+package kamon.util
+
+import com.typesafe.config.Config
+import kamon.{Environment, Kamon}
+
+import scala.collection.JavaConverters._
+
+
+/**
+  *   Utility class to create a Map[String, String] encoding all the Environment information based on the provided
+  *   Config. The Config instance is expected to have the following members:
+  *
+  *     - service:          Boolean. If true a service tag is included.
+  *     - host:             Boolean. If true a host tag is included.
+  *     - instance:         Boolean. If true a instance tag is included.
+  *     - blacklisted-tags: List[String]. List of Environment tags that should not be included in the result.
+  *
+  *   This utility is meant to be used mostly by reporter modules.
+  *
+  */
+object EnvironmentTagBuilder {
+
+  def create(config: Config): Map[String, String] =
+    create(Kamon.environment, config)
+
+  def create(env: Environment, config: Config): Map[String, String] = {
+    val envTags = Map.newBuilder[String, String]
+
+    if(config.getBoolean("service"))
+      envTags += ("service" -> env.service)
+
+    if(config.getBoolean("host"))
+      envTags += ("host" -> env.host)
+
+    if(config.getBoolean("instance"))
+      envTags += ("instance" -> env.instance)
+
+    val blacklistedTags = config.getStringList("blacklisted-tags").asScala
+    env.tags.filterKeys(k => !blacklistedTags.contains(k)).foreach(p => envTags += p)
+
+    envTags.result()
+  }
+}


### PR DESCRIPTION
The idea of this util is to make it super simple for modules to turn environment information into tags that can be included in metrics and spans. The tool allows to define whether to include the service, host and instance tags and blacklist specific environment tags.

Here is the first real-world usage example: https://github.com/kamon-io/kamon-influxdb/pull/20