### PR TITLE
remove unnecessary match on Cassandra instrumentation, fixes #799

### DIFF
--- a/instrumentation/kamon-cassandra/src/main/scala/kamon/instrumentation/cassandra/driver/InstrumentedSession.scala
+++ b/instrumentation/kamon-cassandra/src/main/scala/kamon/instrumentation/cassandra/driver/InstrumentedSession.scala
@@ -93,18 +93,13 @@ class InstrumentedSession(underlying: Session) extends AbstractSession {
       new FutureCallback[ResultSet] {
         override def onSuccess(result: ResultSet): Unit = {
           recordClientQueryExecutionInfo(clientSpan, result)
-          result.getExecutionInfo.getStatement match {
-            case b: BoundStatement =>
-              b.preparedStatement.getQueryString
-            case r: RegularStatement =>
-              r.getQueryString
-          }
           clientSpan.finish()
         }
 
         override def onFailure(cause: Throwable): Unit = {
-          clientSpan.fail(cause.getMessage, cause)
-          clientSpan.finish()
+          clientSpan
+            .fail(cause.getMessage, cause)
+            .finish()
         }
       },
       MoreExecutors.directExecutor()


### PR DESCRIPTION
There was a bit of unnecessary code in the instrumentation what would cause callbacks on batch queries fail, as described on #799. This PR fixes the problem by removing the unnecessary code.