### PR TITLE
show the right error message when metric redefinitions happen, fixes #608

### DIFF
--- a/kamon-core-tests/src/test/scala/kamon/metric/MetricLookupSpec.scala
+++ b/kamon-core-tests/src/test/scala/kamon/metric/MetricLookupSpec.scala
@@ -48,6 +48,38 @@ class MetricLookupSpec extends WordSpec with Matchers {
         val rangeSamplerTwo = Kamon.rangeSampler("range-sampler-lookup")
         rangeSamplerOne shouldBe theSameInstanceAs(rangeSamplerTwo)
       }
+
+      "throw an IllegalArgumentException when a metric redefinition is attempted" in {
+        the[IllegalArgumentException] thrownBy {
+          Kamon.counter("original-counter")
+          Kamon.gauge("original-counter")
+
+        } should have message(redefinitionError("original-counter", "counter", "gauge"))
+
+        the[IllegalArgumentException] thrownBy {
+          Kamon.counter("original-counter")
+          Kamon.histogram("original-counter")
+
+        } should have message(redefinitionError("original-counter", "counter", "histogram"))
+
+        the[IllegalArgumentException] thrownBy {
+          Kamon.counter("original-counter")
+          Kamon.rangeSampler("original-counter")
+
+        } should have message(redefinitionError("original-counter", "counter", "rangeSampler"))
+
+        the[IllegalArgumentException] thrownBy {
+          Kamon.counter("original-counter")
+          Kamon.timer("original-counter")
+
+        } should have message(redefinitionError("original-counter", "counter", "timer"))
+
+        the[IllegalArgumentException] thrownBy {
+          Kamon.histogram("original-histogram")
+          Kamon.counter("original-histogram")
+
+        } should have message(redefinitionError("original-histogram", "histogram", "counter"))
+      }
     }
 
     "refine a metric with tags and" should {
@@ -88,4 +120,7 @@ class MetricLookupSpec extends WordSpec with Matchers {
       }
     }
   }
+
+  def redefinitionError(name: String, currentType: String, newType: String): String =
+    s"Cannot redefine metric [$name] as a [$newType], it was already registered as a [$currentType]"
 }


### PR DESCRIPTION
There was a bit of code checking that metrics will not get "redefined" with a different type but there was a cast before it that would always fail. This PR ensures that the right message is shown when throwing a redefinition error.