### PR TITLE
Make span metrics names configurable

### DIFF
--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -147,6 +147,14 @@ kamon {
       # When this option is enabled the metrics collected for Spans will automatically add a tag named "parentOperation"
       # with the name of the operation on the parent Span, if any.
       scope-spans-to-parent = yes
+
+      # Name to use for metric spans. This should not normally be changed, except when needed to maintain consistency
+      # with other languages/libraries.
+      processing-time-name = "span.processing-time"
+
+      # Name to use for error count spans. This should not normally be changed, except when needed to maintain
+      # consistency with other languages/libraries.
+      error-count-name = "span.error-count"
     }
   }
 

--- a/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -18,6 +18,7 @@ package trace
 
 import java.time.Instant
 
+import com.typesafe.config.ConfigFactory
 import kamon.ReporterRegistry.SpanSink
 import kamon.context.Key
 import kamon.metric.MeasurementUnit
@@ -275,8 +276,11 @@ object Span {
 
 
   object Metrics {
-    val ProcessingTime = Kamon.histogram("span.processing-time", MeasurementUnit.time.nanoseconds)
-    val SpanErrorCount = Kamon.counter("span.error-count")
+    private val processingTimeName = ConfigFactory.load().getString("kamon.trace.span-metrics.processing-time-name")
+    private val errorCountName = ConfigFactory.load().getString("kamon.trace.span-metrics.error-count-name")
+
+    val ProcessingTime = Kamon.histogram(processingTimeName, MeasurementUnit.time.nanoseconds)
+    val SpanErrorCount = Kamon.counter(errorCountName)
   }
 
   case class Mark(instant: Instant, key: String)


### PR DESCRIPTION
When using multiple languages and libraries it can be helpful to ensure all are outputting consistent metrics. This PR helps to address that by allowing the metric spans to be renamed.

Example:

```
kamon {
  trace {
    span-metrics {
      processing-time-name = "request-latency"
      error-count-name = "request-error"
    }
  }
```

This affects the results, e.g. with Prometheus:

```
$curl http://localhost:90
request_latency_seconds_bucket{...}
...
```

Alternative ways to achieve this: I tried to look at whether this can be done in kamon-prometheus but I think by then it is too late to change the name.

It seems this problem is fairly specific to the names of spans - we can add other metrics, and we can manipulate tags.

In kamon-core, there is the `Metrics` singleton object. This could be made into a class and the config injected in, but I'm not sure if that complexity is needed - in particular, is there any performance implication in making it no longer a singleton.