### PR TITLE
Allows to disable the akka remote sharding metrics

### DIFF
--- a/instrumentation/kamon-akka/src/common/resources/reference.conf
+++ b/instrumentation/kamon-akka/src/common/resources/reference.conf
@@ -118,7 +118,6 @@ kamon.instrumentation.akka {
   }
 
   cluster-sharding {
-
     # Sets the interval at which the Shard metrics (sampling of hosted entities and processed messages across all
     # shards) will be sampled.
     shard-metrics-sample-interval = ${kamon.metric.tick-interval}
@@ -130,6 +129,7 @@ kanela.modules {
   akka {
     name = "Akka Instrumentation"
     description = "Provides metrics and message tracing for Akka Actor Systems, Actors, Routers and Dispatchers"
+    enabled = yes
 
     instrumentations = [
       "kamon.instrumentation.akka.instrumentations.EnvelopeInstrumentation",
@@ -156,12 +156,31 @@ kanela.modules {
   akka-remote {
     name = "Akka Remote Instrumentation"
     description = "Provides distributed Context propagation and Cluster Metrics for Akka"
+    enabled = yes
 
     instrumentations = [
       "kamon.instrumentation.akka.remote.MessageBufferInstrumentation",
-      "kamon.instrumentation.akka.remote.ShardingInstrumentation",
       "kamon.instrumentation.akka.instrumentations.akka_25.remote.RemotingInstrumentation"
       "kamon.instrumentation.akka.instrumentations.akka_26.remote.RemotingInstrumentation"
+    ]
+
+    within = [
+      "akka.dispatch..*",
+      "akka.util..*",
+      "akka.remote..*",
+      "akka.actor..*"
+      "akka.cluster..*"
+      "akka.serialization..*"
+    ]
+  }
+
+  akka-remote-sharding {
+    name = "Akka Remote Cluster Sharding Monitoring"
+    description = "Provides cluster sharding metrics for Akka"
+    enabled = yes
+
+    instrumentations = [
+      "kamon.instrumentation.akka.remote.ShardingInstrumentation"
     ]
 
     within = [


### PR DESCRIPTION
Allows to disable the akka remote sharding metrics independent from akka-remote context propagation

This is done in the same manner as kamon-system-metrics are configurable. The benefit of this approach is, that the sharding subsystem is not instrumented at all.

@ivantopo wdyt?