### PR TITLE
Config utils pairs fix

### DIFF
--- a/kamon-core/src/main/scala/kamon/package.scala
+++ b/kamon-core/src/main/scala/kamon/package.scala
@@ -93,9 +93,9 @@ package object kamon {
     }
 
     def pairs: Map[String, String] = {
-      topLevelKeys
-        .map(key => (key, config.getString(key)))
-        .toMap
+      config.root().entrySet().asScala.map { entry =>
+        (entry.getKey, entry.getValue.unwrapped().asInstanceOf[String])
+      }.toMap
     }
   }
 }


### PR DESCRIPTION
Extract key-value pairs directly from config entry set. Extracting topLevelKeys and then fetching values by key will explode in cases where key is not a valid `com.typesafe.config.impl.Path` (globs).
Fixes kamon-io/kamon-akka-http#72