### PR TITLE
Scala 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ lazy val testkit = (project in file("kamon-testkit"))
   .settings(
     moduleName := "kamon-testkit",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+      "org.scalatest" %% "scalatest" % "3.0.8" % "test"
     )
   ).dependsOn(core)
 
@@ -112,7 +112,7 @@ lazy val tests = (project in file("kamon-core-tests"))
   .settings(
     moduleName := "kamon-core-tests",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest"        % "3.0.1" % "test",
+      "org.scalatest" %% "scalatest"        % "3.0.8" % "test",
       "ch.qos.logback" % "logback-classic"  % "1.2.3" % "test"
     )
   ).dependsOn(testkit)
@@ -131,17 +131,19 @@ lazy val commonSettings = Seq(
   fork in Test := true,
   resolvers += Resolver.mavenLocal,
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
+  scalaVersion := "2.13.0",
+  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7", "2.13.0"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
     "-feature",
-    "-Xfuture",
     "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-language:postfixOps",
     "-unchecked"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2,10)) => Seq("-Yno-generic-signatures", "-target:jvm-1.7")
-    case Some((2,11)) => Seq("-Ybackend:GenASM","-Ydelambdafy:method","-target:jvm-1.8")
-    case Some((2,12)) => Seq("-opt:l:method")
+    case Some((2,10)) => Seq("-Xfuture", "-Yno-generic-signatures", "-target:jvm-1.7")
+    case Some((2,11)) => Seq("-Xfuture", "-Ybackend:GenASM","-Ydelambdafy:method","-target:jvm-1.8")
+    case Some((2,12)) => Seq("-Xfuture", "-opt:l:method")
+    case Some((2,13)) => Seq.empty
     case _ => Seq.empty
   }),
   assembleArtifact in assemblyPackageScala := false,

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,7 @@ lazy val commonSettings = Seq(
   resolvers += Resolver.mavenLocal,
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   scalaVersion := "2.13.0",
-  crossScalaVersions := Seq("2.10.7", "2.11.12", "2.12.7", "2.13.0"),
+  crossScalaVersions := Seq("2.11.12", "2.12.7", "2.13.0"),
   scalacOptions ++= Seq(
     "-deprecation",
     "-encoding", "UTF-8",
@@ -140,7 +140,6 @@ lazy val commonSettings = Seq(
     "-language:implicitConversions", "-language:higherKinds", "-language:existentials", "-language:postfixOps",
     "-unchecked"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2,10)) => Seq("-Xfuture", "-Yno-generic-signatures", "-target:jvm-1.7")
     case Some((2,11)) => Seq("-Xfuture", "-Ybackend:GenASM","-Ydelambdafy:method","-target:jvm-1.8")
     case Some((2,12)) => Seq("-Xfuture", "-opt:l:method")
     case Some((2,13)) => Seq.empty

--- a/kamon-core-tests/src/test/scala/kamon/trace/SpanMetricsSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/SpanMetricsSpec.scala
@@ -177,9 +177,9 @@ class SpanMetricsSpec extends WordSpecLike with Matchers with InstrumentInspecti
         .start(createTime.plusNanos(10))
         .finish(createTime.plusNanos(30))
 
-      val waitTime = Span.Metrics.WaitTime.withTags(TagSet.from(Map(operationTag, noErrorTag)))distribution()
-      val elapsedTime = Span.Metrics.ElapsedTime.withTags(TagSet.from(Map(operationTag, noErrorTag)))distribution()
-      val processingTime = Span.Metrics.ProcessingTime.withTags(TagSet.from(Map(operationTag, noErrorTag)))distribution()
+      val waitTime = Span.Metrics.WaitTime.withTags(TagSet.from(Map(operationTag, noErrorTag))).distribution()
+      val elapsedTime = Span.Metrics.ElapsedTime.withTags(TagSet.from(Map(operationTag, noErrorTag))).distribution()
+      val processingTime = Span.Metrics.ProcessingTime.withTags(TagSet.from(Map(operationTag, noErrorTag))).distribution()
 
       waitTime.count shouldBe 1
       waitTime.buckets.head.value shouldBe 10

--- a/kamon-core/src/main/java/org/HdrHistogram/BaseAtomicHdrHistogram.java
+++ b/kamon-core/src/main/java/org/HdrHistogram/BaseAtomicHdrHistogram.java
@@ -1,53 +1,115 @@
 package org.HdrHistogram;
 
+import java.nio.ByteBuffer;
+
 import kamon.metric.DynamicRange;
 
 /**
  * Exposes internal state from the org.HdrHistogram.AtomicHistogram class.
+ * <p>
+ * Could extend AtomicHistogram and avoid the delegate pattern, but for issue https://github.com/scala/bug/issues/11575
  */
-public class BaseAtomicHdrHistogram extends AtomicHistogram implements HdrHistogramInternalState {
+public class BaseAtomicHdrHistogram extends AbstractHistogramBase implements HdrHistogramInternalState {
 
-  public BaseAtomicHdrHistogram(DynamicRange dynamicRange) {
-    super(dynamicRange.lowestDiscernibleValue(), dynamicRange.highestTrackableValue(), dynamicRange.significantValueDigits());
-  }
+    private AtomicHistogram delegate;
 
-  @Override
-  void incrementTotalCount() {
-    // We don't need to track the total count so this is just disabled.
-  }
+    public BaseAtomicHdrHistogram(DynamicRange dynamicRange) {
+        this.delegate = new AtomicHistogram(dynamicRange.lowestDiscernibleValue(), dynamicRange.highestTrackableValue(), dynamicRange.significantValueDigits());
+    }
 
-  @Override
-  void addToTotalCount(long value) {
-    // We don't need to track the total count so this is just disabled.
-  }
+    public long getHighestTrackableValue() {
+        return delegate.highestTrackableValue;
+    }
 
-  @Override
-  public int getCountsArraySize() {
-    return super.counts.length();
-  }
+    public void recordValue(long value) throws ArrayIndexOutOfBoundsException {
+        delegate.recordValue(value);
+    }
 
-  @Override
-  public long getFromCountsArray(int index) {
-    return super.counts.get(index);
-  }
+    public void recordValueWithCount(long value, long count) throws ArrayIndexOutOfBoundsException {
+        delegate.recordValueWithCount(value, count);
+    }
 
-  @Override
-  public long getAndSetFromCountsArray(int index, long newValue) {
-    return super.counts.getAndSet(index, newValue);
-  }
+    public void reset() {
+        delegate.reset();
+    }
 
-  @Override
-  public int getUnitMagnitude() {
-    return super.unitMagnitude;
-  }
+    @Override
+    public int getNeededByteBufferCapacity() {
+        return delegate.getNeededByteBufferCapacity();
+    }
 
-  @Override
-  public int getSubBucketHalfCount() {
-    return super.subBucketHalfCount;
-  }
+    @Override
+    public int encodeIntoCompressedByteBuffer(final ByteBuffer targetBuffer, int compressionLevel) {
+        return delegate.encodeIntoCompressedByteBuffer(targetBuffer, compressionLevel);
+    }
 
-  @Override
-  public int getSubBucketHalfCountMagnitude() {
-    return super.subBucketHalfCountMagnitude;
-  }
+    @Override
+    public long getStartTimeStamp() {
+        return delegate.getStartTimeStamp();
+    }
+
+    @Override
+    public void setStartTimeStamp(long startTimeStamp) {
+        delegate.setStartTimeStamp(startTimeStamp);
+    }
+
+    @Override
+    public long getEndTimeStamp() {
+        return delegate.getEndTimeStamp();
+    }
+
+    @Override
+    public void setEndTimeStamp(long startTimeStamp) {
+        delegate.setEndTimeStamp(startTimeStamp);
+    }
+
+    @Override
+    public String getTag() {
+        return delegate.getTag();
+    }
+
+    @Override
+    public void setTag(String tag) {
+        delegate.setTag(tag);
+    }
+
+    @Override
+    public double getMaxValueAsDouble() {
+        return delegate.getMaxValueAsDouble();
+    }
+
+    @Override
+    void setIntegerToDoubleValueConversionRatio(double integerToDoubleValueConversionRatio) {
+        delegate.setIntegerToDoubleValueConversionRatio(integerToDoubleValueConversionRatio);
+    }
+
+    @Override
+    public int getCountsArraySize() {
+        return delegate.counts.length();
+    }
+
+    @Override
+    public long getFromCountsArray(int index) {
+        return delegate.counts.get(index);
+    }
+
+    @Override
+    public long getAndSetFromCountsArray(int index, long newValue) {
+        return delegate.counts.getAndSet(index, newValue);
+    }
+
+    @Override
+    public int getUnitMagnitude() {
+        return delegate.unitMagnitude;
+    }
+
+    @Override
+    public int getSubBucketHalfCount() {
+        return delegate.subBucketHalfCount;
+    }
+
+    @Override
+    public int getSubBucketHalfCountMagnitude() {
+        return delegate.subBucketHalfCountMagnitude;
+    }
 }

--- a/kamon-core/src/main/scala/kamon/package.scala
+++ b/kamon-core/src/main/scala/kamon/package.scala
@@ -59,7 +59,7 @@ package object kamon {
   implicit class AtomicGetOrElseUpdateOnTrieMap[K, V](val trieMap: TrieMap[K, V]) extends AnyVal {
 
     def atomicGetOrElseUpdate(key: K, op: ⇒ V): V =
-      atomicGetOrElseUpdate(key, op, { _: V ⇒ Unit }, { _: V ⇒ Unit })
+      atomicGetOrElseUpdate(key, op, { _: V ⇒ () }, { _: V ⇒ () })
 
     def atomicGetOrElseUpdate(key: K, op: ⇒ V, cleanup: V ⇒ Unit, init: V => Unit): V =
       trieMap.get(key) match {

--- a/kamon-core/src/main/scala/kamon/status/InstrumentationStatus.scala
+++ b/kamon-core/src/main/scala/kamon/status/InstrumentationStatus.scala
@@ -50,7 +50,7 @@ object InstrumentationStatus {
         .map(toTypeError)
         .toSeq
 
-      Status.Instrumentation(present, modules, errors)
+      Status.Instrumentation(present, modules.toSeq, errors)
     } catch {
       case t: Throwable =>
 
@@ -87,6 +87,6 @@ object InstrumentationStatus {
     */
   private def toTypeError(pair: (String, JavaList[Throwable])): TypeError = {
     val (typeName, errors) = pair
-    TypeError(typeName, errors.asScala)
+    TypeError(typeName, errors.asScala.toSeq)
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.8


### PR DESCRIPTION
Cross compile for scala 2.13
- Some minor tweaks to library versions, scalacOptions
- Expected syntax changes
- `JavaConverters` changes
- Workaround for https://github.com/scala/bug/issues/11575
- Remove 2.10 support