### PR TITLE
Added support for adding custom HTTP headers to responses

### DIFF
--- a/instrumentation/kamon-akka-http/src/main/resources/reference.conf
+++ b/instrumentation/kamon-akka-http/src/main/resources/reference.conf
@@ -51,8 +51,7 @@ kamon.instrumentation.akka.http {
       #
       #enabled = yes
     }
-
-
+  
     #
     # Configuration for HTTP request tracing.
     #
@@ -111,6 +110,12 @@ kamon.instrumentation.akka.http {
 
         # HTTP response header name for the server span identifier, or "none" to disable it.
         #span-id = none
+
+        # Controls adding custom HTTP headers to the responses
+        #   - none: Disabled, no additional headers are appended to the response
+        #   - fqcn: FQCN for a HttpServerResponseHeaderGenerator implementation
+        #
+        #headers-generator = "none"
       }
 
       # Custom mappings between routes and operation names.

--- a/instrumentation/kamon-instrumentation-common/src/main/resources/reference.conf
+++ b/instrumentation/kamon-instrumentation-common/src/main/resources/reference.conf
@@ -45,7 +45,6 @@ kamon {
           enabled = yes
         }
 
-
         #
         # Configuration for HTTP request tracing.
         #
@@ -104,6 +103,12 @@ kamon {
 
             # HTTP response header name for the server span identifier, or "none" to disable it.
             span-id = none
+
+            # Controls adding custom HTTP headers to the responses
+            #   - none: Disabled, no additional headers are appended to the response
+            #   - fqcn: FQCN for a HttpServerResponseHeaderGenerator implementation
+            #
+            headers-generator = "none"
           }
 
           # Custom mappings between routes and operation names.

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/http/HttpServerInstrumentation.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/http/HttpServerInstrumentation.scala
@@ -244,7 +244,8 @@ object HttpServerInstrumentation {
           if(!span.isEmpty) {
             settings.traceIDResponseHeader.foreach(traceIDHeader => response.write(traceIDHeader, span.trace.id.string))
             settings.spanIDResponseHeader.foreach(spanIDHeader => response.write(spanIDHeader, span.id.string))
-
+            settings.httpServerResponseHeaderGenerator.headers(handlerContext).foreach(header => response.write(header._1, header._2))
+            
             SpanTagger.tag(span, TagKeys.HttpStatusCode, response.statusCode, settings.statusCodeTagMode)
 
             val statusCode = response.statusCode
@@ -341,7 +342,8 @@ object HttpServerInstrumentation {
     defaultOperationName: String,
     unhandledOperationName: String,
     operationMappings: Map[Filter.Glob, String],
-    operationNameGenerator: HttpOperationNameGenerator
+    operationNameGenerator: HttpOperationNameGenerator,
+    httpServerResponseHeaderGenerator:HttpServerResponseHeaderGenerator
   ) {
     val operationNameSettings = OperationNameSettings(defaultOperationName, operationMappings, operationNameGenerator)
   }
@@ -372,6 +374,17 @@ object HttpServerInstrumentation {
       val traceIDResponseHeader = optionalString(config.getString("tracing.response-headers.trace-id"))
       val spanIDResponseHeader = optionalString(config.getString("tracing.response-headers.span-id"))
 
+      val httpServerResponseHeaderGenerator: Try[HttpServerResponseHeaderGenerator] = Try {
+        config.getString("tracing.response-headers.headers-generator") match {
+          case "none" => DefaultHttpServerResponseHeaderGenerator
+          case fqcn => ClassLoading.createInstance[HttpServerResponseHeaderGenerator](fqcn)
+        }
+      } recover {
+        case t: Throwable =>
+          _log.warn("Failed to create an HTTP Server Response Header Generator, falling back to the default no-op", t)
+          DefaultHttpServerResponseHeaderGenerator
+      }
+      
       val defaultOperationName = config.getString("tracing.operations.default")
       val operationNameGenerator: Try[HttpOperationNameGenerator] = Try {
         config.getString("tracing.operations.name-generator") match {
@@ -405,7 +418,8 @@ object HttpServerInstrumentation {
         defaultOperationName,
         unhandledOperationName,
         operationMappings,
-        operationNameGenerator.get
+        operationNameGenerator.get,
+        httpServerResponseHeaderGenerator.get
       )
     }
   }

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/http/HttpServerResponseHeaderGenerator.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/http/HttpServerResponseHeaderGenerator.scala
@@ -1,0 +1,25 @@
+package kamon.instrumentation.http
+
+import kamon.context.Context
+
+/**
+ * Allows for adding custom HTTP headers to the responses
+ */
+trait HttpServerResponseHeaderGenerator {
+  /**
+   * Returns the headers (name/value) to be appended to the response
+   * @param context The context for the current request
+   * @return
+   */
+  def headers(context:Context):Map[String, String]
+}
+
+/**
+ * Default implementation of the ''HttpServerResponseHeaderGenerator''
+ */
+object DefaultHttpServerResponseHeaderGenerator extends HttpServerResponseHeaderGenerator {
+  /**
+   * Always returns empty Map
+   */
+  def headers(context:Context):Map[String, String] = Map.empty
+}

--- a/instrumentation/kamon-instrumentation-common/src/test/resources/application.conf
+++ b/instrumentation/kamon-instrumentation-common/src/test/resources/application.conf
@@ -47,6 +47,11 @@ kamon {
       with-custom-operation-name-generator {
         tracing.operations.name-generator = "kamon.instrumentation.http.DedicatedNameGenerator"
       }
+
+      with-custom-server-response-header-generator {
+        tracing.response-headers.headers-generator = "kamon.instrumentation.http.DedicatedResponseHeaderGenerator"
+      }
+
     }
 
     http-client {


### PR DESCRIPTION
This PR implements the feature request from issue: #857

In essence following the similar pattern as e.g. custom operator naming allowing the developer to provide a FQCN to a class that generates a Map of headers to add to the response.
Default implementation does nothing, i.e. empty Map