### PR TITLE
remove proguard from the build

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,3 @@ lazy val root: Project = project in file(".") dependsOn(RootProject(uri("git://g
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
-addSbtPlugin("com.lightbend.sbt" % "sbt-proguard" % "0.3.0")


### PR DESCRIPTION
Proguard has issues handling several levels of nested classes and after much searching and dead ends, opted for just removing the proguard plugin in favor of manually zap'ing most of the big chunks of extra stuff that proguard was removing anyways. The final jar with Proguard was 1.1MB while the result of zap'ing is 1.8MB, but this new version is actually correct :man_shrugging: