### PR TITLE
Prometheus: append  postfix only if missing

### DIFF
--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -51,7 +51,7 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
 
   private def appendCounterMetric(metric: MetricSnapshot.Values[Long]): Unit = {
     val unit = metric.settings.unit
-    val normalizedMetricName = normalizeMetricName(metric.name, unit) + "_total"
+    val normalizedMetricName = addPostfixOnlyIfMissing(normalizeMetricName(metric.name, unit), "_total")
 
     if(metric.description.nonEmpty)
       append("# HELP ").append(normalizedMetricName).append(" ").append(metric.description).append("\n")
@@ -194,11 +194,14 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
     val normalizedMetricName = metricName.map(validNameChar(_))
 
     unit.dimension match  {
-      case Time         => normalizedMetricName + "_seconds"
-      case Information  => normalizedMetricName + "_bytes"
+      case Time         => addPostfixOnlyIfMissing(normalizedMetricName, "_seconds")
+      case Information  => addPostfixOnlyIfMissing(normalizedMetricName, "_bytes")
       case _            => normalizedMetricName
     }
   }
+  private def addPostfixOnlyIfMissing(metricName: String, postfix: String) =
+    if (metricName.endsWith(postfix)) metricName
+    else metricName + postfix
 
   private def normalizeLabelName(label: String): String =
     label.map(validLabelChar)

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -194,8 +194,8 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
     val normalizedMetricName = metricName.map(validNameChar(_))
 
     unit.dimension match  {
-      case Time         => addPostfixOnlyIfMissing(normalizedMetricName, "_total_seconds")
-      case Information  => addPostfixOnlyIfMissing(normalizedMetricName, "_total_bytes")
+      case Time         => addPostfixOnlyIfMissing(normalizedMetricName, "_seconds_total")
+      case Information  => addPostfixOnlyIfMissing(normalizedMetricName, "_bytes_total")
       case _            => addPostfixOnlyIfMissing(normalizedMetricName, "_total")
     }
   }

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -51,7 +51,7 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
 
   private def appendCounterMetric(metric: MetricSnapshot.Values[Long]): Unit = {
     val unit = metric.settings.unit
-    val normalizedMetricName = addPostfixOnlyIfMissing(normalizeMetricName(metric.name, unit), "_total")
+    val normalizedMetricName = normalizeCounterMetricName(metric.name, unit)
 
     if(metric.description.nonEmpty)
       append("# HELP ").append(normalizedMetricName).append(" ").append(metric.description).append("\n")
@@ -190,6 +190,15 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
     if(allTags.nonEmpty) buffer.append("}")
   }
 
+  private def normalizeCounterMetricName(metricName: String, unit: MeasurementUnit): String = {
+    val normalizedMetricName = metricName.map(validNameChar(_))
+
+    unit.dimension match  {
+      case Time         => addPostfixOnlyIfMissing(normalizedMetricName, "_total_seconds")
+      case Information  => addPostfixOnlyIfMissing(normalizedMetricName, "_total_bytes")
+      case _            => addPostfixOnlyIfMissing(normalizedMetricName, "_total")
+    }
+  }
   private def normalizeMetricName(metricName: String, unit: MeasurementUnit): String = {
     val normalizedMetricName = metricName.map(validNameChar(_))
 

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -60,6 +60,22 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
         """.stripMargin.trim()
       }
     }
+    "not add extra '_total' postfix if metric name already ends with it" in {
+      val counterOne = MetricSnapshotBuilder.counter("app:counter-one-total", "", TagSet.of("tag.with.dots", "value"), time.seconds, 10)
+      val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
+
+      builder()
+        .appendCounters(Seq(counterOne))
+        .appendGauges(Seq(gaugeOne))
+        .build() should include {
+        """
+          |# TYPE app:counter_one_seconds_total counter
+          |app:counter_one_seconds_total{tag_with_dots="value"} 10.0
+          |# TYPE gauge_one_seconds gauge
+          |gauge_one_seconds{tag_with_dashes="value"} 20.0
+        """.stripMargin.trim()
+      }
+    }
 
 //    "append counters and group them together by metric name" in {
 //      val counterOne = MetricValue("counter-one", Map.empty, none, 10)

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -62,7 +62,7 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
     }
     "not add extra '_total' postfix if metric name already ends with it when using units" in {
       val counterOne = MetricSnapshotBuilder.counter("app:counter-one-seconds-total", "", TagSet.of("tag.with.dots", "value"), time.seconds, 10)
-      val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
+      val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one-seconds", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
 
       builder()
         .appendCounters(Seq(counterOne))
@@ -78,17 +78,17 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
     }
     "not add extra '_total' postfix if metric name already ends with it when not using units" in {
       val counterOne = MetricSnapshotBuilder.counter("app:counter-one-total", "", TagSet.of("tag.with.dots", "value"), 10)
-      val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
+      val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.of("tag-with-dashes", "value"), 20)
 
       builder()
         .appendCounters(Seq(counterOne))
         .appendGauges(Seq(gaugeOne))
         .build() should include {
         """
-          |# TYPE app:counter_one_seconds_total counter
-          |app:counter_one_seconds_total{tag_with_dots="value"} 10.0
-          |# TYPE gauge_one_seconds gauge
-          |gauge_one_seconds{tag_with_dashes="value"} 20.0
+          |# TYPE app:counter_one_total counter
+          |app:counter_one_total{tag_with_dots="value"} 10.0
+          |# TYPE gauge_one gauge
+          |gauge_one{tag_with_dashes="value"} 20.0
         """.stripMargin.trim()
       }
     }

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -60,8 +60,24 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
         """.stripMargin.trim()
       }
     }
-    "not add extra '_total' postfix if metric name already ends with it" in {
-      val counterOne = MetricSnapshotBuilder.counter("app:counter-one-total", "", TagSet.of("tag.with.dots", "value"), time.seconds, 10)
+    "not add extra '_total' postfix if metric name already ends with it when using units" in {
+      val counterOne = MetricSnapshotBuilder.counter("app:counter-one-seconds-total", "", TagSet.of("tag.with.dots", "value"), time.seconds, 10)
+      val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
+
+      builder()
+        .appendCounters(Seq(counterOne))
+        .appendGauges(Seq(gaugeOne))
+        .build() should include {
+        """
+          |# TYPE app:counter_one_seconds_total counter
+          |app:counter_one_seconds_total{tag_with_dots="value"} 10.0
+          |# TYPE gauge_one_seconds gauge
+          |gauge_one_seconds{tag_with_dashes="value"} 20.0
+        """.stripMargin.trim()
+      }
+    }
+    "not add extra '_total' postfix if metric name already ends with it when not using units" in {
+      val counterOne = MetricSnapshotBuilder.counter("app:counter-one-total", "", TagSet.of("tag.with.dots", "value"), 10)
       val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
 
       builder()


### PR DESCRIPTION
Append metric name postfix only if missing. 
It help
1) Avoid weird metric names like "my_counter_total_total"
2) Allow naming metrics in a way that results in same metric name with tools that don't rename metrics (statsD Exportorter) 
3) Standardizes with Micrometer 