### PR TITLE
add support for Akka HTTP 10.2.0, fixes #835

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -378,18 +378,18 @@ lazy val `kamon-akka-http` = (project in file("instrumentation/kamon-akka-http")
   .settings(instrumentationSettings)
   .settings(Seq(
     resolvers += Resolver.bintrayRepo("hseeberger", "maven"),
-    javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.9" % "test",
+    javaAgents += "org.mortbay.jetty.alpn" % "jetty-alpn-agent" % "2.0.10" % "test",
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
-      "com.typesafe.akka" %% "akka-http"            % "10.1.9" % "provided",
-      "com.typesafe.akka" %% "akka-http2-support"   % "10.1.9" % "provided",
-      "com.typesafe.akka" %% "akka-stream"          % "2.5.24" % "provided",
+      "com.typesafe.akka" %% "akka-http"            % "10.1.12" % "provided",
+      "com.typesafe.akka" %% "akka-http2-support"   % "10.1.12" % "provided",
+      "com.typesafe.akka" %% "akka-stream"          % "2.5.31" % "provided",
 
       scalatest % "test",
       slf4jApi % "test",
       slf4jnop % "test",
       okHttp % "test",
-      "com.typesafe.akka" %% "akka-http-testkit"    % "10.1.9" % "test",
+      "com.typesafe.akka" %% "akka-http-testkit"    % "10.1.12" % "test",
       "de.heikoseeberger" %% "akka-http-json4s"     % "1.27.0" % "test",
       "org.json4s"        %% "json4s-native"        % "3.6.7" % "test",
     )

--- a/instrumentation/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/PoolMasterDispatchRequestAdvice.java
+++ b/instrumentation/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/PoolMasterDispatchRequestAdvice.java
@@ -1,0 +1,41 @@
+package kamon.instrumentation.akka.http;
+
+import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
+import kamon.Kamon;
+import kamon.context.Storage;
+import kamon.instrumentation.http.HttpClientInstrumentation;
+import kamon.instrumentation.http.HttpMessage;
+import kamon.trace.Span;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+import scala.concurrent.Future;
+
+import static kamon.instrumentation.akka.http.AkkaHttpInstrumentation.toRequestBuilder;
+
+public class PoolMasterDispatchRequestAdvice {
+
+  @Advice.OnMethodEnter
+  public static void onEnter(
+      @Advice.Argument(value = 1, readOnly = false) HttpRequest request,
+      @Advice.Local("handler") HttpClientInstrumentation.RequestHandler<HttpRequest> handler,
+      @Advice.Local("scope")Storage.Scope scope) {
+
+    final HttpMessage.RequestBuilder<HttpRequest> requestBuilder = toRequestBuilder(request);
+
+    handler = AkkaHttpClientInstrumentation.httpClientInstrumentation()
+        .createHandler(requestBuilder, Kamon.currentContext());
+
+    request = handler.request();
+    scope = Kamon.storeContext(Kamon.currentContext().withEntry(Span.Key(), handler.span()));
+  }
+
+  @Advice.OnMethodExit
+  public static void onExit(
+      @Advice.Return Future<HttpResponse> response,
+      @Advice.Local("handler") HttpClientInstrumentation.RequestHandler<HttpRequest> handler,
+      @Advice.Local("scope")Storage.Scope scope) {
+
+    AkkaHttpClientInstrumentation.handleResponse(response, handler);
+    scope.close();
+  }
+}

--- a/instrumentation/kamon-akka-http/src/main/scala-2.11/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
+++ b/instrumentation/kamon-akka-http/src/main/scala-2.11/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
@@ -2,9 +2,9 @@ package kamon.instrumentation.akka.http
 
 import java.util.concurrent.Callable
 
-import akka.http.scaladsl.marshalling.{ToResponseMarshallable, ToResponseMarshaller}
+import akka.http.scaladsl.marshalling.{ToEntityMarshaller, ToResponseMarshallable, ToResponseMarshaller}
 import akka.http.scaladsl.model.StatusCodes.Redirection
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse, StatusCode, Uri}
 import akka.http.scaladsl.server.PathMatcher.{Matched, Unmatched}
 import akka.http.scaladsl.server.directives.{BasicDirectives, CompleteOrRecoverWithMagnet, OnSuccessMagnet}
 import akka.http.scaladsl.server.directives.RouteDirectives.reject
@@ -27,6 +27,8 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import kamon.context.Context
 import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.isPublic
+
+import scala.collection.immutable
 
 
 class AkkaHttpServerInstrumentation extends InstrumentationBuilder {
@@ -134,6 +136,12 @@ object ResolveOperationNameOnRouteInterceptor {
 
   def complete(@Argument(1) m: => ToResponseMarshallable): StandardRoute =
     StandardRoute(resolveOperationName(_).complete(m))
+
+  def complete[T](status: StatusCode, v: => T)(implicit m: ToEntityMarshaller[T]): StandardRoute =
+    StandardRoute(resolveOperationName(_).complete((status, v)))
+
+  def complete[T](status: StatusCode, headers: immutable.Seq[HttpHeader], v: => T)(implicit m: ToEntityMarshaller[T]): StandardRoute =
+    complete((status, headers, v))
 
   def redirect(@Argument(1) uri: Uri, @Argument(2) redirectionType: Redirection): StandardRoute =
     StandardRoute(resolveOperationName(_).redirect(uri, redirectionType))

--- a/instrumentation/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/AkkaHttpClientInstrumentation.scala
+++ b/instrumentation/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/AkkaHttpClientInstrumentation.scala
@@ -35,6 +35,9 @@ class AkkaHttpClientInstrumentation extends InstrumentationBuilder {
     */
   onType("akka.http.scaladsl.HttpExt")
     .advise(method("singleRequestImpl"), classOf[HttpExtSingleRequestAdvice])
+
+  onType("akka.http.impl.engine.client.PoolMaster")
+    .advise(method("dispatchRequest"), classOf[PoolMasterDispatchRequestAdvice])
 }
 
 object AkkaHttpClientInstrumentation {

--- a/instrumentation/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
+++ b/instrumentation/kamon-akka-http/src/test/scala/kamon/testkit/TestWebServer.scala
@@ -20,7 +20,7 @@ import java.security.cert.{Certificate, CertificateFactory}
 import java.security.{KeyStore, SecureRandom}
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.{Http, HttpsConnectionContext, UseHttp2}
+import akka.http.scaladsl.{Http, HttpsConnectionContext}
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import akka.http.scaladsl.model.StatusCodes.{BadRequest, InternalServerError, OK}


### PR DESCRIPTION
These changes bring support for Akka HTTP 10.2.0, while still supporting the older versions. I ran all the tests with 10.2.0 and they all pass, but I didn't upgrade the dependency on the build because Akka HTTP 10.2.0 is not published for Scala 2.11 and we would need to get in a little of SBT hell. 