### PR TITLE
cleanup the context from RepointableActorRef after its pointed to a started Cell

### DIFF
--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorRefInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorRefInstrumentation.scala
@@ -1,6 +1,7 @@
 package kamon.instrumentation.akka.instrumentations
 
 import kamon.Kamon
+import kamon.context.Context
 import kamon.context.Storage.Scope
 import kamon.instrumentation.context.HasContext
 import kanela.agent.api.instrumentation.InstrumentationBuilder
@@ -44,8 +45,13 @@ object RepointableActorRefPointAdvice {
     Kamon.storeContext(repointableActorRef.asInstanceOf[HasContext].context)
 
   @Advice.OnMethodExit
-  def exit(@Advice.Enter scope: Scope): Unit =
+  def exit(@Advice.Enter scope: Scope, @Advice.This repointableActorRef: Object): Unit = {
     scope.close()
+
+    repointableActorRef
+      .asInstanceOf[HasContext]
+      .setContext(Context.Empty)
+  }
 }
 
 


### PR DESCRIPTION
This can lead to higher memory consumption than necessary when actors are created with an ongoing trace, since a Context gets captured by the `RepointableActorRef` instance but never cleaned, which leaves Spans laying around until the actor is stopped.