### PR TITLE
Make `context.Storage.Scope` `AutoCloseable`

### DIFF
--- a/kamon-core/src/main/scala/kamon/context/Storage.scala
+++ b/kamon-core/src/main/scala/kamon/context/Storage.scala
@@ -43,7 +43,7 @@ object Storage {
     * Encapsulates the extend during which a Context is held by an Storage implementation. Once a Scope is closed, the
     * Context will be removed from the Storage that created the Scope.
     */
-  trait Scope {
+  trait Scope extends AutoCloseable {
 
     /**
       * Returns the Context managed by this Scope.


### PR DESCRIPTION
For a small convenience increase when using it with `scala.util.Using`, `cats.effect.Resource` or whatever resource management tools one might use.