### PR TITLE
programatically drop and keep traces / delaying sampling decisions

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/trace/B3SingleSpanPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/B3SingleSpanPropagationSpec.scala
@@ -81,9 +81,9 @@ class B3SingleSpanPropagationSpec extends WordSpecLike with Matchers with Option
       val context = testContext()
       val sampledSpan = context.get(Span.Key)
       val notSampledSpanContext = Context.Empty.withKey(Span.Key,
-        new Span.Remote(sampledSpan.id, sampledSpan.parentId, sampledSpan.trace.copy(samplingDecision = SamplingDecision.DoNotSample)))
+        new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.DoNotSample)))
       val unknownSamplingSpanContext = Context.Empty.withKey(Span.Key,
-        new Span.Remote(sampledSpan.id, sampledSpan.parentId, sampledSpan.trace.copy(samplingDecision = SamplingDecision.Unknown)))
+        new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.Unknown)))
 
       val headersMap = mutable.Map.empty[String, String]
 

--- a/kamon-core-tests/src/test/scala/kamon/trace/B3SpanPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/B3SpanPropagationSpec.scala
@@ -101,9 +101,9 @@ class B3SpanPropagationSpec extends WordSpecLike with Matchers with OptionValues
       val context = testContext()
       val sampledSpan = context.get(Span.Key)
       val notSampledSpanContext = Context.Empty.withKey(Span.Key,
-        new Span.Remote(sampledSpan.id, sampledSpan.parentId, sampledSpan.trace.copy(samplingDecision = SamplingDecision.DoNotSample)))
+        new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.DoNotSample)))
       val unknownSamplingSpanContext = Context.Empty.withKey(Span.Key,
-        new Span.Remote(sampledSpan.id, sampledSpan.parentId, sampledSpan.trace.copy(samplingDecision = SamplingDecision.Unknown)))
+        new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.Unknown)))
       val headersMap = mutable.Map.empty[String, String]
 
       b3Propagation.write(context, headerWriterFromMap(headersMap))

--- a/kamon-core/src/main/scala/kamon/trace/AdaptiveSampler.scala
+++ b/kamon-core/src/main/scala/kamon/trace/AdaptiveSampler.scala
@@ -27,8 +27,8 @@ class AdaptiveSampler extends Sampler {
   @volatile private var _settings = AdaptiveSampler.Settings.from(Kamon.config())
   private val _samplers = TrieMap.empty[String, AdaptiveSampler.OperationSampler]
 
-  override def decide(rootSpanBuilder: SpanBuilder): SamplingDecision = {
-    val operationName = rootSpanBuilder.operationName()
+  override def decide(operation: Sampler.Operation): SamplingDecision = {
+    val operationName = operation.operationName()
     val operationSampler = _samplers.get(operationName).getOrElse {
       // It might happen that the first time we see an operation under high concurrent throughput we will reach this
       // block more than once, but worse case effect is that we will rebalance the operation samplers more than once.

--- a/kamon-core/src/main/scala/kamon/trace/ConstantSampler.scala
+++ b/kamon-core/src/main/scala/kamon/trace/ConstantSampler.scala
@@ -8,7 +8,7 @@ import kamon.trace.Trace.SamplingDecision
   */
 class ConstantSampler private(decision: SamplingDecision) extends Sampler {
 
-  override def decide(rootSpanBuilder: SpanBuilder): SamplingDecision =
+  override def decide(operation: Sampler.Operation): SamplingDecision =
     decision
 
   override def toString: String =

--- a/kamon-core/src/main/scala/kamon/trace/RandomSampler.scala
+++ b/kamon-core/src/main/scala/kamon/trace/RandomSampler.scala
@@ -12,7 +12,7 @@ class RandomSampler private(probability: Double) extends Sampler {
   val upperBoundary = Long.MaxValue * probability
   val lowerBoundary = -upperBoundary
 
-  override def decide(rootSpanBuilder: SpanBuilder): SamplingDecision = {
+  override def decide(operation: Sampler.Operation): SamplingDecision = {
     val random = ThreadLocalRandom.current().nextLong()
     if(random >= lowerBoundary && random <= upperBoundary) SamplingDecision.Sample else SamplingDecision.DoNotSample
   }

--- a/kamon-core/src/main/scala/kamon/trace/Sampler.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Sampler.scala
@@ -26,5 +26,26 @@ trait Sampler {
     * Decides whether a trace should be sampled or not. The provided SpanBuilder contains the information that has been
     * gathered so far for what will become the root Span for the new Trace.
     */
-  def decide(rootSpanBuilder: SpanBuilder): Trace.SamplingDecision
+  def decide(operation: Sampler.Operation): Trace.SamplingDecision
+
+}
+
+object Sampler {
+
+  /**
+    * Exposes access to information about the operation triggering the sampling. The Kamon tracer can take a sampling in
+    * two different situations: during Span creation via SpanBuilder.start (the most common case) and once a Span has
+    * been already started with an Unknown Sampling Decision and Span.takSamplingDecision is called; this interface
+    * helps to abstract the actual instance holding the operation information (a SpanBuilder or Span) from the Sampler's
+    * external API.
+    */
+  trait Operation {
+
+    /**
+      * Name assigned to the operation that triggers the sampler. The name is typically assigned by either the user or
+      * automatic instrumentation.
+      */
+    def operationName(): String
+
+  }
 }

--- a/kamon-core/src/main/scala/kamon/trace/SpanBuilder.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanBuilder.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import kamon.context.Context
 import kamon.tag.TagSet
 import kamon.trace.Span.Link
+import kamon.trace.Trace.SamplingDecision
 
 /**
   * Gathers information about an operation before it can be turned into a Span. The Span creation is handled in two
@@ -14,7 +15,7 @@ import kamon.trace.Span.Link
   *
   * Implementations are not expected to be thread safe.
   */
-trait SpanBuilder {
+trait SpanBuilder extends Sampler.Operation {
 
   /**
     * Changes the operation name on this SpanBuilder.
@@ -136,11 +137,17 @@ trait SpanBuilder {
   def context(context: Context): SpanBuilder
 
   /**
-    * Suggests a Trace Identifier for the Span to be created. This suggestion will only be taken into account if the new
-    * Span is to become the root Span in a new Trace, in which case the provided identifier will become the Trace id
-    * instead of a newly generated one.
+    * Suggests a Trace Identifier in case a new Trace will be created for the new Span. This suggestion will only be
+    * taken into account if the new Span is to become the root Span in a new Trace, otherwise the parent Span's trace
+    * will be used.
     */
   def traceId(id: Identifier): SpanBuilder
+
+  /**
+    * Suggests a sampling decision in case a new Trace will be created for the new Span. This suggestion will only be
+    * taken into account if this Span doesn't have any parent or the parent's sampling decision is Unknown.
+    */
+  def samplingDecision(decision: SamplingDecision): SpanBuilder
 
   /**
     * Sets the kind of operation represented by the Span to be created.

--- a/kamon-core/src/main/scala/kamon/trace/Trace.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Trace.scala
@@ -5,14 +5,41 @@ package trace
   * Holds information shared across all Spans from the same Trace. It might seem like too little information but all in
   * all, a trace is just a bunch of Spans that share the same trace identifier ;).
   */
-case class Trace (
-  id: Identifier,
-  samplingDecision: Trace.SamplingDecision
-) {
+trait Trace {
 
-  override def toString(): String = {
-    s"{id=${id.string},samplingDecision=${samplingDecision}"
-  }
+  /**
+    * Unique identifier for the trace. All Spans related to this trace (in the local and any remote processes) will
+    * share the same identifier.
+    */
+  def id: Identifier
+
+  /**
+    * Indicates whether Spans belonging to this Trace should be captured and sent to the Span reporters.
+    */
+  def samplingDecision: Trace.SamplingDecision
+
+  /**
+    * Changes the sampling on this trace to DoNotSample. None of the related Spans finished after the Trace has been
+    * dropped will be reported to Span reporters. Ideally, the decision to drop a Trace should be taken as early as
+    * possible to avoid situations in which calls to external services are possibly sent out with a Sampled decision
+    * and later deciding to drop all the local Spans, which will leave the external service Spans as orphans.
+    *
+    * Use with caution, in most situations there is no need to manually control the Sampling Decision but rather leave
+    * it for the SpanBuilder and Sampler to decide.
+    */
+  def drop(): Unit
+
+  /**
+    * Changes the sampling on this trace to Sample. All of the related Spans finished after the Trace has been marked
+    * for keeping will be reported to Span reporters. Ideally, the decision to keep a Trace should be taken as early as
+    * possible to avoid situations in which calls to external services are possibly sent out with a NotSampled decision
+    * and later deciding to keep all the local Spans, which will produce a partial trace.
+    *
+    * Use with caution, in most situations there is no need to manually control the Sampling Decision but rather leave
+    * it for the SpanBuilder and Sampler to decide.
+    */
+  def keep(): Unit
+
 }
 
 object Trace {
@@ -20,7 +47,36 @@ object Trace {
   /**
     * A trace without identifier nor sampling decision. Used to signal that there is no trace information available.
     */
-  val Empty = Trace(Identifier.Empty, SamplingDecision.Unknown)
+  val Empty: Trace = new MutableTrace(Identifier.Empty, SamplingDecision.Unknown)
+
+  /**
+    * Creates a new Trace instance with the provided Id and Sampling Decision.
+    */
+  def apply(id: Identifier, samplingDecision: SamplingDecision): Trace =
+    new MutableTrace(id, samplingDecision)
+
+  /**
+    * Creates a new Trace instance with the provided Id and Sampling Decision.
+    */
+  def create(id: Identifier, samplingDecision: SamplingDecision): Trace =
+    new MutableTrace(id, samplingDecision)
+
+
+  private class MutableTrace(val id: Identifier, initialDecision: Trace.SamplingDecision) extends Trace {
+    @volatile private var _samplingDecision = initialDecision
+
+    override def samplingDecision: SamplingDecision =
+      _samplingDecision
+
+    override def drop(): Unit =
+      _samplingDecision = SamplingDecision.DoNotSample
+
+    override def keep(): Unit =
+      _samplingDecision = SamplingDecision.Sample
+
+    override def toString(): String =
+      s"{id=${id.string},samplingDecision=${_samplingDecision}"
+  }
 
 
   /**


### PR DESCRIPTION
This PR is addressing two needs that we found while upgrading instrumentation on HTTP servers:

First, we always try to start the HTTP Server Spans as early as possible in the request processing, so early that it might happen (in fact, it is almost always the case) that at the point where we are starting the Span, we don't have an operation name to assign to it. So far when we got into this situation we would just assign a default name and then the instrumentation would take care of assigning a decent operation name down the road, where "decent" means that it doesn't have any high cardinality parts on it as it is used for the `span.xxx-time` metric. In the pre-2.0 world, we only had the constant and random samplers so it just wouldn't matter what the operation name was, but since we are introducing an adaptive sampler that actually needs an operation name to work, we should allow for the sampling decision to be taken at a point where we actually have an operation name that could be given to the adaptive sampler if it is being used. 

Second need is, to have some manual control over sampling decisions. This comes in two forms: one is to be able to "suggest" a Sampling Decision, so that if a Span is going to start a new Trace and a sampling decision must be taken, the tracer will use the suggestion instead of using the sampler; the other form is by explicitly asking to keep or drop a trace, which can be really useful if the user somehow detects that they really want to keep/drop a trace, regardless of the sampling decision already available. When a trace is dropped/kept, all Spans in the current process will immediately see the change. This might lead to missing data in some cases where, for example, the decision to keep a trace is made after several calls to external services were fired with the previous sampling decision, but that is something we can't influence much.

In the case of our own instrumentation, we will suggest a Unknown sampling decision when we start the Spans, then let the instrumentation hit the points where we can actually assign a proper operation name and then make the Span take a sampling decision. 