### PR TITLE
Issue 805/fail when cassandra driver is missing

### DIFF
--- a/instrumentation/kamon-cassandra/src/main/scala/com/datastax/driver/core/ConnectionPoolAdvices.scala
+++ b/instrumentation/kamon-cassandra/src/main/scala/com/datastax/driver/core/ConnectionPoolAdvices.scala
@@ -58,6 +58,7 @@ object PoolCloseAdvice {
   * Measure time spent waiting for a connection
   * Record number of in-flight queries on just-acquired connection
   */
+class BorrowAdvice
 object BorrowAdvice {
 
   @Advice.OnMethodEnter
@@ -65,11 +66,11 @@ object BorrowAdvice {
     Kamon.clock().nanos()
   }
 
-  @Advice.OnMethodExit(suppress = classOf[Throwable])
+  @Advice.OnMethodExit(suppress = classOf[Throwable], inline = false)
   def onBorrowed(
-      @Advice.Return(readOnly = false) connection: ListenableFuture[Connection],
-      @Advice.Enter start:                               Long,
-      @Advice.This poolMetrics:                          HasPoolMetrics,
+      @Advice.Return connection:  ListenableFuture[Connection],
+      @Advice.Enter start:        Long,
+      @Advice.This poolMetrics:   HasPoolMetrics,
       @Advice.FieldValue("totalInFlight") totalInflight: AtomicInteger
   ): Unit = {
 

--- a/instrumentation/kamon-cassandra/src/main/scala/com/datastax/driver/core/SessionInterceptor.scala
+++ b/instrumentation/kamon-cassandra/src/main/scala/com/datastax/driver/core/SessionInterceptor.scala
@@ -19,13 +19,13 @@ package com.datastax.driver.core
 import java.util.concurrent.Callable
 
 import kamon.instrumentation.cassandra.driver.InstrumentedSession
-import kanela.agent.libs.net.bytebuddy.asm.Advice
-import kanela.agent.libs.net.bytebuddy.implementation.bind.annotation.SuperCall
+import kanela.agent.libs.net.bytebuddy.implementation.bind.annotation.{RuntimeType, SuperCall}
 
+class SessionInterceptor
 object SessionInterceptor {
 
-  @Advice.OnMethodExit
-  def wrapSession(@SuperCall session: Callable[Session]): Session = {
+  @RuntimeType
+  def newSession(@SuperCall session: Callable[Session]): Session = {
     new InstrumentedSession(session.call())
   }
 }

--- a/instrumentation/kamon-cassandra/src/main/scala/kamon/instrumentation/cassandra/driver/DriverInstrumentation.scala
+++ b/instrumentation/kamon-cassandra/src/main/scala/kamon/instrumentation/cassandra/driver/DriverInstrumentation.scala
@@ -32,7 +32,7 @@ class DriverInstrumentation extends InstrumentationBuilder {
     * Wraps the client session with an InstrumentedSession.
     */
   onType("com.datastax.driver.core.Cluster$Manager")
-    .intercept(method("newSession"), SessionInterceptor)
+    .intercept(method("newSession"), classOf[SessionInterceptor])
     .bridge(classOf[ClusterManagerBridge])
 
   /**
@@ -42,7 +42,7 @@ class DriverInstrumentation extends InstrumentationBuilder {
     * Pool metrics are mixed in the pool object itself
     */
   onType("com.datastax.driver.core.HostConnectionPool")
-    .advise(method("borrowConnection"), BorrowAdvice)
+    .advise(method("borrowConnection"), classOf[BorrowAdvice])
     .advise(method("trashConnection"), TrashConnectionAdvice)
     .advise(method("addConnectionIfUnderMaximum"), CreateConnectionAdvice)
     .advise(method("onConnectionDefunct"), ConnectionDefunctAdvice)


### PR DESCRIPTION
I'm not entirely sure of why these changes fix the issue, but they do :shrug: 

My theory is that the advices were pulling references to the Cassandra Driver classes, specially when inlining. But we do have other advices looking very similar to the ones in the driver instrumentation and those don't generate any problems.

I'm going to release this in a few minutes since it could be affecting a lot of people out there.