### PR TITLE
Fix wrong response size

### DIFF
--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
@@ -14,10 +14,12 @@ class SunEmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSou
     val handler = new HttpHandler {
       override def handle(httpExchange: HttpExchange): Unit = {
         val data = scrapeSource.scrapeData()
-        httpExchange.sendResponseHeaders(200, data.length)
+        val bytes = data.getBytes(StandardCharsets.UTF_8)
+        httpExchange.sendResponseHeaders(200, bytes.length)
         val os = httpExchange.getResponseBody
-        try
-          os.write(data.getBytes(StandardCharsets.UTF_8))
+        try {
+          os.write(bytes)
+        }
         finally
           os.close()
       }


### PR DESCRIPTION
The original solutions set response size equals to string size, but wrote bytes from UTF-8 encoded string. Which in most cases okay, but I encountered difficult to find problem when my string has some non-UTF-8 characters(in my case most likely NaN or Inf). When trying to curl `/metrics` url I was getting: `curl: (18) transfer closed with 6060 bytes remaining to read`