### PR TITLE
Updating NoIdentifier to match bytes value

### DIFF
--- a/kamon-core/src/main/scala/kamon/trace/IdentityProvider.scala
+++ b/kamon-core/src/main/scala/kamon/trace/IdentityProvider.scala
@@ -37,7 +37,7 @@ object IdentityProvider {
     }
   }
 
-  val NoIdentifier = Identifier("", new Array[Byte](0))
+  val NoIdentifier = Identifier("0", new Array[Byte](0))
 
   trait Generator {
     def generate(): Identifier


### PR DESCRIPTION
To match the string with the bytes value for the NoIdentifier it should have value `0` also this nicely fixes the issue reported here: https://github.com/kamon-io/kamon-zipkin/issues/9