### PR TITLE
Add support for providing a custom Sampler

### DIFF
--- a/kamon-core/src/main/scala/kamon/trace/Tracer.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Tracer.scala
@@ -73,6 +73,9 @@ object Tracer {
           case "always" => Sampler.Always
           case "never" => Sampler.Never
           case "random" => Sampler.random(traceConfig.getDouble("random-sampler.probability"))
+          case "custom" => dynamic.createInstanceFor[Sampler](
+            traceConfig.getString("custom-sampler"), immutable.Seq.empty[(Class[_], AnyRef)]
+          ).get
           case other => sys.error(s"Unexpected sampler name $other.")
         }
 


### PR DESCRIPTION
This PR makes it possible to set `kamon.trace.sampler = custom`, after which `kamon.trace.custom-sampler` may be used to specify the name of a custom `Sampler` to be used. This is useful in our development environment where we generally don't want to sample traces, but we occasionally want to white-list specific top-level operations to be sampled for debugging.  