### PR TITLE
kamon-akka: Remove hookHeavyweightWarning logging

### DIFF
--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/AskPatternInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/AskPatternInstrumentation.scala
@@ -60,8 +60,6 @@ object AskPatternInstrumentation {
         case Lightweight => hookLightweightWarning(future, sourceLocation(origin), actor)
         case Heavyweight => hookHeavyweightWarning(future, new StackTraceCaptureException, actor)
       }
-
-      hookHeavyweightWarning(future, new StackTraceCaptureException, actor)
     }
   }
 


### PR DESCRIPTION
The logging of an ask pattern timeout can be configured by `kamon.instrumentation.akka.ask-pattern-timeout-warning` 

Default is off, however the `hookHeavyweightWarning` is always triggered. 

By removing this case, the setting is actually respected.