### PR TITLE
Small documentation fix

### DIFF
--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -7,7 +7,8 @@ kamon.prometheus {
   # Enable or disable publishing the Prometheus scraping enpoint using a embedded server.
   start-embedded-http-server = yes
 
-  # Enable of disable including tags from kamon.prometheus.environment as labels
+  # Enable or disable including tags from kamon.environment.tags as labels
+  # reference: https://github.com/kamon-io/Kamon/blob/master/core/kamon-core/src/main/resources/reference.conf#L23
   include-environment-tags = no
 
   buckets {


### PR DESCRIPTION
The namespace referenced for `include-environment-tags` was wrong.
Also include a reference to `kamon.environment.tags` documentation