### PR TITLE
kamon-twitter-future and kamon-cats-io Cross compile 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: scala
 script:
   - sbt +test
-scala:
-   - 2.12.6
 jdk:
    - openjdk8
 before_script:
   - mkdir $TRAVIS_BUILD_DIR/tmp
   - export SBT_OPTS="-Djava.io.tmpdir=$TRAVIS_BUILD_DIR/tmp"
 sudo: false
-  
+

--- a/build.sbt
+++ b/build.sbt
@@ -189,16 +189,15 @@ def groupByExperimentalExecutorTests(tests: Seq[TestDefinition], kanelaJar: File
 
 val twitterUtilCore  = "com.twitter"   %% "util-core"         % "6.40.0"
 val scalazConcurrent = "org.scalaz"    %% "scalaz-concurrent" % "7.2.28"
-val catsEffect       = "org.typelevel" %%  "cats-effect"      % "1.2.0"
+val catsEffect       = "org.typelevel" %%  "cats-effect"      % "2.1.2"
 
 lazy val `kamon-twitter-future` = (project in file("instrumentation/kamon-twitter-future"))
   .disablePlugins(AssemblyPlugin)
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
   .settings(
-    scalaVersion := "2.12.10",
     bintrayPackage := "kamon-futures",
-    crossScalaVersions := Seq("2.11.12", "2.12.10"),
+    crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
     libraryDependencies ++=
       providedScope(kanelaAgent, twitterUtilCore) ++
       testScope(scalatest, logbackClassic)
@@ -231,9 +230,8 @@ lazy val `kamon-cats-io` = (project in file("instrumentation/kamon-cats-io"))
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
   .settings(
-    scalaVersion := "2.12.10",
     bintrayPackage := "kamon-futures",
-    crossScalaVersions := Seq("2.11.12", "2.12.10"),
+    crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
     libraryDependencies ++=
       providedScope(catsEffect, kanelaAgent) ++
       testScope(scalatest, logbackClassic)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -104,7 +104,7 @@ object BaseProject extends AutoPlugin {
 
   private lazy val compilationSettings = Seq(
     crossPaths := true,
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.13.1",
     crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
     javacOptions := Seq(
       "-source", "1.8",


### PR DESCRIPTION
Add cross compilation for `kamon-twitter-future` and `kamon-cats-io` to scala 2.13

This should replace both
https://github.com/kamon-io/kamon-futures/pull/15
https://github.com/kamon-io/kamon-futures/pull/17