### PR TITLE
Fix logger name in DatadogSpanReporter.

### DIFF
--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
@@ -80,7 +80,7 @@ class DatadogSpanReporterFactory extends ModuleFactory {
 
 class DatadogSpanReporter(@volatile private var configuration: Configuration) extends SpanReporter {
 
-  private val logger = LoggerFactory.getLogger(classOf[DatadogAPIReporter])
+  private val logger = LoggerFactory.getLogger(classOf[DatadogSpanReporter])
 
   override def reportSpans(spans: Seq[Span.Finished]): Unit = if (spans.nonEmpty) {
     val spanList: List[Seq[JsObject]] = spans


### PR DESCRIPTION
Just a small error I noticed when firing up the span reporter.