### PR TITLE
Allow using negative values in RangeSampler#increment and RangeSampler#decrement

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/metric/RangeSamplerSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/metric/RangeSamplerSpec.scala
@@ -83,6 +83,34 @@ class RangeSamplerSpec extends WordSpec with Matchers {
       snapshot.distribution.min should be(0)
       snapshot.distribution.max should be(0)
     }
+
+    "report correct min and max values if increment or decrement are used with negative values" in {
+      val rangeSampler = buildRangeSampler("report-increment-decrement-negative")
+
+      rangeSampler.increment(5)
+      rangeSampler.decrement(3)
+      rangeSampler.sample()
+
+      val firstSnapshot = rangeSampler.snapshot()
+      firstSnapshot.distribution.min should be(0)
+      firstSnapshot.distribution.max should be(5)
+
+      rangeSampler.increment(-1)
+      rangeSampler.increment(2)
+      rangeSampler.sample()
+
+      val secondSnapshot = rangeSampler.snapshot()
+      secondSnapshot.distribution.min should be(1)
+      secondSnapshot.distribution.max should be(3)
+
+      rangeSampler.decrement(-2)
+      rangeSampler.decrement(2)
+      rangeSampler.sample()
+
+      val thirdSnapshot = rangeSampler.snapshot()
+      thirdSnapshot.distribution.min should be(3)
+      thirdSnapshot.distribution.max should be(5)
+    }
   }
 
   def buildRangeSampler(name: String, tags: Map[String, String] = Map.empty, unit: MeasurementUnit = MeasurementUnit.none): SimpleRangeSampler =

--- a/kamon-core/src/main/scala/kamon/metric/RangeSampler.scala
+++ b/kamon-core/src/main/scala/kamon/metric/RangeSampler.scala
@@ -50,6 +50,7 @@ class SimpleRangeSampler(name: String, tags: Map[String, String], underlyingHist
   def increment(times: Long): Unit = {
     val currentValue = sum.addAndGet(times)
     max.update(currentValue)
+    min.update(-currentValue)
   }
 
   def decrement(): Unit =
@@ -57,6 +58,7 @@ class SimpleRangeSampler(name: String, tags: Map[String, String], underlyingHist
 
   def decrement(times: Long): Unit = {
     val currentValue = sum.addAndGet(-times)
+    max.update(currentValue)
     min.update(-currentValue)
   }
 


### PR DESCRIPTION
This pull request modifies the `increment` and `decrement` methods of `RangeSampler` so that they correctly track the minimum and maximum values if they're supplied with negative values.