### PR TITLE
allow adding several tags to Span/SpanBuilder at once, rename tagMetric

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/trace/SpanMetricsSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/SpanMetricsSpec.scala
@@ -64,9 +64,9 @@ class SpanMetricsSpec extends WordSpecLike with Matchers with InstrumentInspecti
     "allow specifying custom Span metric tags" in {
       val operation = "span-with-custom-metric-tags"
       spanBuilder(operation)
-        .tagMetric("custom-metric-tag-on-builder", "value")
+        .tagMetrics("custom-metric-tag-on-builder", "value")
         .start()
-        .tagMetric("custom-metric-tag-on-span", "value")
+        .tagMetrics("custom-metric-tag-on-span", "value")
         .finish()
 
       Span.Metrics.ProcessingTime.tagValues("custom-metric-tag-on-builder") should contain("value")

--- a/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
@@ -40,8 +40,8 @@ class TracerSpec extends WordSpec with Matchers with SpanInspection.Syntax with 
 
     "pass the operation name and tags to started Span" in {
       val span = Kamon.spanBuilder("myOperation")
-        .tagMetric("metric-tag", "value")
-        .tagMetric("metric-tag", "value")
+        .tagMetrics("metric-tag", "value")
+        .tagMetrics("metric-tag", "value")
         .tag("hello", "world")
         .tag("kamon", "rulez")
         .tag("number", 123)

--- a/kamon-core/src/main/scala/kamon/tag/TagSet.scala
+++ b/kamon-core/src/main/scala/kamon/tag/TagSet.scala
@@ -282,6 +282,9 @@ object TagSet {
     /** Adds a new key/value pair to the builder. */
     def add(key: String, value: Boolean): Builder
 
+    /** Adds all key/value pairs to the builder. */
+    def add(tags: TagSet): Builder
+
     /** Creates a new TagSet instance that includes all valid key/value pairs added to this builder. */
     def build(): TagSet
   }
@@ -462,6 +465,13 @@ object TagSet {
 
       override def add(key: String, value: Boolean): Builder = {
         addPair(key, value)
+        this
+      }
+
+      override def add(tags: TagSet): Builder = {
+        if(tags.nonEmpty())
+          tags.iterator().foreach(t => addPair(t.key, Tag.unwrapValue(t)))
+
         this
       }
 

--- a/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -123,22 +123,34 @@ sealed abstract class Span extends Sampler.Operation {
   def tag(key: String, value: Boolean): Span
 
   /**
-    * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
-    * its value will be overwritten.
+    * Adds all key/value pairs in the provided tags to the Span tags. If a tag with the provided key was already present
+    * then its value will be overwritten.
     */
-  def tagMetric(key: String, value: String): Span
+  def tag(tags: TagSet): Span
 
   /**
     * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
     * its value will be overwritten.
     */
-  def tagMetric(key: String, value: Long): Span
+  def tagMetrics(key: String, value: String): Span
 
   /**
     * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
     * its value will be overwritten.
     */
-  def tagMetric(key: String, value: Boolean): Span
+  def tagMetrics(key: String, value: Long): Span
+
+  /**
+    * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
+    * its value will be overwritten.
+    */
+  def tagMetrics(key: String, value: Boolean): Span
+
+  /**
+    * Adds all key/value pairs in the provided tags to the Span metric tags. If a tag with the provided key was already
+    * present then its value will be overwritten.
+    */
+  def tagMetrics(tags: TagSet): Span
 
   /**
     * Adds a new mark with the provided key using the current instant from Kamon's clock.
@@ -439,21 +451,33 @@ object Span {
       this
     }
 
-    override def tagMetric(key: String, value: String): Span = synchronized {
+    override def tag(tags: TagSet): Span = synchronized {
+      if(isSampled && _isOpen)
+        _spanTags.add(tags)
+      this
+    }
+
+    override def tagMetrics(key: String, value: String): Span = synchronized {
       if(_isOpen && _trackMetrics)
         _metricTags.add(key, value)
       this
     }
 
-    override def tagMetric(key: String, value: Long): Span = synchronized {
+    override def tagMetrics(key: String, value: Long): Span = synchronized {
       if(_isOpen && _trackMetrics)
         _metricTags.add(key, value)
       this
     }
 
-    override def tagMetric(key: String, value: Boolean): Span = synchronized {
+    override def tagMetrics(key: String, value: Boolean): Span = synchronized {
       if(_isOpen && _trackMetrics)
         _metricTags.add(key, value)
+      this
+    }
+
+    override def tagMetrics(tags: TagSet): Span = synchronized {
+      if(_isOpen && _trackMetrics)
+        _metricTags.add(tags)
       this
     }
 
@@ -647,9 +671,11 @@ object Span {
     override def tag(key: String, value: String): Span = this
     override def tag(key: String, value: Long): Span = this
     override def tag(key: String, value: Boolean): Span = this
-    override def tagMetric(key: String, value: String): Span = this
-    override def tagMetric(key: String, value: Long): Span = this
-    override def tagMetric(key: String, value: Boolean): Span = this
+    override def tag(tagSet: TagSet): Span = this
+    override def tagMetrics(key: String, value: String): Span = this
+    override def tagMetrics(key: String, value: Long): Span = this
+    override def tagMetrics(key: String, value: Boolean): Span = this
+    override def tagMetrics(tagSet: TagSet): Span = this
     override def mark(key: String): Span = this
     override def mark(key: String, at: Instant): Span = this
     override def link(span: Span, kind: Link.Kind): Span = this
@@ -680,9 +706,11 @@ object Span {
     override def tag(key: String, value: String): Span = this
     override def tag(key: String, value: Long): Span = this
     override def tag(key: String, value: Boolean): Span = this
-    override def tagMetric(key: String, value: String): Span = this
-    override def tagMetric(key: String, value: Long): Span = this
-    override def tagMetric(key: String, value: Boolean): Span = this
+    override def tag(tagSet: TagSet): Span = this
+    override def tagMetrics(key: String, value: String): Span = this
+    override def tagMetrics(key: String, value: Long): Span = this
+    override def tagMetrics(key: String, value: Boolean): Span = this
+    override def tagMetrics(tagSet: TagSet): Span = this
     override def mark(key: String): Span = this
     override def mark(key: String, at: Instant): Span = this
     override def link(span: Span, kind: Link.Kind): Span = this

--- a/kamon-core/src/main/scala/kamon/trace/SpanBuilder.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanBuilder.scala
@@ -62,6 +62,12 @@ trait SpanBuilder extends Sampler.Operation {
   def tag(key: String, value: Boolean): SpanBuilder
 
   /**
+    * Adds all key/value pairs in the provided tags to the Span tags. If a tag with the provided key was already present
+    * then its value will be overwritten.
+    */
+  def tag(tags: TagSet): SpanBuilder
+
+  /**
     * Returns the Span tags that have been added so far to the SpanBuilder.
     */
   def tags(): TagSet
@@ -70,19 +76,25 @@ trait SpanBuilder extends Sampler.Operation {
     * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
     * its value will be overwritten.
     */
-  def tagMetric(key: String, value: String): SpanBuilder
+  def tagMetrics(key: String, value: String): SpanBuilder
 
   /**
     * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
     * its value will be overwritten.
     */
-  def tagMetric(key: String, value: Long): SpanBuilder
+  def tagMetrics(key: String, value: Long): SpanBuilder
 
   /**
     * Adds the provided key/value pair to the Span metric tags. If a tag with the provided key was already present then
     * its value will be overwritten.
     */
-  def tagMetric(key: String, value: Boolean): SpanBuilder
+  def tagMetrics(key: String, value: Boolean): SpanBuilder
+
+  /**
+    * Adds all key/value pairs in the provided tags to the Span metric tags. If a tag with the provided key was already
+    * present then its value will be overwritten.
+    */
+  def tagMetrics(tags: TagSet): SpanBuilder
 
   /**
     * Returns the Span metric tags that have been added so far to the SpanBuilder.

--- a/kamon-core/src/main/scala/kamon/trace/Tracer.scala
+++ b/kamon-core/src/main/scala/kamon/trace/Tracer.scala
@@ -71,7 +71,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
     * generating the Span.
     */
   def serverSpanBuilder(operationName: String, component: String): SpanBuilder =
-    spanBuilder(operationName).kind(Kind.Server).tagMetric(Span.TagKeys.Component, component)
+    spanBuilder(operationName).kind(Kind.Server).tagMetrics(Span.TagKeys.Component, component)
 
 
   /**
@@ -80,7 +80,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
     * generating the Span.
     */
   def clientSpanBuilder(operationName: String, component: String): SpanBuilder =
-    spanBuilder(operationName).kind(Kind.Client).tagMetric(Span.TagKeys.Component, component)
+    spanBuilder(operationName).kind(Kind.Client).tagMetrics(Span.TagKeys.Component, component)
 
 
   /**
@@ -89,7 +89,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
     * generating the Span.
     */
   def producerSpanBuilder(operationName: String, component: String): SpanBuilder =
-    spanBuilder(operationName).kind(Kind.Producer).tagMetric(Span.TagKeys.Component, component)
+    spanBuilder(operationName).kind(Kind.Producer).tagMetrics(Span.TagKeys.Component, component)
 
 
   /**
@@ -98,7 +98,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
     * generating the Span.
     */
   def consumerSpanBuilder(operationName: String, component: String): SpanBuilder =
-    spanBuilder(operationName).kind(Kind.Consumer).tagMetric(Span.TagKeys.Component, component)
+    spanBuilder(operationName).kind(Kind.Consumer).tagMetrics(Span.TagKeys.Component, component)
 
 
   /**
@@ -107,7 +107,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
     * generating the Span.
     */
   def internalSpanBuilder(operationName: String, component: String): SpanBuilder =
-    spanBuilder(operationName).kind(Kind.Internal).tagMetric(Span.TagKeys.Component, component)
+    spanBuilder(operationName).kind(Kind.Internal).tagMetrics(Span.TagKeys.Component, component)
 
 
   /**
@@ -172,18 +172,28 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
       this
     }
 
-    override def tagMetric(key: String, value: String): SpanBuilder = {
+    override def tag(tags: TagSet): SpanBuilder = {
+      _spanTags.add(tags)
+      this
+    }
+
+    override def tagMetrics(key: String, value: String): SpanBuilder = {
       _metricTags.add(key, value)
       this
     }
 
-    override def tagMetric(key: String, value: Long): SpanBuilder = {
+    override def tagMetrics(key: String, value: Long): SpanBuilder = {
       _metricTags.add(key, value)
       this
     }
 
-    override def tagMetric(key: String, value: Boolean): SpanBuilder = {
+    override def tagMetrics(key: String, value: Boolean): SpanBuilder = {
       _metricTags.add(key, value)
+      this
+    }
+
+    override def tagMetrics(tags: TagSet): SpanBuilder = {
+      _metricTags.add(tags)
       this
     }
 


### PR DESCRIPTION
There are two small changes here:
- Allowing to add a `TagSet` to a Span/SpanBuilder, which becomes really convenient when writing instrumentation.
- Changing the name of `[Span|SpanBuilder].tagMetric` to `[Span|SpanBuilder].tagMetrics` (just that little `s` at the end). This is a minor nitpicking on my side, motivated by the fact that now a Span could track more than one metric (since we introduced delayed Spans) and given that we are just about to release 2.0, this is a now or on 3.0 change, better to do it right away!