### PR TITLE
limit the number of packets sent per millisecond to StatsD

### DIFF
--- a/reporters/kamon-statsd/src/main/resources/reference.conf
+++ b/reporters/kamon-statsd/src/main/resources/reference.conf
@@ -13,6 +13,17 @@ kamon {
     # Max packet size for UDP metrics data sent.
     max-packet-size = 1024 bytes
 
+    # Throttles the number of packets sent to StatsD every millisecond. Decreasing this number might help with a high
+    # packet drop rate on the receiving server, but beware that setting it too low might cause the reporter to pile up
+    # a backlog of packets waiting to be delivered.
+    max-packets-per-milli = 3
+
+    # Decides whether to send zero values to StatsD. When enabled, the reporter will ignore:
+    #   - Counters that were not incremented in the last tick interval.
+    #   - Gauges that were set to zero.
+    #   - The "zero" bucket in all distribution metrics.
+    send-zero-values = yes
+
     # All time values are collected in nanoseconds,
     # to scale before sending to StatsD set "time-units" to "s" or "ms" or "µs".
     # Value "n" is equivalent to omitting the setting


### PR DESCRIPTION
This comes from the long conversation with @decyg on [Gitter](https://gitter.im/kamon-io/Kamon?at=5f2156df25cae90e6d8a97bb)

This adds two settings to the StatsD reporter:
  - `max-packets-per-milli` with a default of 3. This helps prevent the huge waves of packets sent on every tick interval and hopefully lower the chance of having dropped packets on StatsD.
  - `send-zero-values` with default to yes. When this setting is set to no, all zero values on counters, gauges and the zero bucket of histograms are not sent to StatsD.