### PR TITLE
change the store prefix to runWith on Context storage functions

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/context/BinaryPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/context/BinaryPropagationSpec.scala
@@ -94,8 +94,8 @@ class BinaryPropagationSpec extends WordSpec with Matchers with OptionValues {
 
     "round trip a Context that with tags and entries" in {
       val context = Context.of(TagSet.from(Map("hello" -> "world", "kamon" -> "rulez")))
-        .withKey(BinaryPropagationSpec.StringKey, "string-value")
-        .withKey(BinaryPropagationSpec.IntegerKey, 42)
+        .withEntry(BinaryPropagationSpec.StringKey, "string-value")
+        .withEntry(BinaryPropagationSpec.IntegerKey, 42)
 
       val writer = inspectableByteStreamWriter()
       binaryPropagation.write(context, writer)
@@ -138,7 +138,7 @@ object BinaryPropagationSpec {
       val valueData = medium.readAll()
 
       if(valueData.length > 0) {
-        context.withKey(StringKey, new String(valueData))
+        context.withEntry(StringKey, new String(valueData))
       } else context
     }
 
@@ -161,7 +161,7 @@ object BinaryPropagationSpec {
           sys.error("The fail string entry reader has triggered")
         }
 
-        context.withKey(FailStringKey, stringValue)
+        context.withEntry(FailStringKey, stringValue)
       } else context
     }
 

--- a/kamon-core-tests/src/test/scala/kamon/context/HttpPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/context/HttpPropagationSpec.scala
@@ -144,7 +144,7 @@ object HttpPropagationSpec {
 
     override def read(reader: HttpPropagation.HeaderReader, context: Context): Context = {
       reader.read(HeaderName)
-        .map(v => context.withKey(StringKey, v))
+        .map(v => context.withEntry(StringKey, v))
         .getOrElse(context)
     }
 
@@ -156,7 +156,7 @@ object HttpPropagationSpec {
   class IntegerEntryCodec extends EntryReader[HeaderReader] {
     override def read(reader: HttpPropagation.HeaderReader, context: Context): Context = {
       reader.read("integer-header")
-        .map(v => context.withKey(IntegerKey, v.toInt))
+        .map(v => context.withEntry(IntegerKey, v.toInt))
         .getOrElse(context)
 
     }

--- a/kamon-core-tests/src/test/scala/kamon/trace/B3SingleSpanPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/B3SingleSpanPropagationSpec.scala
@@ -80,9 +80,9 @@ class B3SingleSpanPropagationSpec extends WordSpecLike with Matchers with Option
     "not include the X-B3-Sampled header if the sampling decision is unknown" in {
       val context = testContext()
       val sampledSpan = context.get(Span.Key)
-      val notSampledSpanContext = Context.Empty.withKey(Span.Key,
+      val notSampledSpanContext = Context.Empty.withEntry(Span.Key,
         new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.DoNotSample)))
-      val unknownSamplingSpanContext = Context.Empty.withKey(Span.Key,
+      val unknownSamplingSpanContext = Context.Empty.withEntry(Span.Key,
         new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.Unknown)))
 
       val headersMap = mutable.Map.empty[String, String]

--- a/kamon-core-tests/src/test/scala/kamon/trace/B3SpanPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/B3SpanPropagationSpec.scala
@@ -100,9 +100,9 @@ class B3SpanPropagationSpec extends WordSpecLike with Matchers with OptionValues
     "not include the X-B3-Sampled header if the sampling decision is unknown" in {
       val context = testContext()
       val sampledSpan = context.get(Span.Key)
-      val notSampledSpanContext = Context.Empty.withKey(Span.Key,
+      val notSampledSpanContext = Context.Empty.withEntry(Span.Key,
         new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.DoNotSample)))
-      val unknownSamplingSpanContext = Context.Empty.withKey(Span.Key,
+      val unknownSamplingSpanContext = Context.Empty.withEntry(Span.Key,
         new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.Unknown)))
       val headersMap = mutable.Map.empty[String, String]
 

--- a/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
@@ -63,7 +63,7 @@ class TracerSpec extends WordSpec with Matchers with SpanInspection.Syntax with 
 
     "automatically take the Span from the current Context as parent" in {
       val parent = Kamon.spanBuilder("myOperation").start()
-      val child = Kamon.storeSpan(parent) {
+      val child = Kamon.runWithSpan(parent) {
         Kamon.spanBuilder("childOperation").asChildOf(parent).start()
       }
 
@@ -72,7 +72,7 @@ class TracerSpec extends WordSpec with Matchers with SpanInspection.Syntax with 
 
     "ignore the span from the current context as parent if explicitly requested" in {
       val parent = Kamon.spanBuilder("myOperation").start()
-      val child = Kamon.storeSpan(parent) {
+      val child = Kamon.runWithSpan(parent) {
         Kamon.spanBuilder("childOperation").ignoreParentFromContext().start()
       }
 
@@ -244,7 +244,7 @@ class TracerSpec extends WordSpec with Matchers with SpanInspection.Syntax with 
     }
 
     "apply pre-start hooks to all Spans" in {
-      val span = Kamon.storeContextKey(PreStart.Key, PreStart.updateOperationName("customName")) {
+      val span = Kamon.runWithContextEntry(PreStart.Key, PreStart.updateOperationName("customName")) {
         Kamon.spanBuilder("defaultOperationName").start()
       }
 
@@ -253,7 +253,7 @@ class TracerSpec extends WordSpec with Matchers with SpanInspection.Syntax with 
 
     "apply pre-finish hooks to all Spans" in {
       val span = Kamon.spanBuilder("defaultOperationName").start()
-      Kamon.storeContextKey(PreFinish.Key, PreFinish.updateOperationName("customName")) {
+      Kamon.runWithContextEntry(PreFinish.Key, PreFinish.updateOperationName("customName")) {
         span.finish()
       }
 

--- a/kamon-core/src/main/scala/kamon/ContextStorage.scala
+++ b/kamon-core/src/main/scala/kamon/ContextStorage.scala
@@ -76,7 +76,7 @@ trait ContextStorage {
     * finishes.
     */
   def runWithContextEntry[T, K](key: Context.Key[K], value: K)(f: => T): T =
-    runWithContext(currentContext().withKey(key, value))(f)
+    runWithContext(currentContext().withEntry(key, value))(f)
 
   /**
     * Temporarily stores the provided Context tag on Kamon's Context Storage. The provided Context tag will be added to

--- a/kamon-core/src/main/scala/kamon/context/Context.scala
+++ b/kamon-core/src/main/scala/kamon/context/Context.scala
@@ -61,7 +61,7 @@ class Context private (private val _underlying: UnifiedMap[String, Any], private
     * Creates a new Context instance that includes the provided key and value. If the provided key was already
     * associated with another value then the previous value will be discarded and overwritten with the provided one.
     */
-  def withKey[T](key: Context.Key[T], value: T): Context = {
+  def withEntry[T](key: Context.Key[T], value: T): Context = {
     if(key == Span.Key)
       new Context(_underlying, value.asInstanceOf[Span], tags)
     else {
@@ -76,7 +76,7 @@ class Context private (private val _underlying: UnifiedMap[String, Any], private
   /**
     * Creates a new Context without the specified Context entry.
     */
-  def withoutKey[T](key: Context.Key[T]): Context = {
+  def withoutEntry[T](key: Context.Key[T]): Context = {
     if(_underlying.containsKey(key.name)) {
       if (key == Span.Key)
         if(_span.isEmpty) this else new Context(_underlying, Span.Empty, tags)

--- a/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -61,7 +61,7 @@ object SpanPropagation {
           case _ => SamplingDecision.Unknown
         }
 
-        context.withKey(Span.Key, new Span.Remote(spanID, parentID, Trace(traceID, samplingDecision)))
+        context.withEntry(Span.Key, new Span.Remote(spanID, parentID, Trace(traceID, samplingDecision)))
 
       } else context
     }
@@ -138,7 +138,7 @@ object SpanPropagation {
             case _ => SamplingDecision.Unknown
           }
 
-          context.withKey(Span.Key, new Span.Remote(si, parentID, Trace(ti, sd)))
+          context.withEntry(Span.Key, new Span.Remote(si, parentID, Trace(ti, sd)))
         } else context
       }.getOrElse(context)
     }
@@ -216,7 +216,7 @@ object SpanPropagation {
         val colferSpan = new ColferSpan()
         colferSpan.unmarshal(medium.readAll(), 0)
 
-        context.withKey(Span.Key, new Span.Remote(
+        context.withEntry(Span.Key, new Span.Remote(
           id = identityProvider.spanIdFactory.from(colferSpan.spanID),
           parentId = identityProvider.spanIdFactory.from(colferSpan.parentID),
           trace = Trace(


### PR DESCRIPTION
After going through all modules updating code and trying to help out people do little bits of manual context propagation it seemed like the new `.storeXXX` methods are not really explicit about what they do. Earlier they were called `.withXXX` (e.g. `Kamon.withSpan(...) {....}`) but they were changed because of inconsistency with other parts of the codebase where all methods starting with `.with` are always returning a new/modified version of the object in which they were called. After some consideration, it seems like the `.runWith` prefix makes it a lot easier to understand what is happening and more importantly, to give implicitly express that there is a scope for the action: only while the provided function runs.

This would be the very last change before release 2.0 and since it doesn't change any semantics but only naming, I would vote for merging and starting the release of all modules.