### PR TITLE
Update New Relic SDK version and allow ingest URI override

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -494,8 +494,8 @@ lazy val `kamon-newrelic` = (project in file("reporters/kamon-newrelic"))
   .disablePlugins(AssemblyPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.newrelic.telemetry" % "telemetry" % "0.4.0",
-      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.4.0",
+      "com.newrelic.telemetry" % "telemetry" % "0.6.0",
+      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.6.0",
       scalatest % "test",
       "org.mockito" % "mockito-core" % "3.1.0" % "test"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -494,8 +494,8 @@ lazy val `kamon-newrelic` = (project in file("reporters/kamon-newrelic"))
   .disablePlugins(AssemblyPlugin)
   .settings(
     libraryDependencies ++= Seq(
-      "com.newrelic.telemetry" % "telemetry" % "0.6.0",
-      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.6.0",
+      "com.newrelic.telemetry" % "telemetry" % "0.6.1",
+      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.6.1",
       scalatest % "test",
       "org.mockito" % "mockito-core" % "3.1.0" % "test"
     )

--- a/reporters/kamon-newrelic/src/main/resources/reference.conf
+++ b/reporters/kamon-newrelic/src/main/resources/reference.conf
@@ -14,8 +14,9 @@ kamon.newrelic {
     enable-audit-logging = false
 
     # This provides a means of overriding the default ingest URI for New Relic metrics.
-    # The majority of users should not provide this value.
-    metric-ingest-uri = "https://metric-api.newrelic.com"
+    # If provided, it must be the full URL including scheme, host, [port], and path.
+    # The majority of users should omit this value.
+    metric-ingest-uri = "https://metric-api.newrelic.com/metric/v1"
 }
 
 kamon.modules {

--- a/reporters/kamon-newrelic/src/main/resources/reference.conf
+++ b/reporters/kamon-newrelic/src/main/resources/reference.conf
@@ -15,8 +15,13 @@ kamon.newrelic {
 
     # This provides a means of overriding the default ingest URI for New Relic metrics.
     # If provided, it must be the full URL including scheme, host, [port], and path.
-    # The majority of users should omit this value.
+    # Most users should omit this value.
     metric-ingest-uri = "https://metric-api.newrelic.com/metric/v1"
+
+    # This provides a means of overriding the default ingest URI for New Relic spans.
+    # If provided, it must be the full URL including scheme, host, [port], and path.
+    # Most users should omit this value.
+    span-ingest-uri = "https://trace-api.newrelic.com/trace/v1"
 }
 
 kamon.modules {

--- a/reporters/kamon-newrelic/src/main/resources/reference.conf
+++ b/reporters/kamon-newrelic/src/main/resources/reference.conf
@@ -12,6 +12,10 @@ kamon.newrelic {
     # NOTE: This will expose all telemetry data to your logging system, so be careful before
     # enabling it if there may be sensitive information in the telemetry.
     enable-audit-logging = false
+
+    # This provides a means of overriding the default ingest URI for New Relic metrics.
+    # The majority of users should not provide this value.
+    metric-ingest-uri = "https://metric-api.newrelic.com"
 }
 
 kamon.modules {

--- a/reporters/kamon-newrelic/src/main/resources/reference.conf
+++ b/reporters/kamon-newrelic/src/main/resources/reference.conf
@@ -16,12 +16,12 @@ kamon.newrelic {
     # This provides a means of overriding the default ingest URI for New Relic metrics.
     # If provided, it must be the full URL including scheme, host, [port], and path.
     # Most users should omit this value.
-    metric-ingest-uri = "https://metric-api.newrelic.com/metric/v1"
+    #metric-ingest-uri = "https://metric-api.newrelic.com/metric/v1"
 
     # This provides a means of overriding the default ingest URI for New Relic spans.
     # If provided, it must be the full URL including scheme, host, [port], and path.
     # Most users should omit this value.
-    span-ingest-uri = "https://trace-api.newrelic.com/trace/v1"
+    #span-ingest-uri = "https://trace-api.newrelic.com/trace/v1"
 }
 
 kamon.modules {

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
@@ -8,7 +8,7 @@ package kamon.newrelic.spans
 import java.net.URL
 import java.time.Duration
 
-import com.newrelic.telemetry.{OkHttpPoster, SimpleSpanBatchSender}
+import com.newrelic.telemetry.{OkHttpPoster, SenderConfiguration, SimpleSpanBatchSender}
 import com.newrelic.telemetry.spans.SpanBatchSender
 import com.typesafe.config.Config
 import kamon.newrelic.LibraryVersion
@@ -30,6 +30,11 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
     */
   override def build(config: Config) = {
     logger.warn("NewRelicSpanReporter buildReporter...")
+    val senderConfig = buildConfig(config)
+    SpanBatchSender.create(senderConfig)
+  }
+
+  def buildConfig(config: Config): SenderConfiguration = {
     val nrConfig = config.getConfig("kamon.newrelic")
     // TODO maybe some validation around these values?
     val nrInsightsInsertKey = nrConfig.getString("nr-insights-insert-key")
@@ -54,6 +59,6 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
       senderConfig.endpointWithPath(new URL(uriOverride))
     }
 
-    SpanBatchSender.create(senderConfig.build())
+    senderConfig.build
   }
 }

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
@@ -49,10 +49,11 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
       .secondaryUserAgent(userAgent)
       .auditLoggingEnabled(enableAuditLogging)
 
-    if(nrConfig.hasPath("span-ingest-uri")){
+    if (nrConfig.hasPath("span-ingest-uri")) {
       val uriOverride = nrConfig.getString("span-ingest-uri")
       senderConfig.endpointWithPath(new URL(uriOverride))
     }
 
     SpanBatchSender.create(senderConfig)
+  }
 }

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
@@ -54,6 +54,6 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
       senderConfig.endpointWithPath(new URL(uriOverride))
     }
 
-    SpanBatchSender.create(senderConfig)
+    SpanBatchSender.create(senderConfig.build())
   }
 }

--- a/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -5,7 +5,7 @@
 
 package kamon.newrelic.metrics
 
-import java.net.InetAddress
+import java.net.{InetAddress, URL}
 
 import com.newrelic.telemetry.Attributes
 import com.newrelic.telemetry.metrics._
@@ -142,6 +142,31 @@ class NewRelicMetricsReporterSpec extends WordSpec with Matchers {
       reporter.reportPeriodSnapshot(periodSnapshot)
 
       verify(sender).sendBatch(expectedBatch)
+    }
+  }
+
+  "The metrics reporter builder" should {
+    "default the url when config not provided" in {
+      val newrelicConfig: ConfigValue = ConfigValueFactory.fromMap(Map(
+        "enable-audit-logging" -> false,
+        "nr-insights-insert-key" -> "secret"
+      ).asJava)
+      val config: Config = Kamon.config().withValue("kamon.newrelic", newrelicConfig)
+
+      val result = NewRelicMetricsReporter.buildSenderConfig(config)
+      assert(new URL("https://metric-api.newrelic.com/metric/v1") == result.getEndpointUrl)
+    }
+
+    "use config to override the URI" in {
+      val newrelicConfig: ConfigValue = ConfigValueFactory.fromMap(Map(
+        "enable-audit-logging" -> false,
+        "nr-insights-insert-key" -> "secret",
+        "metric-ingest-uri" -> "https://example.com/foo"
+      ).asJava)
+      val config: Config = Kamon.config().withValue("kamon.newrelic", newrelicConfig)
+
+      val result = NewRelicMetricsReporter.buildSenderConfig(config)
+      assert(new URL("https://example.com/foo") == result.getEndpointUrl)
     }
   }
 

--- a/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/spans/SpanBatchSenderBuilderSpec.scala
+++ b/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/spans/SpanBatchSenderBuilderSpec.scala
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2020 New Relic Corporation. All rights reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package kamon.newrelic.spans
+
+import java.net.URL
+
+import com.typesafe.config.ConfigValueFactory
+import kamon.Kamon
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.collection.JavaConverters._
+
+class SpanBatchSenderBuilderSpec extends WordSpec with Matchers {
+
+  "the span batch sender builder" should {
+    "default the uri if not configured" in {
+      val nrConfig = ConfigValueFactory.fromMap(Map(
+        "enable-audit-logging" -> false,
+        "nr-insights-insert-key" -> "secret"
+      ).asJava)
+
+      val config = Kamon.config().withValue("kamon.newrelic", nrConfig)
+      val result = new SimpleSpanBatchSenderBuilder().buildConfig(config)
+      assert(new URL("https://trace-api.newrelic.com/trace/v1") == result.getEndpointUrl)
+    }
+    "be able to override the ingest uri" in {
+      val nrConfig = ConfigValueFactory.fromMap(Map(
+        "enable-audit-logging" -> false,
+        "span-ingest-uri" -> "https://example.com/foo",
+        "nr-insights-insert-key" -> "secret"
+      ).asJava)
+
+      val config = Kamon.config().withValue("kamon.newrelic", nrConfig)
+      val result = new SimpleSpanBatchSenderBuilder().buildConfig(config)
+      assert(new URL("https://example.com/foo") == result.getEndpointUrl)
+    }
+  }
+}


### PR DESCRIPTION
This resolves #789.

Updates to the latest version of the NR telemetry SDK (0.6.0) and uses the new style configuration-based builders.  It also provides configuration items for overriding the ingest URIs, which is at the core of #789.

Thanks for your consideration.