### PR TITLE
B3 debug flag fix

### DIFF
--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -64,10 +64,14 @@ object SpanPropagation {
 
         val flags = reader.read(Headers.Flags)
 
-        val samplingDecision = flags.orElse(reader.read(Headers.Sampled)) match {
-          case Some(sampled) if sampled == "1" => SamplingDecision.Sample
-          case Some(sampled) if sampled == "0" => SamplingDecision.DoNotSample
-          case _ => SamplingDecision.Unknown
+        val samplingDecision = flags match {
+          case Some(debug) if debug == "1" => SamplingDecision.Sample
+          case _ =>
+            reader.read(Headers.Sampled) match {
+              case Some(sampled) if sampled == "1" => SamplingDecision.Sample
+              case Some(sampled) if sampled == "0" => SamplingDecision.DoNotSample
+              case _ => SamplingDecision.Unknown
+            }
         }
 
         context.withEntry(Span.Key, new Span.Remote(spanID, parentID, Trace(traceID, samplingDecision)))


### PR DESCRIPTION
As per [the B3 propagation spec](https://github.com/openzipkin/b3-propagation#debug-flag), the debug flag should only be considered if it has a value of `1`. This PR rectifies the current logic to ensure that the system falls back to the `X-B3-Sampled` header if the debug flag holds an invalid value.