### PR TITLE
Remove nanohttpd from the prometheus reporter since it is unmaintaine…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -507,7 +507,6 @@ lazy val `kamon-prometheus` = (project in file("reporters/kamon-prometheus"))
   .settings(
     libraryDependencies ++= Seq(
       okHttp,
-      "org.nanohttpd" % "nanohttpd" % "2.3.1",
       scalatest % "test",
       logbackClassic % "test"
     )

--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -64,6 +64,12 @@ kamon.prometheus {
     # Hostname and port used by the embedded web server to publish the scraping enpoint.
     hostname = "0.0.0.0"
     port = 9095
+
+    # embedded server impl
+    # choose between
+    # - sun ->using openjdk/jdk com.sun.net.httpserver
+    # - anyFQCN ->classname of a subclass of kamon.prometheus.EmbeddedHttpServer
+    impl = "sun"
   }
 
   # Specify metric name overrides here

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/HttpClient.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/HttpClient.scala
@@ -21,11 +21,11 @@ class HttpClient(val apiUrl: String, connectTimeout: Duration, readTimeout: Dura
     )
   }
 
-  private def doRequest(request: Request): Try[Response] = {
-    Try(httpClient.newCall(request).execute())
+  def doPost(contentType: String, contentBody: Array[Byte]): Try[String] = {
+    doMethodWithBody("POST", contentType, contentBody)
   }
 
-  def doMethodWithBody(method: String, contentType: String, contentBody: Array[Byte]): Try[String] = {
+  private def doMethodWithBody(method: String, contentType: String, contentBody: Array[Byte]): Try[String] = {
     val body = RequestBody.create(MediaType.parse(contentType), contentBody)
     val request = new Request.Builder().url(apiUrl).method(method, body).build
 
@@ -46,8 +46,8 @@ class HttpClient(val apiUrl: String, connectTimeout: Duration, readTimeout: Dura
     }
   }
 
-  def doPost(contentType: String, contentBody: Array[Byte]): Try[String] = {
-    doMethodWithBody("POST", contentType, contentBody)
+  private def doRequest(request: Request): Try[Response] = {
+    Try(httpClient.newCall(request).execute())
   }
 
   private def createHttpClient(): OkHttpClient = {

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/EmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/EmbeddedHttpServer.scala
@@ -1,0 +1,8 @@
+package kamon.prometheus.embeddedhttp
+
+import com.typesafe.config.Config
+import kamon.prometheus.ScrapeSource
+
+abstract class EmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSource, config: Config) {
+  def stop(): Unit
+}

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
@@ -1,0 +1,33 @@
+package kamon.prometheus.embeddedhttp
+
+import java.net.{InetAddress, InetSocketAddress}
+import java.nio.charset.StandardCharsets
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import com.typesafe.config.Config
+import kamon.prometheus.ScrapeSource
+
+class SunEmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSource, config: Config) extends EmbeddedHttpServer(hostname, port, scrapeSource, config) {
+  private val server = {
+    val s = HttpServer.create(new InetSocketAddress(InetAddress.getByName(hostname), port), 0)
+    s.setExecutor(null)
+    val handler = new HttpHandler {
+      override def handle(httpExchange: HttpExchange): Unit = {
+        val data = scrapeSource.scrapeData()
+        httpExchange.sendResponseHeaders(200, data.length)
+        val os = httpExchange.getResponseBody
+        try
+          os.write(data.getBytes(StandardCharsets.UTF_8))
+        finally
+          os.close()
+      }
+
+    }
+    s.createContext("/metrics", handler)
+    s.createContext("/", handler)
+    s.start()
+    s
+  }
+
+  def stop(): Unit = server.stop(0)
+}

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/EmbeddedHttpServerSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/EmbeddedHttpServerSpec.scala
@@ -1,0 +1,77 @@
+package kamon.prometheus
+
+import java.net.URL
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+class SunHttpServerSpecSuite extends EmbeddedHttpServerSpecSuite {
+  override def testConfig: Config = ConfigFactory.load()
+}
+//class NanoHttpServerSpecSuite extends EmbeddedHttpServerSpecSuite {
+//  override def testConfig: Config = ConfigFactory.parseString(
+//    """
+//      kamon.prometheus.embedded-server{
+//        impl=nano
+//        port=9096
+//      }
+//      """).withFallback(ConfigFactory.load())
+//  override def port = 9096
+//}
+
+abstract class EmbeddedHttpServerSpecSuite extends WordSpec with Matchers with BeforeAndAfterAll with KamonTestSnapshotSupport {
+  protected def testConfig: Config
+  protected def port: Int = 9095
+
+  private var testee: PrometheusReporter = _
+
+  override def beforeAll(): Unit = testee = new PrometheusReporter(initialConfig = testConfig)
+
+  override def afterAll(): Unit = testee.stop()
+
+  "the embedded sun http server" should {
+    "provide no data comment on GET to /metrics when no data loaded yet" in {
+      //act
+      val metrics = httpGetMetrics()
+      //assert
+      metrics shouldBe "# The kamon-prometheus module didn't receive any data just yet.\n"
+    }
+
+    "provide the metrics on GET to /metrics with empty data" in {
+      //arrange
+      testee.reportPeriodSnapshot(emptyPeriodSnapshot)
+      //act
+      val metrics = httpGetMetrics()
+      //assert
+      metrics shouldBe ""
+    }
+
+    "provide the metrics on GET to /metrics with data" in {
+      //arrange
+      testee.reportPeriodSnapshot(counter("jvm.mem"))
+      //act
+      val metrics = httpGetMetrics()
+      //assert
+      metrics shouldBe "# TYPE jvm_mem_total counter\njvm_mem_total 1.0\n"
+    }
+
+    "provide the metrics on GET to /metrics with data after reconfigure" in {
+      //arrange
+      testee.reconfigure(testConfig)
+      testee.reportPeriodSnapshot(counter("jvm.mem"))
+      //act
+      val metrics = httpGetMetrics()
+      //assert
+      metrics shouldBe "# TYPE jvm_mem_total counter\njvm_mem_total 2.0\n"
+    }
+  }
+
+
+  private def httpGetMetrics(): String = {
+    val src = scala.io.Source.fromURL(new URL(s"http://127.0.0.1:$port/metrics"))
+    try
+      src.mkString
+    finally
+      src.close()
+  }
+}

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/KamonTestSnapshotSupport.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/KamonTestSnapshotSupport.scala
@@ -1,0 +1,26 @@
+package kamon.prometheus
+
+import kamon.Kamon
+import kamon.metric.PeriodSnapshot
+import kamon.tag.TagSet
+import kamon.testkit.MetricSnapshotBuilder
+
+trait KamonTestSnapshotSupport {
+  val emptyPeriodSnapshot: PeriodSnapshot = PeriodSnapshot(Kamon.clock().instant(), Kamon.clock().instant(),
+    Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty)
+
+  def counter(metricName: String, tags: Map[String, String] = Map.empty): PeriodSnapshot =
+    emptyPeriodSnapshot.copy(counters = Seq(MetricSnapshotBuilder.counter(metricName, TagSet.from(tags), 1L)))
+
+  def gauge(metricName: String, tags: Map[String, String] = Map.empty): PeriodSnapshot =
+    emptyPeriodSnapshot.copy(gauges = Seq(MetricSnapshotBuilder.gauge(metricName, TagSet.from(tags), 1D)))
+
+  def histogram(metricName: String, tags: Map[String, String] = Map.empty): PeriodSnapshot =
+    emptyPeriodSnapshot.copy(histograms = Seq(MetricSnapshotBuilder.histogram(metricName, TagSet.from(tags))(1)))
+
+  def rangeSampler(metricName: String, tags: Map[String, String] = Map.empty): PeriodSnapshot =
+    emptyPeriodSnapshot.copy(rangeSamplers = Seq(MetricSnapshotBuilder.histogram(metricName, TagSet.from(tags))(1)))
+
+  def timers(metricName: String, tags: Map[String, String] = Map.empty): PeriodSnapshot =
+    emptyPeriodSnapshot.copy(rangeSamplers = Seq(MetricSnapshotBuilder.histogram(metricName, TagSet.from(tags))(1)))
+}

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/MetricOverrideReporterSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/MetricOverrideReporterSpec.scala
@@ -23,41 +23,41 @@ import kamon.module.MetricReporter
 import kamon.tag.TagSet
 import org.scalatest.{Matchers, WordSpec}
 
-class MetricOverrideReporterSpec extends WordSpec with Matchers with MetricInspection.Syntax with InstrumentInspection.Syntax {
+class MetricOverrideReporterSpec extends WordSpec with Matchers with MetricInspection.Syntax with InstrumentInspection.Syntax with KamonTestSnapshotSupport {
 
   "A MetricOverrideReporter" should {
     "apply metric overrides" in {
-      report(histogram("default.metric-name", Map.empty)) { snapshot =>
+      report(histogram("default.metric-name")) { snapshot =>
         snapshot.histograms.head.name shouldEqual "new-metric-name"
       }
 
-      report(rangeSampler("default.metric-name", Map.empty)) { snapshot =>
+      report(rangeSampler("default.metric-name")) { snapshot =>
         snapshot.rangeSamplers.head.name shouldEqual "new-metric-name"
       }
 
-      report(gauge("default.metric-name", Map.empty)) { snapshot =>
+      report(gauge("default.metric-name")) { snapshot =>
         snapshot.gauges.head.name shouldEqual "new-metric-name"
       }
 
-      report(counter("default.metric-name", Map.empty)) { snapshot =>
+      report(counter("default.metric-name")) { snapshot =>
         snapshot.counters.head.name shouldEqual "new-metric-name"
       }
     }
 
     "not modify metrics that do not appear in the override configuration" in {
-      report(histogram("other-metric-name", Map.empty)) { snapshot =>
+      report(histogram("other-metric-name")) { snapshot =>
         snapshot.histograms.head.name shouldEqual "other-metric-name"
       }
 
-      report(rangeSampler("other-metric-name", Map.empty)) { snapshot =>
+      report(rangeSampler("other-metric-name")) { snapshot =>
         snapshot.rangeSamplers.head.name shouldEqual "other-metric-name"
       }
 
-      report(gauge("other-metric-name", Map.empty)) { snapshot =>
+      report(gauge("other-metric-name")) { snapshot =>
         snapshot.gauges.head.name shouldEqual "other-metric-name"
       }
 
-      report(counter("other-metric-name", Map.empty)) { snapshot =>
+      report(counter("other-metric-name")) { snapshot =>
         snapshot.counters.head.name shouldEqual "other-metric-name"
       }
     }
@@ -135,7 +135,7 @@ class MetricOverrideReporterSpec extends WordSpec with Matchers with MetricInspe
     }
   }
 
-  val config = ConfigFactory.parseString(
+  val config: Config = ConfigFactory.parseString(
     """
       |kamon.prometheus {
       |  metric-overrides {
@@ -173,21 +173,5 @@ class MetricOverrideReporterSpec extends WordSpec with Matchers with MetricInspe
     assertions(reporter.latestSnapshot)
   }
 
-  val emptyPeriodSnapshot = PeriodSnapshot(Kamon.clock().instant(), Kamon.clock().instant(),
-    Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty)
 
-  def counter(metricName: String, tags: Map[String, String]): PeriodSnapshot =
-    emptyPeriodSnapshot.copy(counters = Seq(MetricSnapshotBuilder.counter(metricName, TagSet.from(tags), 1L)))
-
-  def gauge(metricName: String, tags: Map[String, String]): PeriodSnapshot =
-    emptyPeriodSnapshot.copy(gauges = Seq(MetricSnapshotBuilder.gauge(metricName, TagSet.from(tags), 1D)))
-
-  def histogram(metricName: String, tags: Map[String, String]): PeriodSnapshot =
-    emptyPeriodSnapshot.copy(histograms = Seq(MetricSnapshotBuilder.histogram(metricName, TagSet.from(tags))(1)))
-
-  def rangeSampler(metricName: String, tags: Map[String, String]): PeriodSnapshot =
-    emptyPeriodSnapshot.copy(rangeSamplers = Seq(MetricSnapshotBuilder.histogram(metricName, TagSet.from(tags))(1)))
-
-  def timers(metricName: String, tags: Map[String, String]): PeriodSnapshot =
-    emptyPeriodSnapshot.copy(rangeSamplers = Seq(MetricSnapshotBuilder.histogram(metricName, TagSet.from(tags))(1)))
 }


### PR DESCRIPTION
…d and has major flaws such as doing a reverse dns lookup for every request served

-adds generic EmbeddedHttpServer and a default implementation without needing any other dependencies
-adds tests for the embedded http server feature

->this replaces https://github.com/kamon-io/kamon-prometheus/pull/42 from the old prometheus-reporter project