### PR TITLE
Removed the config kamon.status-page.enabled

### DIFF
--- a/kamon-status-page/src/main/resources/reference.conf
+++ b/kamon-status-page/src/main/resources/reference.conf
@@ -1,10 +1,6 @@
 kamon {
   status-page {
 
-    # When enabled Kamon will start an embedded web server to publish the status page mini-site, which contains basic
-    # system information that can be used for debugging and troubleshooting issues with Kamon.
-    enabled = true
-
     # Controls the hostname and port on which the status page embedded server will be listening.
     listen {
       hostname = "0.0.0.0"


### PR DESCRIPTION
According to discussion this should not be in the config, nor is there any code that uses it.
This is related to my duplicate ticket #620 and to the discussion in PR #613 which seems to have gone stale. Since the config apparently should not be there I went ahead and removed it