### PR TITLE
keep the module registry schedulers alive after stopping all modules, fixes #604

### DIFF
--- a/kamon-core/src/main/scala/kamon/ModuleLoading.scala
+++ b/kamon-core/src/main/scala/kamon/ModuleLoading.scala
@@ -70,6 +70,6 @@ trait ModuleLoading { self: Configuration with Utilities with Metrics with Traci
     * have been completed. This includes automatically and programmatically registered modules.
     */
   def stopModules(): Future[Unit] =
-    _moduleRegistry.stop()
+    _moduleRegistry.stopModules()
 
 }


### PR DESCRIPTION
This leaves the ModuleRegistry schedulers running after all modules have stopped, which allows for them to be started again in the same JVM.