### PR TITLE
+ core: provide span propagation codec for "uber-trace-id", default jaeger format

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/trace/UberSpanPropagationSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/trace/UberSpanPropagationSpec.scala
@@ -1,0 +1,182 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2018 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.trace
+
+import kamon.context.{Context, HttpPropagation}
+import kamon.trace.Trace.SamplingDecision
+import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+
+import scala.collection.mutable
+
+
+class UberSpanPropagationSpec extends WordSpecLike with Matchers with OptionValues {
+  import SpanPropagation.UberSpanCodec
+  val uberPropagation = UberSpanCodec()
+
+  "The Uber SpanContextCodec" should {
+    "return a TextMap containing the SpanContext data" in {
+      val headersMap = mutable.Map.empty[String, String]
+      uberPropagation.write(testContext(), headerWriterFromMap(headersMap))
+
+      headersMap.get("uber-trace-id").value shouldBe "1234%3A4321%3A2222%3A1"
+    }
+
+    "do not include the ParentSpanId if there is no parent" in {
+      val headersMap = mutable.Map.empty[String, String]
+      uberPropagation.write(testContextWithoutParent(), headerWriterFromMap(headersMap))
+
+      headersMap.get(UberSpanCodec.HeaderName).value shouldBe "1234%3A4321%3A0%3A1"
+    }
+
+
+    "not inject anything if there is no Span in the Context" in {
+      val headersMap = mutable.Map.empty[String, String]
+      uberPropagation.write(Context.Empty, headerWriterFromMap(headersMap))
+
+      headersMap.values shouldBe empty
+    }
+
+    "extract a RemoteSpan from a TextMap when all fields are set" in {
+      val headersMap = Map(UberSpanCodec.HeaderName -> "1234:4321:2222:1")
+
+      val span = uberPropagation.read(headerReaderFromMap(headersMap), Context.Empty).get(Span.Key)
+
+      span.id.string shouldBe "4321"
+      span.parentId.string shouldBe "2222"
+      span.trace.id.string shouldBe "1234"
+      span.trace.samplingDecision shouldBe SamplingDecision.Sample
+    }
+
+    "decode the sampling decision based on the 'uber-trace-id' header" in {
+      val sampledHeadersMap = Map(UberSpanCodec.HeaderName -> "1234:4321:0:1")
+
+      val notSampledHeadersMap = Map(UberSpanCodec.HeaderName -> "1234:4321:0:0")
+
+      val noSamplingHeadersMap = Map(UberSpanCodec.HeaderName -> "1234:4321") // is not part of the spec
+
+      uberPropagation.read(headerReaderFromMap(sampledHeadersMap), Context.Empty)
+        .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.Sample
+
+      uberPropagation.read(headerReaderFromMap(notSampledHeadersMap), Context.Empty)
+        .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.DoNotSample
+
+      uberPropagation.read(headerReaderFromMap(noSamplingHeadersMap), Context.Empty)
+        .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.Unknown
+    }
+
+    "include the sampled header if the sampling decision is unknown" in {
+      val context = testContext()
+      val sampledSpan = context.get(Span.Key)
+      val notSampledSpanContext = Context.Empty.withEntry(Span.Key,
+        Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.DoNotSample)))
+      val unknownSamplingSpanContext = Context.Empty.withEntry(Span.Key,
+        Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.Unknown)))
+
+      val headersMap = mutable.Map.empty[String, String]
+
+      uberPropagation.write(context, headerWriterFromMap(headersMap))
+      headersMap.get(UberSpanCodec.HeaderName).value shouldBe "1234%3A4321%3A2222%3A1"
+      headersMap.clear()
+
+      uberPropagation.write(notSampledSpanContext, headerWriterFromMap(headersMap))
+      headersMap.get(UberSpanCodec.HeaderName).value shouldBe "1234%3A4321%3A2222%3A0"
+      headersMap.clear()
+
+      uberPropagation.write(unknownSamplingSpanContext,headerWriterFromMap(headersMap))
+      headersMap.get(UberSpanCodec.HeaderName).value shouldBe "1234%3A4321%3A2222%3A1"
+      headersMap.clear()
+    }
+
+    "use the Debug flag to override the sampling decision, if provided." in {
+      val headers = Map(UberSpanCodec.HeaderName -> "1234:4321:2222:d")
+
+      val span = uberPropagation.read(headerReaderFromMap(headers), Context.Empty).get(Span.Key)
+      span.trace.samplingDecision shouldBe SamplingDecision.Sample
+    }
+
+    "use the Debug flag as sampling decision when Sampled is not provided" in {
+      val headers = Map(UberSpanCodec.HeaderName -> "1234:4321:0:d")
+
+      val span = uberPropagation.read(headerReaderFromMap(headers), Context.Empty).get(Span.Key)
+      span.trace.samplingDecision shouldBe SamplingDecision.Sample
+    }
+
+    "extract a minimal SpanContext from a TextMap containing only the Trace ID and Span ID" in {
+      val headers = Map(UberSpanCodec.HeaderName -> "1234:4321")
+
+      val span = uberPropagation.read(headerReaderFromMap(headers), Context.Empty).get(Span.Key)
+      span.id.string shouldBe "4321"
+      span.parentId shouldBe Identifier.Empty
+      span.trace.id.string shouldBe "1234"
+      span.trace.samplingDecision shouldBe SamplingDecision.Unknown
+    }
+
+    "do not extract a SpanContext if Trace ID and Span ID are not provided" in {
+      val onlyTraceID = Map(UberSpanCodec.HeaderName -> "1234::0")
+      val onlySpanID = Map(UberSpanCodec.HeaderName -> ":4321:d")
+      val noIds = Map(UberSpanCodec.HeaderName -> "::0")
+
+      uberPropagation.read(headerReaderFromMap(onlyTraceID), Context.Empty).get(Span.Key) shouldBe Span.Empty
+      uberPropagation.read(headerReaderFromMap(onlySpanID), Context.Empty).get(Span.Key) shouldBe Span.Empty
+      uberPropagation.read(headerReaderFromMap(noIds), Context.Empty).get(Span.Key) shouldBe Span.Empty
+    }
+
+    "round trip a Span from TextMap -> Context -> TextMap" in {
+      val headers = Map(UberSpanCodec.HeaderName -> "1234:4312:2222:1")
+
+      val writenHeaders = mutable.Map.empty[String, String]
+      val context = uberPropagation.read(headerReaderFromMap(headers), Context.Empty)
+      uberPropagation.write(context, headerWriterFromMap(writenHeaders))
+      writenHeaders.map { case (k, v) => k -> SpanPropagation.Util.urlDecode(v) } should contain theSameElementsAs headers
+    }
+  }
+
+  def headerReaderFromMap(map: Map[String, String]): HttpPropagation.HeaderReader = new HttpPropagation.HeaderReader {
+    override def read(header: String): Option[String] = {
+      if(map.get("fail").nonEmpty)
+        sys.error("failing on purpose")
+
+      map.get(header)
+    }
+
+    override def readAll(): Map[String, String] = map
+  }
+
+  def headerWriterFromMap(map: mutable.Map[String, String]): HttpPropagation.HeaderWriter = new HttpPropagation.HeaderWriter {
+    override def write(header: String, value: String): Unit = map.put(header, value)
+  }
+
+  def testContext(): Context =
+    Context.of(Span.Key, new Span.Remote(
+      id = Identifier("4321", Array[Byte](4, 3, 2, 1)),
+      parentId = Identifier("2222", Array[Byte](2, 2, 2, 2)),
+      trace = Trace(
+        id = Identifier("1234", Array[Byte](1, 2, 3, 4)),
+        samplingDecision = SamplingDecision.Sample
+      )
+    ))
+
+  def testContextWithoutParent(): Context =
+    Context.of(Span.Key, new Span.Remote(
+      id = Identifier("4321", Array[Byte](4, 3, 2, 1)),
+      parentId = Identifier.Empty,
+      trace = Trace(
+        id = Identifier("1234", Array[Byte](1, 2, 3, 4)),
+        samplingDecision = SamplingDecision.Sample
+      )
+    ))
+}

--- a/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -25,11 +25,20 @@ import kamon.context.generated.binary.span.{Span => ColferSpan}
 import kamon.context.{Context, _}
 import kamon.trace.Trace.SamplingDecision
 
+import scala.util.Try
+
 
 /**
   * Propagation mechanisms for Kamon's Span data to and from HTTP and Binary mediums.
   */
 object SpanPropagation {
+
+  object Util {
+    def urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8")
+    def urlDecode(s: String): String = URLDecoder.decode(s, "UTF-8")
+  }
+
+  import Util._
 
   /**
     * Reads and Writes a Span instance using the B3 propagation format. The specification and semantics of the B3
@@ -88,8 +97,6 @@ object SpanPropagation {
       case SamplingDecision.Unknown     => None
     }
 
-    private def urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8")
-    private def urlDecode(s: String): String = URLDecoder.decode(s, "UTF-8")
   }
 
   object B3 {
@@ -170,8 +177,6 @@ object SpanPropagation {
       case SamplingDecision.Unknown     => None
     }
 
-    private def urlEncode(s: String): String = URLEncoder.encode(s, "UTF-8")
-    private def urlDecode(s: String): String = URLDecoder.decode(s, "UTF-8")
   }
 
   object B3Single {
@@ -193,6 +198,80 @@ object SpanPropagation {
       new B3Single()
   }
 
+
+  /**
+   * Reads and Writes a Span instance using the jaeger single-header propagation format.
+   * The specification and semantics can be found here:
+   *   https://www.jaegertracing.io/docs/1.7/client-libraries/#propagation-format
+   *
+   * The description somewhat ambiguous, a lots of implementation details are second-guessed from existing clients
+   */
+  object UberSpanCodec {
+    def apply(): UberSpanCodec = new UberSpanCodec()
+    val HeaderName = "uber-trace-id"
+    val Separator = ":"
+    val Default = "0"
+    val DebugFlag = "d"
+  }
+
+  class UberSpanCodec extends Propagation.EntryReader[HeaderReader] with Propagation.EntryWriter[HeaderWriter] {
+    import UberSpanCodec._
+
+    override def write(context: Context, writer: HttpPropagation.HeaderWriter): Unit = {
+      val span = context.get(Span.Key)
+
+      if (span != Span.Empty) {
+        val parentContext = if (span.parentId != Identifier.Empty) span.parentId.string else Default
+        val sampling = encodeSamplingDecision(span.trace.samplingDecision)
+        val debug: Byte = 0
+        val flags = (sampling + (debug << 1)).toHexString
+        val headerValue = Seq(span.trace.id.string, span.id.string, parentContext, flags).mkString(Separator)
+
+        writer.write(HeaderName, urlEncode(headerValue))
+      }
+
+    }
+
+    override def read(reader: HttpPropagation.HeaderReader, context: Context): Context = {
+      val identifierScheme = Kamon.identifierScheme
+      val header = reader.read(HeaderName)
+      val headerParts = header.toList.flatMap(_.split(':'))
+      val parts = headerParts ++ List.fill(4)("") // all parts are mandatory, but we want to be resilient
+
+      val List(traceID, spanID, parentContext, flags) = parts.take(4)
+      val trace = stringToId(identifierScheme, traceID)
+      val span = stringToId(identifierScheme, spanID)
+
+      if (trace != Identifier.Empty && span != Identifier.Empty) {
+        val parent = stringToId(identifierScheme, parentContext)
+        val samplingDecision = decodeSamplingDecision(flags)
+        context.withEntry(Span.Key, Span.Remote(span, parent, Trace(trace, samplingDecision)))
+      } else {
+        context
+      }
+    }
+
+    private def stringToId(identifierScheme: Identifier.Scheme, s: String) = {
+      val str = if (s == null || s.isEmpty) None else Option(s)
+      val id = str.map(urlDecode).map(identifierScheme.traceIdFactory.from)
+      id.getOrElse(Identifier.Empty)
+    }
+
+    private def lowestBit(s: String) = Try(Integer.parseInt(s, 16) % 2).toOption
+
+    private def decodeSamplingDecision(flags: String) =
+      if (flags.equalsIgnoreCase(DebugFlag)) SamplingDecision.Sample
+      else if (lowestBit(flags).contains(1)) SamplingDecision.Sample
+      else if (lowestBit(flags).contains(0)) SamplingDecision.DoNotSample
+      else SamplingDecision.Unknown
+
+    private def encodeSamplingDecision(samplingDecision: SamplingDecision): Byte = samplingDecision match {
+      case SamplingDecision.Sample      => 1
+      case SamplingDecision.DoNotSample => 0
+      case SamplingDecision.Unknown     => 1 // the sampling decision is mandatory in this format
+    }
+
+  }
 
   /**
     * Defines a bare bones binary context propagation that uses Colfer [1] as the serialization library. The Schema

--- a/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -268,7 +268,7 @@ object SpanPropagation {
     private def encodeSamplingDecision(samplingDecision: SamplingDecision): Byte = samplingDecision match {
       case SamplingDecision.Sample      => 1
       case SamplingDecision.DoNotSample => 0
-      case SamplingDecision.Unknown     => 1 // the sampling decision is mandatory in this format
+      case SamplingDecision.Unknown     => 0 // the sampling decision is mandatory in this format
     }
 
   }


### PR DESCRIPTION
…as described here: https://www.jaegertracing.io/docs/1.7/client-libraries/#propagation-format