### PR TITLE
+ kamon-kafka: add kafka clients 2.5 and 2.6 support and fixes #828

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,16 +272,16 @@ lazy val `kamon-jdbc` = (project in file("instrumentation/kamon-jdbc"))
 lazy val `kamon-kafka` = (project in file("instrumentation/kamon-kafka"))
   .disablePlugins(AssemblyPlugin)
   .enablePlugins(JavaAgent)
+  .settings(crossScalaVersions := Seq("2.12.11", "2.13.1"))
   .settings(instrumentationSettings)
   .settings(
     libraryDependencies ++= Seq(
-      kanelaAgent % "provided",
+      kanelaAgent                 % "provided",
+      "org.apache.kafka"          % "kafka-clients"     % "2.6.0" % "provided",
 
-      "org.apache.kafka"    % "kafka-clients"	                    % "2.3.1" % "provided",
-
-      scalatest % "test",
-      logbackClassic % "test",
-      "io.github.embeddedkafka" %% "embedded-kafka"               % "2.4.1.1" % "test"
+      scalatest                   % "test",
+      logbackClassic              % "test",
+      "io.github.embeddedkafka"   %% "embedded-kafka"   % "2.6.0" % "test"
     )
   ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-testkit` % "test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -272,16 +272,15 @@ lazy val `kamon-jdbc` = (project in file("instrumentation/kamon-jdbc"))
 lazy val `kamon-kafka` = (project in file("instrumentation/kamon-kafka"))
   .disablePlugins(AssemblyPlugin)
   .enablePlugins(JavaAgent)
-  .settings(crossScalaVersions := Seq("2.12.11", "2.13.1"))
   .settings(instrumentationSettings)
   .settings(
     libraryDependencies ++= Seq(
       kanelaAgent                 % "provided",
-      "org.apache.kafka"          % "kafka-clients"     % "2.6.0" % "provided",
+      "org.apache.kafka"          % "kafka-clients"     % "2.4.0" % "provided",
 
       scalatest                   % "test",
       logbackClassic              % "test",
-      "io.github.embeddedkafka"   %% "embedded-kafka"   % "2.6.0" % "test"
+      "io.github.embeddedkafka"   %% "embedded-kafka"   % "2.4.1.1" % "test"
     )
   ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-testkit` % "test")
 

--- a/instrumentation/kamon-kafka/src/main/java/kamon/instrumentation/kafka/client/advisor/PollMethodAdvisor.java
+++ b/instrumentation/kamon-kafka/src/main/java/kamon/instrumentation/kafka/client/advisor/PollMethodAdvisor.java
@@ -1,5 +1,5 @@
 /* =========================================================================================
- * Copyright (C) 2013-2019 the kamon project <http://kamon.io/>
+ * Copyright (C) 2013-2020 the kamon project <http://kamon.io/>
  *
  * Licensed under the Apache License, Version 2.0 (the "License") you may not use this file
  * except in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,7 @@ package kamon.instrumentation.kafka.client.advisor;
 import kamon.Kamon;
 import kamon.instrumentation.kafka.client.RecordProcessor;
 import kanela.agent.libs.net.bytebuddy.asm.Advice;
+import kanela.agent.libs.net.bytebuddy.implementation.bytecode.assign.Assigner;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 import java.time.Instant;
@@ -31,7 +32,12 @@ public class PollMethodAdvisor {
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class)
-    public static <K, V> void onExit(@Advice.Local("startTime") Instant startTime, @Advice.FieldValue("groupId") String groupId, @Advice.FieldValue("clientId") String clientId, @Advice.Return(readOnly = false) ConsumerRecords<K, V> records) {
+    public static <K, V> void onExit(
+            @Advice.Local("startTime") Instant startTime,
+            @Advice.FieldValue(value = "groupId", typing = Assigner.Typing.DYNAMIC) Object groupId,
+            @Advice.FieldValue("clientId") String clientId,
+            @Advice.Return(readOnly = false) ConsumerRecords<K, V> records) {
+
         records = RecordProcessor.process(startTime, clientId, groupId, records);
     }
 }

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/ConsumerInstrumentation.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/ConsumerInstrumentation.scala
@@ -50,12 +50,12 @@ trait ConsumedRecordData {
   def incomingContext(): Context
   def nanosSincePollStart(): Long
   def consumerInfo(): ConsumerInfo
-  def set(incomingContext: Context, nanosSincePollStart: Long, consumerInfo: ConsumerInfo)
+  def set(incomingContext: Context, nanosSincePollStart: Long, consumerInfo: ConsumerInfo): Unit
 }
 
 object ConsumedRecordData {
 
-  case class ConsumerInfo(groupId: String, clientId: String)
+  case class ConsumerInfo(groupId: Option[String], clientId: String)
 
   class Mixin extends ConsumedRecordData {
     private var _incomingContext: Context = _

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/KafkaInstrumentation.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/KafkaInstrumentation.scala
@@ -155,7 +155,7 @@ object KafkaInstrumentation {
       val incomingSpan = incomingContext.get(Span.Key)
 
       consumerSpan
-        .tag("kafka.group-id", consumerRecordData.consumerInfo().groupId)
+        .tag("kafka.group-id", consumerRecordData.consumerInfo().groupId.getOrElse("unknown"))
         .tag("kafka.client-id", consumerRecordData.consumerInfo().clientId)
         .tag("kafka.poll-time", consumerRecordData.nanosSincePollStart())
 

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
@@ -1,6 +1,7 @@
 package kamon.instrumentation.kafka.client
 
 import java.time.Instant
+import java.util.Optional
 
 import kamon.Kamon
 import kamon.context.Context
@@ -17,10 +18,10 @@ private[kafka] object RecordProcessor {
    * linked to it's bundled span (if any is present). Context (either new or inbound) containing consumer
    * span is then propagated with the record via `HasContext` mixin
    */
-  def process[V, K](startTime: Instant, clientId: String, groupId: String, records: ConsumerRecords[K, V]): ConsumerRecords[K, V] = {
+  def process[V, K](startTime: Instant, clientId: String, groupId: AnyRef, records: ConsumerRecords[K, V]): ConsumerRecords[K, V] = {
 
     if (!records.isEmpty) {
-      val consumerInfo = ConsumerInfo(groupId, clientId)
+      val consumerInfo = ConsumerInfo(resolve(groupId), clientId)
 
       records.iterator().asScala.foreach(record => {
         val header = Option(record.headers.lastHeader(KafkaInstrumentation.Keys.ContextHeader))
@@ -39,4 +40,14 @@ private[kafka] object RecordProcessor {
 
     records
   }
+
+  /**
+    * In order to be backward compatible we need check the groupId field.
+    *
+    * KafkaConsumer which versions < 2.5 relies on internal groupId: String and and higher versions in Optional[String].
+    */
+  private def resolve(groupId: AnyRef): Option[String] = groupId match {
+      case opt: Optional[String] => if (opt.isPresent) Some(opt.get()) else None
+      case value: String => Option(value)
+    }
 }

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
@@ -44,7 +44,7 @@ private[kafka] object RecordProcessor {
   /**
     * In order to be backward compatible we need check the groupId field.
     *
-    * KafkaConsumer which versions < 2.5 relies on internal groupId: String and and higher versions in Optional[String].
+    * KafkaConsumer which versions < 2.5 relies on internal groupId: String and higher versions in Optional[String].
     */
   private def resolve(groupId: AnyRef): Option[String] = groupId match {
       case opt: Optional[String] => if (opt.isPresent) Some(opt.get()) else None

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -102,7 +102,7 @@ object BaseProject extends AutoPlugin {
     concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
     licenses += (("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     resolvers += Resolver.bintrayRepo("kamon-io", "releases"),
-    resolvers += Resolver.mavenLocal,
+    resolvers += Resolver.mavenLocal
   )
 
   private lazy val compilationSettings = Seq(
@@ -114,7 +114,7 @@ object BaseProject extends AutoPlugin {
       "-target", "1.8",
       "-Xlint:-options",
       "-encoding", "UTF-8",
-      "-XDignore.symbol.file",
+      "-XDignore.symbol.file"
     ),
     scalacOptions := Seq(
       "-g:vars",
@@ -243,7 +243,7 @@ object BaseProject extends AutoPlugin {
     Seq[ReleaseStep](
       runClean,
       publishStep,
-      releaseStepCommandAndRemaining("sonatypeBundleRelease"),
+      releaseStepCommandAndRemaining("sonatypeBundleRelease")
     )
   }
 }


### PR DESCRIPTION
This change fixes # 828 and adds support for versions `2.5` and `2.6` of `kafka-clients`.

#### Compatibility
I tested it by running the tests in cross-version fashion against `kafka-clients` `2.3` , `2.4`, `2.5` and  `2.6`