### PR TITLE
include trace identifiers in HTTP responses, fixes #558

### DIFF
--- a/kamon-core-tests/src/test/resources/reference.conf
+++ b/kamon-core-tests/src/test/resources/reference.conf
@@ -21,8 +21,14 @@ kamon {
   instrumentation {
     http-server {
       default {
-        tracing.preferred-trace-id-tag = "correlation-id"
-        tracing.tags.from-context.peer = span
+        tracing {
+          preferred-trace-id-tag = "correlation-id"
+          tags.from-context.peer = span
+          response-headers {
+            trace-id = "x-trace-id"
+            span-id = "x-span-id"
+          }
+        }
       }
 
       no-span-metrics {

--- a/kamon-core-tests/src/test/scala/kamon/instrumentation/HttpServerInstrumentationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/instrumentation/HttpServerInstrumentationSpec.scala
@@ -220,6 +220,18 @@ class HttpServerInstrumentationSpec extends WordSpec with Matchers with SpanInsp
         val span = inspect(handler.span)
         span.tag("peer").value shouldBe "superservice"
       }
+
+      "write trace identifiers on the responses" in {
+        val handler = httpServer().receive(fakeRequest("http://localhost:8080/", "/", "GET", Map(
+          "x-correlation-id" -> "0011223344556677"
+        )))
+
+        val responseHeaders = mutable.Map.empty[String, String]
+        handler.send(fakeResponse(200, responseHeaders), handler.context)
+
+        responseHeaders.get("x-trace-id").value shouldBe "0011223344556677"
+        responseHeaders.get("x-span-id") shouldBe defined
+      }
     }
 
     "all capabilities are disabled" should {

--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -203,6 +203,7 @@ kamon {
           # Specify mappings between Context keys and the Propagation.EntryReader[HeaderReader] implementation in charge
           # of reading them from the incoming HTTP request into the Context.
           incoming {
+
             # kamon.trace.SpanPropagation$B3 for default header format or kamon.trace.SpanPropagation$B3Simple for 'b3 single' header format.
             span = "kamon.trace.SpanPropagation$B3"
           }
@@ -210,6 +211,7 @@ kamon {
           # Specify mappings betwen Context keys and the Propagation.EntryWriter[HeaderWriter] implementation in charge
           # of writing them to outgoing HTTP requests.
           outgoing {
+
             # kamon.trace.SpanPropagation$B3 for default header format or kamon.trace.SpanPropagation$B3Simple for 'b3 single' header format.
             span = "kamon.trace.SpanPropagation$B3"
           }
@@ -218,6 +220,7 @@ kamon {
     }
 
     binary {
+
       # Default HTTP propagation. Unless specified otherwise, all instrumentation will use the configuration on
       # this section for HTTP context propagation.
       #
@@ -336,6 +339,18 @@ kamon {
             from-context {
 
             }
+          }
+
+          # Controls writing trace and span identifiers to HTTP response headers sent by the instrumented servers. The
+          # configuration can be set to either "none" to disable writing the identifiers on the response headers or to
+          # the header name to be used when writing the identifiers.
+          response-headers {
+
+            # HTTP response header name for the trace identifier, or "none" to disable it.
+            trace-id = "trace-id"
+
+            # HTTP response header name for the server span identifier, or "none" to disable it.
+            span-id = none
           }
 
           # Custom mappings between routes and operation names.


### PR DESCRIPTION
Allows users to specify whether trace identifiers (trace and span) should be written to instrumented HTTP responses. By default we are including the trace ID using the `trace-id` header. The header names are configurable.