### PR TITLE
Fix bug that causes loss of context when using cats-effect IO timer

### DIFF
--- a/instrumentation/kamon-cats-io/src/main/resources/reference.conf
+++ b/instrumentation/kamon-cats-io/src/main/resources/reference.conf
@@ -5,5 +5,6 @@
 kanela.modules {
   executor-service {
     within += "cats.effect.internals.IOShift\\$Tick"
+    within += "cats.effect.internals.IOTimer\\$ShiftTick"
   }
 }

--- a/instrumentation/kamon-cats-io/src/test/scala/kamon/instrumentation/futures/cats/CatsIOInstrumentationSpec.scala
+++ b/instrumentation/kamon-cats-io/src/test/scala/kamon/instrumentation/futures/cats/CatsIOInstrumentationSpec.scala
@@ -27,6 +27,9 @@ class CatsIoInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
         val anotherExecutionContext: ExecutionContext =
           ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
         val context = Context.of("key", "value")
+
+        implicit val timer = IO.timer(global)
+
         val contextTagAfterTransformations =
           for {
             scope <- IO {
@@ -36,6 +39,7 @@ class CatsIoInstrumentationSpec extends WordSpec with ScalaFutures with Matchers
             _ <- IO(len.toString)
             _ <- IO.shift(global)
             _ <- IO.shift
+            _ <- IO.sleep(Duration.Zero)
             _ <- IO.shift(anotherExecutionContext)
           } yield {
             val tagValue = Kamon.currentContext().getTag(plain("key"))


### PR DESCRIPTION
Adds instrumentation needed to preserve context across the boundary created by IO.sleep.