### PR TITLE
Create a gauge for the percentile requested, not the one that was returned

### DIFF
--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/metrics/NewRelicDistributionMetrics.scala
@@ -48,12 +48,12 @@ object NewRelicDistributionMetrics {
 
   private def makePercentiles(name: String, end: Long, distValue: Distribution, instrumentBaseAttributes: Attributes): Seq[Metric] = {
     percentilesToReport
-      .map(rank => distValue.percentile(rank))
-      .filter(percentileValue => percentileValue != null)
-      .map { percentile =>
+      .map(rank => (distValue.percentile(rank), rank))
+      .filter(percentileAndRank => percentileAndRank._1 != null)
+      .map { percentileAndRank =>
         val attributes: Attributes = instrumentBaseAttributes.copy()
-          .put("percentile", percentile.rank)
-        new Gauge(name + ".percentiles", percentile.value, end, attributes)
+          .put("percentile", percentileAndRank._2)
+        new Gauge(name + ".percentiles", percentileAndRank._1.value, end, attributes)
       }
   }
 

--- a/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/metrics/TestMetricHelper.scala
+++ b/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/metrics/TestMetricHelper.scala
@@ -46,7 +46,7 @@ object TestMetricHelper {
     val settings = Metric.Settings.ForDistributionInstrument(
       new MeasurementUnit(Dimension.Information, metric.MeasurementUnit.Magnitude("eimer", 603.3d)), Duration.ofMillis(12), dynamicRange)
 
-    val percentiles = Map(90d -> Percentage(90d, 2L, 816L), 87d -> Percentage(87d, 2L, 816L))
+    val percentiles = Map(90d -> Percentage(89.9996d, 2L, 816L), 87d -> Percentage(87d, 2L, 816L))
     val distribution: Distribution = buildHistogramDist(Percentage(19d, 2L, 816L), Bucket(717L, 881L), Distro(13L, 17L, 101L, 44L), percentiles)
     val inst: Snapshot[Distribution] = new Snapshot[Distribution](tagSet, distribution)
     new metric.MetricSnapshot.Distributions("trev", "a good trevor", settings, Seq(inst))


### PR DESCRIPTION
This is a work around for issue #772 

/cc @breedx-nr 