### PR TITLE
provide a debug context storage

### DIFF
--- a/kamon-core/src/main/scala/kamon/ContextStorage.scala
+++ b/kamon-core/src/main/scala/kamon/ContextStorage.scala
@@ -140,5 +140,10 @@ object ContextStorage {
     * store and remove Context instances for small periods of time as events flow through the system and the
     * instrumentation follows them around.
     */
-  private val _contextStorage = Storage.ThreadLocal()
+  private val _contextStorage: Storage = {
+    if("true".equals(System.getProperty("kamon.context.debug")))
+      Storage.Debug()
+    else
+      Storage.ThreadLocal()
+  }
 }


### PR DESCRIPTION
This is something that came in really really handy while trying to troubleshoot https://github.com/kamon-io/kamon-play/issues/51 and seems like a good thing to have in core. The only way to enable the debug storage is with a system property (instead of via config like everything else) because it can happen in instrumented applications that the very first time ever that the Kamon companion object is used its from an instrumented tool trying to get the current Context. Maybe at some point in the future we could expose this information through the status page as well!