### PR TITLE
Prometheus: Add exportation of Summary based on Distribution

### DIFF
--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -58,6 +58,26 @@ kamon.prometheus {
     }
   }
 
+  summary: {
+    # Determines if summaries should be added in addition to or instead of prometheus-histogram
+    exclusive: false
+
+    # Histograms that should be reported as summary. Notation in Glob syntax.
+    metrics: [
+      # example:
+      # "request*",
+      # "*akka*"
+    ]
+
+    quantiles: [
+      # Quantiles that should be reported (will be translated to the according percentiles)
+      0.5,
+      0.75,
+      0.95,
+      0.99,
+      0.999
+    ]
+  }
 
   embedded-server {
 

--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -58,10 +58,7 @@ kamon.prometheus {
     }
   }
 
-  summary: {
-    # Determines if summaries should be added in addition to or instead of prometheus-histogram
-    exclusive: false
-
+  summaries: {
     # Histograms that should be reported as summary. Notation in Glob syntax.
     metrics: [
       # example:

--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -58,16 +58,16 @@ kamon.prometheus {
     }
   }
 
-  summaries: {
-    # Histograms that should be reported as summary. Notation in Glob syntax.
-    metrics: [
+  summaries {
+    # Names of the histogram, timer and range sampler metrics that must be exported as summaries. All patterns are treared as Glob patterns.
+    metrics = [
       # example:
       # "request*",
       # "*akka*"
     ]
 
-    quantiles: [
-      # Quantiles that should be reported (will be translated to the according percentiles)
+    # Quantiles that should be reported (will be translated to the according percentiles)
+    quantiles = [
       0.5,
       0.75,
       0.95,

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
@@ -2,6 +2,7 @@ package kamon.prometheus
 
 import com.typesafe.config.{Config, ConfigUtil}
 import kamon.tag.TagSet
+import kamon.util.Filter.Glob
 import kamon.{Kamon, UtilsOnConfig}
 
 import scala.collection.JavaConverters._
@@ -13,7 +14,14 @@ object PrometheusSettings {
     timeBuckets: Seq[java.lang.Double],
     informationBuckets: Seq[java.lang.Double],
     customBuckets: Map[String, Seq[java.lang.Double]],
-    includeEnvironmentTags: Boolean
+    includeEnvironmentTags: Boolean,
+    summarySettings: SummarySettings
+  )
+
+  case class SummarySettings(
+    exclusive: Boolean,
+    quantiles: Seq[java.lang.Double],
+    metricMatchers: Seq[Glob]
   )
 
   def readSettings(prometheusConfig: Config): Generic = {
@@ -22,7 +30,12 @@ object PrometheusSettings {
       timeBuckets = prometheusConfig.getDoubleList("buckets.time-buckets").asScala.toSeq,
       informationBuckets = prometheusConfig.getDoubleList("buckets.information-buckets").asScala.toSeq,
       customBuckets = readCustomBuckets(prometheusConfig.getConfig("buckets.custom")),
-      includeEnvironmentTags = prometheusConfig.getBoolean("include-environment-tags")
+      includeEnvironmentTags = prometheusConfig.getBoolean("include-environment-tags"),
+      summarySettings = SummarySettings(
+        exclusive = prometheusConfig.getBoolean("summary.exclusive"),
+        quantiles = prometheusConfig.getDoubleList("summary.quantiles").asScala.toSeq,
+        metricMatchers = prometheusConfig.getStringList("summary.metrics").asScala.map(Glob).toSeq
+      )
     )
   }
 

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
@@ -19,7 +19,6 @@ object PrometheusSettings {
   )
 
   case class SummarySettings(
-    exclusive: Boolean,
     quantiles: Seq[java.lang.Double],
     metricMatchers: Seq[Glob]
   )
@@ -32,9 +31,8 @@ object PrometheusSettings {
       customBuckets = readCustomBuckets(prometheusConfig.getConfig("buckets.custom")),
       includeEnvironmentTags = prometheusConfig.getBoolean("include-environment-tags"),
       summarySettings = SummarySettings(
-        exclusive = prometheusConfig.getBoolean("summary.exclusive"),
-        quantiles = prometheusConfig.getDoubleList("summary.quantiles").asScala.toSeq,
-        metricMatchers = prometheusConfig.getStringList("summary.metrics").asScala.map(Glob).toSeq
+        quantiles = prometheusConfig.getDoubleList("summaries.quantiles").asScala.toSeq,
+        metricMatchers = prometheusConfig.getStringList("summaries.metrics").asScala.map(Glob).toSeq
       )
     )
   }

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -87,13 +87,9 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
 
   private def appendDistributionMetric(metric: MetricSnapshot.Distributions): Unit = {
     val reportAsSummary = prometheusConfig.summarySettings.metricMatchers.exists(_.accept(metric.name))
-    (reportAsSummary, prometheusConfig.summarySettings.exclusive) match {
-      case (true, true) =>
+    if (reportAsSummary) {
         appendDistributionMetricAsSummary(metric)
-      case (true, false) =>
-        appendDistributionMetricAsSummary(metric)
-        appendDistributionMetricAsHistogram(metric)
-      case _ =>
+    } else {
         appendDistributionMetricAsHistogram(metric)
     }
   }
@@ -138,8 +134,6 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
           unit,
           prometheusConfig.summarySettings.quantiles
         )
-        appendTimeSerieValue(normalizedMetricName, instrument.tags, format(instrument.value.max), "_max")
-        appendTimeSerieValue(normalizedMetricName, instrument.tags, format(instrument.value.min), "_min")
         appendTimeSerieValue(normalizedMetricName, instrument.tags, format(instrument.value.count), "_count")
         appendTimeSerieValue(normalizedMetricName, instrument.tags, format(instrument.value.sum), "_sum")
       }

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -252,43 +252,15 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
         """.stripMargin.trim()
       }
     }
-
-    "append summaries per metric inclusive" in {
+    "append summaries per metric" in {
       val histogramWithHundredEntries = constantDistribution("distribution-100", none, 1, 100)
-      builder(withSummary = Seq("**"), exclusive = false).appendHistograms(Seq(histogramWithHundredEntries)).build() should include {
-        """|# TYPE distribution_100 summary
-          |distribution_100{quantile="0.5"} 50.0
-          |distribution_100{quantile="0.75"} 75.0
-          |distribution_100{quantile="0.95"} 95.0
-          |distribution_100{quantile="0.99"} 99.0
-          |distribution_100_max 100.0
-          |distribution_100_min 1.0
-          |distribution_100_count 100.0
-          |distribution_100_sum 5050.0
-          |# TYPE distribution_100 histogram
-          |distribution_100_bucket{le="5.0"} 5.0
-          |distribution_100_bucket{le="7.0"} 7.0
-          |distribution_100_bucket{le="8.0"} 8.0
-          |distribution_100_bucket{le="9.0"} 9.0
-          |distribution_100_bucket{le="10.0"} 10.0
-          |distribution_100_bucket{le="11.0"} 11.0
-          |distribution_100_bucket{le="12.0"} 12.0
-          |distribution_100_bucket{le="+Inf"} 100.0
-          |""".stripMargin
-      }
-    }
-
-    "append summaries per metric exclusive" in {
-      val histogramWithHundredEntries = constantDistribution("distribution-100", none, 1, 100)
-      val result = builder(withSummary = Seq("**"), exclusive = true).appendHistograms(Seq(histogramWithHundredEntries)).build()
+      val result = builder(withSummary = Seq("**")).appendHistograms(Seq(histogramWithHundredEntries)).build()
       result should include {
         """|# TYPE distribution_100 summary
           |distribution_100{quantile="0.5"} 50.0
           |distribution_100{quantile="0.75"} 75.0
           |distribution_100{quantile="0.95"} 95.0
           |distribution_100{quantile="0.99"} 99.0
-          |distribution_100_max 100.0
-          |distribution_100_min 1.0
           |distribution_100_count 100.0
           |distribution_100_sum 5050.0
           |""".stripMargin
@@ -319,8 +291,6 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
            |firstMetric{quantile="0.75"} 75.0
            |firstMetric{quantile="0.95"} 95.0
            |firstMetric{quantile="0.99"} 99.0
-           |firstMetric_max 100.0
-           |firstMetric_min 1.0
            |firstMetric_count 100.0
            |firstMetric_sum 5050.0
            |""".stripMargin
@@ -331,8 +301,6 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
            |firstMetric{quantile="0.75"} 75.0
            |firstMetric{quantile="0.95"} 95.0
            |firstMetric{quantile="0.99"} 99.0
-           |firstMetric_max 100.0
-           |firstMetric_min 1.0
            |firstMetric_count 100.0
            |firstMetric_sum 5050.0
            |""".stripMargin
@@ -390,8 +358,7 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
   private def builder(buckets: Seq[java.lang.Double] = Seq(5D, 7D, 8D, 9D, 10D, 11D, 12D),
                       customBuckets: Map[String, Seq[java.lang.Double]] = Map("histogram.custom-buckets" -> Seq(1D, 3D)),
                       environmentTags: TagSet = TagSet.Empty,
-                      withSummary: Seq[String] = Seq.empty,
-                      exclusive: Boolean = false) = {
+                      withSummary: Seq[String] = Seq.empty) = {
     new ScrapeDataBuilder(
       PrometheusSettings.Generic(
         buckets,
@@ -399,7 +366,7 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
         buckets,
         customBuckets,
         false,
-        SummarySettings(exclusive, Seq(0.5, 0.75, 0.95, 0.99), withSummary.map(Glob))),
+        SummarySettings(Seq(0.5, 0.75, 0.95, 0.99), withSummary.map(Glob))),
       environmentTags
     )
   }

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -3,8 +3,10 @@ package kamon.prometheus
 import com.typesafe.config.ConfigFactory
 import kamon.metric.MeasurementUnit.{information, none, time}
 import kamon.metric.{MeasurementUnit, MetricSnapshot}
+import kamon.prometheus.PrometheusSettings.SummarySettings
 import kamon.tag.TagSet
 import kamon.testkit.MetricSnapshotBuilder
+import kamon.util.Filter.Glob
 import org.scalatest.{Matchers, WordSpec}
 
 class ScrapeDataBuilderSpec extends WordSpec with Matchers {
@@ -251,6 +253,105 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
       }
     }
 
+    "append summaries per metric inclusive" in {
+      val histogramWithHundredEntries = constantDistribution("distribution-100", none, 1, 100)
+      builder(withSummary = Seq("**"), exclusive = false).appendHistograms(Seq(histogramWithHundredEntries)).build() should include {
+        """|# TYPE distribution_100 summary
+          |distribution_100{quantile="0.5"} 50.0
+          |distribution_100{quantile="0.75"} 75.0
+          |distribution_100{quantile="0.95"} 95.0
+          |distribution_100{quantile="0.99"} 99.0
+          |distribution_100_max 100.0
+          |distribution_100_min 1.0
+          |distribution_100_count 100.0
+          |distribution_100_sum 5050.0
+          |# TYPE distribution_100 histogram
+          |distribution_100_bucket{le="5.0"} 5.0
+          |distribution_100_bucket{le="7.0"} 7.0
+          |distribution_100_bucket{le="8.0"} 8.0
+          |distribution_100_bucket{le="9.0"} 9.0
+          |distribution_100_bucket{le="10.0"} 10.0
+          |distribution_100_bucket{le="11.0"} 11.0
+          |distribution_100_bucket{le="12.0"} 12.0
+          |distribution_100_bucket{le="+Inf"} 100.0
+          |""".stripMargin
+      }
+    }
+
+    "append summaries per metric exclusive" in {
+      val histogramWithHundredEntries = constantDistribution("distribution-100", none, 1, 100)
+      val result = builder(withSummary = Seq("**"), exclusive = true).appendHistograms(Seq(histogramWithHundredEntries)).build()
+      result should include {
+        """|# TYPE distribution_100 summary
+          |distribution_100{quantile="0.5"} 50.0
+          |distribution_100{quantile="0.75"} 75.0
+          |distribution_100{quantile="0.95"} 95.0
+          |distribution_100{quantile="0.99"} 99.0
+          |distribution_100_max 100.0
+          |distribution_100_min 1.0
+          |distribution_100_count 100.0
+          |distribution_100_sum 5050.0
+          |""".stripMargin
+      }
+      result should not include {
+        """|# TYPE distribution_100 histogram
+          |distribution_100_bucket{le="5.0"} 5.0
+          |distribution_100_bucket{le="7.0"} 7.0
+          |distribution_100_bucket{le="8.0"} 8.0
+          |distribution_100_bucket{le="9.0"} 9.0
+          |distribution_100_bucket{le="10.0"} 10.0
+          |distribution_100_bucket{le="11.0"} 11.0
+          |distribution_100_bucket{le="12.0"} 12.0
+          |distribution_100_bucket{le="+Inf"} 100.0
+          |""".stripMargin
+      }
+    }
+
+    "append summary only for matching metrics" in {
+      val histogramWithHundredEntries = constantDistribution("firstMetric", none, 1, 100)
+      val histogramWithHundredEntriesTwo = constantDistribution("secondMetric", none, 1, 100)
+      val result = builder(withSummary = Seq("first*"))
+        .appendHistograms(Seq(histogramWithHundredEntries, histogramWithHundredEntriesTwo))
+        .build()
+      result should include {
+        """|# TYPE firstMetric summary
+           |firstMetric{quantile="0.5"} 50.0
+           |firstMetric{quantile="0.75"} 75.0
+           |firstMetric{quantile="0.95"} 95.0
+           |firstMetric{quantile="0.99"} 99.0
+           |firstMetric_max 100.0
+           |firstMetric_min 1.0
+           |firstMetric_count 100.0
+           |firstMetric_sum 5050.0
+           |""".stripMargin
+      }
+      result should not include {
+        """|# TYPE secondMetric summary
+           |firstMetric{quantile="0.5"} 50.0
+           |firstMetric{quantile="0.75"} 75.0
+           |firstMetric{quantile="0.95"} 95.0
+           |firstMetric{quantile="0.99"} 99.0
+           |firstMetric_max 100.0
+           |firstMetric_min 1.0
+           |firstMetric_count 100.0
+           |firstMetric_sum 5050.0
+           |""".stripMargin
+      }
+      result should include {
+        """|# TYPE secondMetric histogram
+           |secondMetric_bucket{le="5.0"} 5.0
+           |secondMetric_bucket{le="7.0"} 7.0
+           |secondMetric_bucket{le="8.0"} 8.0
+           |secondMetric_bucket{le="9.0"} 9.0
+           |secondMetric_bucket{le="10.0"} 10.0
+           |secondMetric_bucket{le="11.0"} 11.0
+           |secondMetric_bucket{le="12.0"} 12.0
+           |secondMetric_bucket{le="+Inf"} 100.0
+           |""".stripMargin
+      }
+
+    }
+
     "include global custom tags from the Kamon.environment.tags" in {
       val counterOne = MetricSnapshotBuilder.counter("counter-one", "", TagSet.of("tag.with.dots", "value"), time.seconds, 10)
       val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one", "", TagSet.Empty, time.seconds, 20)
@@ -286,11 +387,22 @@ class ScrapeDataBuilderSpec extends WordSpec with Matchers {
     }
   }
 
-  private def builder(buckets: Seq[java.lang.Double] = Seq(5D, 7D, 8D, 9D, 10D, 11D, 12D), customBuckets: Map[String, Seq[java.lang.Double]] =
-    Map("histogram.custom-buckets" -> Seq(1D, 3D)), environmentTags: TagSet = TagSet.Empty) = new ScrapeDataBuilder(
-      PrometheusSettings.Generic(buckets, buckets, buckets, customBuckets, false),
-    environmentTags
-  )
+  private def builder(buckets: Seq[java.lang.Double] = Seq(5D, 7D, 8D, 9D, 10D, 11D, 12D),
+                      customBuckets: Map[String, Seq[java.lang.Double]] = Map("histogram.custom-buckets" -> Seq(1D, 3D)),
+                      environmentTags: TagSet = TagSet.Empty,
+                      withSummary: Seq[String] = Seq.empty,
+                      exclusive: Boolean = false) = {
+    new ScrapeDataBuilder(
+      PrometheusSettings.Generic(
+        buckets,
+        buckets,
+        buckets,
+        customBuckets,
+        false,
+        SummarySettings(exclusive, Seq(0.5, 0.75, 0.95, 0.99), withSummary.map(Glob))),
+      environmentTags
+    )
+  }
 
   private def constantDistribution(name: String, unit: MeasurementUnit, lower: Long, upper: Long): MetricSnapshot.Distributions =
     MetricSnapshotBuilder.histogram(name, "", TagSet.Empty)((lower to upper): _*)


### PR DESCRIPTION
As discussed in #751 there can be the wish to expose summaries.
This PR adds the possibility to configure metrics that are exposed as
Summaries and a way to do this in addition to histograms or as a
replacement. Default quantiles are provided in reference.conf but can be overwritten.

closes #751 