### PR TITLE
remove the start method from the Module interface

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/KamonLifecycleSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/KamonLifecycleSpec.scala
@@ -40,14 +40,12 @@ class KamonLifecycleSpec extends WordSpec with Matchers with Eventually {
 }
 
 class DummyMetricReporter extends kamon.module.MetricReporter {
-  override def start(): Unit = {}
   override def stop(): Unit = {}
   override def reconfigure(config: Config): Unit = {}
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {}
 }
 
 class DummySpanReporter extends kamon.module.SpanReporter {
-  override def start(): Unit = {}
   override def stop(): Unit = {}
   override def reconfigure(config: Config): Unit = {}
   override def reportSpans(spans: Seq[Span.Finished]): Unit = {}

--- a/kamon-core-tests/src/test/scala/kamon/module/ModuleRegistrySpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/module/ModuleRegistrySpec.scala
@@ -124,7 +124,6 @@ class ModuleRegistrySpec extends WordSpec with Matchers with Reconfigure with Ev
     def snapshotCount(): Int =
       count
 
-    override def start(): Unit = {}
     override def stop(): Unit = {}
     override def reconfigure(config: Config): Unit = {}
   }

--- a/kamon-core/src/main/resources/reference.conf
+++ b/kamon-core/src/main/resources/reference.conf
@@ -37,12 +37,15 @@ kamon {
   #     enabled = true
   #     name = "The Module Name"
   #     description = "A module description"
-  #     class = "com.example.ModuleClass"
+  #     factory = "com.example.ModuleFactory"
+  #     config-path = "kamon.my-module"
   #   }
   # }
   #
   # All available modules in the classpath are started when calling Kamon.loadModules() and stopped when calling
-  # Kamon.stopModules().
+  # Kamon.stopModules(). When starting modules available on the classpath, Kamon will instantiate the configurated
+  # "factory" (must be an implementation of kamon.module.ModuleFactory) using a parameter-less constructor and passing
+  # in the configuration instance under the specified "configuration-path".
   #
   modules {
 

--- a/kamon-core/src/main/scala/kamon/module/MetricReporter.scala
+++ b/kamon-core/src/main/scala/kamon/module/MetricReporter.scala
@@ -28,7 +28,6 @@ object MetricReporter {
   def withTransformations(reporter: MetricReporter, transformations: Transformation*): MetricReporter =
       new Module.Wrapped with MetricReporter {
 
-    override def start(): Unit = reporter.start()
     override def stop(): Unit = reporter.stop()
     override def reconfigure(newConfig: Config): Unit = reporter.reconfigure(newConfig)
     override def originalClass: Class[_ <: Module] = reporter.getClass

--- a/kamon-core/src/main/scala/kamon/status/Status.scala
+++ b/kamon-core/src/main/scala/kamon/status/Status.scala
@@ -39,7 +39,7 @@ class Status(_moduleRegistry: ModuleRegistry, _metricRegistry: MetricRegistry, c
     * object docs for more information.
     */
   def instrumentation(): Status.Instrumentation =
-    InstrumentationStatus.create()
+    InstrumentationStatus.create(warnIfFailed = false)
 
 }
 

--- a/kamon-status-page/src/main/resources/reference.conf
+++ b/kamon-status-page/src/main/resources/reference.conf
@@ -20,8 +20,9 @@ kamon {
     status-page {
       enabled = yes
       name = "Status Page"
-      class = "kamon.status.page.StatusPage"
       description = "Exposes an embedded web server with a single page app displaying Kamon status information."
+      factory = "kamon.status.page.StatusPage$Factory"
+      config-path = "kamon.status-page"
     }
   }
 }

--- a/kamon-testkit/src/main/scala/kamon/testkit/TestSpanReporter.scala
+++ b/kamon-testkit/src/main/scala/kamon/testkit/TestSpanReporter.scala
@@ -94,7 +94,6 @@ object TestSpanReporter {
     }
 
     // Here go the reporter-specific implementation details:
-    override def start(): Unit = {}
     override def stop(): Unit = {}
     override def reconfigure(config: Config): Unit = {}
     override def reportSpans(spans: Seq[Span.Finished]): Unit =


### PR DESCRIPTION
While creating and updating modules I noticed one small annoyance that is sort of forced by the `Module` interface: since users are supposed to implement a `start` method but obviously there are always a number of "things" that need to be instantiated for the module to work then we end up creating modules with a bunch of `vars` that are initialized with some sort of default value or defined as `Option[X]` and then create the actual values when `start` is called, but, in practice, there is no need to do that. All modules are instantiated right when they are going to be started, there is no chance to have an instantiated but not started module so I'm proposing to remove the `start` method from the `Module` interface.

Besides that change, I'm adding a `ModuleFactory` to be used when the modules are automatically instantiated by Kamon instead of provided by the user (which will be the default behavior).. this way, we force the parameter-less constructor only on the Factory and the Module itself is free to receive/grab any dependencies it might need on its constructor.