### PR TITLE
During reconfigure, tickers are restarted using old config

### DIFF
--- a/kamon-core/src/main/scala/kamon/ReporterRegistry.scala
+++ b/kamon-core/src/main/scala/kamon/ReporterRegistry.scala
@@ -195,12 +195,13 @@ object ReporterRegistry {
     }
 
     private[kamon] def reconfigure(config: Config): Unit = synchronized {
-      val newConfig = readRegistryConfiguration(config)
+      val oldConfig = registryConfiguration
+      registryConfiguration = readRegistryConfiguration(config)
 
-      if(newConfig.metricTickInterval != registryConfiguration.metricTickInterval && metricReporters.nonEmpty)
+      if(oldConfig.metricTickInterval != registryConfiguration.metricTickInterval && metricReporters.nonEmpty)
         reStartMetricTicker()
 
-      if(newConfig.traceTickInterval != registryConfiguration.traceTickInterval && spanReporters.nonEmpty)
+      if(oldConfig.traceTickInterval != registryConfiguration.traceTickInterval && spanReporters.nonEmpty)
         reStartTraceTicker()
 
       // Reconfigure all registered reporters
@@ -224,8 +225,6 @@ object ReporterRegistry {
             }
           }(entry.executionContext)
       }
-
-      registryConfiguration = newConfig
     }
 
 


### PR DESCRIPTION
I noticed that when Kamon is reconfigured with a new tick-interval, the new interval is ignored (the old one is used).
It turns out that `reStartMetricTicker` and `reStartTraceTicker` read the configuration from `registryConfiguration`, but the `registryConfiguration` has not been updated yet when these methods are called.

I just moved the update of `registryConfiguration` to happen before the tickers are restarted, but an alternative would be to pass a `Configuration` parameter to `reStartMetricTicker` and `reStartTraceTicker`.
What do you think ?