### PR TITLE
Matching the Stale Period of PrometheusPushgatewayReporter accumulator to the one of PrometheusReporter accumulator

### DIFF
--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusPushgatewayReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusPushgatewayReporter.scala
@@ -15,7 +15,7 @@ class PrometheusPushgatewayReporter(
   ) extends MetricReporter {
 
   private val _logger = LoggerFactory.getLogger(classOf[PrometheusPushgatewayReporter])
-  private val _snapshotAccumulator = PeriodSnapshot.accumulator(Duration.ofDays(365 * 5), Duration.ZERO)
+  private val _snapshotAccumulator = PeriodSnapshot.accumulator(Duration.ofDays(365 * 5), Duration.ZERO, Duration.ofDays(365 * 5))
 
   @volatile private var httpClient: HttpClient = _
   @volatile private var settings: PrometheusSettings.Generic = _


### PR DESCRIPTION
Really not sure if this was intended behaviour or not but when PrometheusPushgatewayReporter is instantiated it creates an instance of PeriodSnapshot accumulator using the default Stale Period of 365 days (as opposed to PrometheusReporter which creates it with a period of 5 years). As a result when using the PGWReporter all of our metrics get cleaned as stale and are not sent out.

Note I haven't signed the CLA yet as I am not sure if this was intended behaviour or not.
Perhaps there's something I missed in the config that would resolve this issue? 