### PR TITLE
Take the enabled flag into account

### DIFF
--- a/kamon-status-page/src/main/scala/kamon/status/page/StatusPage.scala
+++ b/kamon-status-page/src/main/scala/kamon/status/page/StatusPage.scala
@@ -42,24 +42,26 @@ class StatusPage(configPath: String) extends Module {
     init(newConfig.getConfig(configPath))
 
 
-  private def init(config: Config): Unit = synchronized {
-    val hostname = config.getString("listen.hostname")
-    val port = config.getInt("listen.port")
+  private def init(config: Config): Unit = if (config.getBoolean("enabled")) {
+    synchronized {
+     val hostname = config.getString("listen.hostname")
+     val port = config.getInt("listen.port")
 
-    _statusPageServer.fold {
-      // Starting a new server on the configured hostname/port
-      startServer(hostname, port, ClassLoading.classLoader())
+     _statusPageServer.fold {
+       // Starting a new server on the configured hostname/port
+       startServer(hostname, port, ClassLoading.classLoader())
 
-    }(existentServer => {
-      // If the configuration has changed we will stop the previous version
-      // and start a new one with the new hostname/port.
-
-      if(existentServer.getHostname != hostname || existentServer.getListeningPort != port) {
-        stopServer()
-        startServer(hostname, port, ClassLoading.classLoader())
-      }
-    })
-  }
+     }(existentServer => {
+       // If the configuration has changed we will stop the previous version
+       // and start a new one with the new hostname/port.
+       {
+       if(existentServer.getHostname != hostname || existentServer.getListeningPort != port) {
+         stopServer()
+         startServer(hostname, port, ClassLoading.classLoader())
+       }
+       })
+    }
+  } else stopServer()
 
   private def startServer(hostname: String, port: Int, resourceLoader: ClassLoader): Unit = {
     Try {


### PR DESCRIPTION
The `kamon.status-page.enabled = false` is always starting the statuspage server.

This PR will stop the server on reload, and on creation.