### PR TITLE
Add elasticsearch instrumentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,6 +122,7 @@ lazy val instrumentation = (project in file("instrumentation"))
     `kamon-kafka`,
     `kamon-mongo`,
     `kamon-cassandra`,
+    `kamon-elasticsearch`,
     `kamon-annotation`,
     `kamon-annotation-api`,
     `kamon-system-metrics`,
@@ -319,6 +320,22 @@ lazy val `kamon-cassandra` = (project in file("instrumentation/kamon-cassandra")
     )
   ).dependsOn(`kamon-core`, `kamon-instrumentation-common`, `kamon-testkit` % "test", `kamon-executors`)
 
+lazy val `kamon-elasticsearch` = (project in file("instrumentation/kamon-elasticsearch"))
+  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(JavaAgent)
+  .settings(instrumentationSettings)
+  .settings(
+    fork in (Test,run) := true,
+    libraryDependencies ++= Seq(
+      kanelaAgent % "provided",
+      "org.elasticsearch.client" % "elasticsearch-rest-client" % "7.9.1" % "provided",
+      "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.1" % "provided",
+      scalatest % "test",
+      logbackClassic % "test",
+      "com.dimafeng" %% "testcontainers-scala" % "0.38.3" % "test",
+      "com.dimafeng" %% "testcontainers-scala-elasticsearch" % "0.38.3" % "test"
+    )
+  ).dependsOn(`kamon-core`, `kamon-instrumentation-common`, `kamon-testkit` % "test")
 
 
 lazy val `kamon-annotation-api` = (project in file("instrumentation/kamon-annotation-api"))
@@ -630,6 +647,7 @@ val `kamon-bundle` = (project in file("bundle/kamon-bundle"))
     `kamon-kafka` % "shaded",
     `kamon-mongo` % "shaded",
     `kamon-cassandra` % "shaded",
+    `kamon-elasticsearch` % "shaded",
     `kamon-annotation` % "shaded",
     `kamon-annotation-api` % "shaded",
     `kamon-system-metrics` % "shaded",

--- a/instrumentation/kamon-elasticsearch/src/main/java/kamon/instrumentation/elasticsearch/AsyncElasticsearchRestClientInstrumentation.java
+++ b/instrumentation/kamon-elasticsearch/src/main/java/kamon/instrumentation/elasticsearch/AsyncElasticsearchRestClientInstrumentation.java
@@ -1,0 +1,28 @@
+package kamon.instrumentation.elasticsearch;
+
+import kamon.Kamon;
+import kamon.trace.Span;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.ResponseListener;
+
+public class AsyncElasticsearchRestClientInstrumentation {
+
+    @Advice.OnMethodEnter
+    public static void enter(
+            @Advice.Argument(0) Request request,
+            @Advice.Argument(value = 1, readOnly = false) ResponseListener responseListener) {
+        final String operationName =
+                RequestNameConverter.convert(
+                        HighLevelElasticsearchClientInstrumentation.requestClassName.get(),
+                        "AsyncRequest");
+
+        Span span = Kamon.clientSpanBuilder(operationName, "elasticsearch.client")
+                .tag("elasticsearch.http.endpoint", request.getEndpoint())
+                .tag("elasticsearch.http.method", request.getMethod())
+                .start();
+
+        RequestSizeHistogram.record(request.getEntity());
+        responseListener = new InstrumentedListener(responseListener, span);
+    }
+}

--- a/instrumentation/kamon-elasticsearch/src/main/java/kamon/instrumentation/elasticsearch/HighLevelElasticsearchClientInstrumentation.java
+++ b/instrumentation/kamon-elasticsearch/src/main/java/kamon/instrumentation/elasticsearch/HighLevelElasticsearchClientInstrumentation.java
@@ -1,0 +1,18 @@
+package kamon.instrumentation.elasticsearch;
+
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+
+public class HighLevelElasticsearchClientInstrumentation {
+    public static final ThreadLocal<String> requestClassName = new ThreadLocal<>();
+
+    @Advice.OnMethodEnter
+    public static <Req> void enter(
+            @Advice.Argument(0) Req request) {
+        requestClassName.set(request.getClass().getSimpleName());
+    }
+
+    @Advice.OnMethodExit
+    public static void exit() {
+        requestClassName.remove();
+    }
+}

--- a/instrumentation/kamon-elasticsearch/src/main/java/kamon/instrumentation/elasticsearch/SyncElasticsearchRestClientInstrumentation.java
+++ b/instrumentation/kamon-elasticsearch/src/main/java/kamon/instrumentation/elasticsearch/SyncElasticsearchRestClientInstrumentation.java
@@ -1,0 +1,30 @@
+package kamon.instrumentation.elasticsearch;
+
+import kamon.Kamon;
+import kamon.trace.Span;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+import org.elasticsearch.client.Request;
+
+public class SyncElasticsearchRestClientInstrumentation {
+
+    @Advice.OnMethodEnter
+    public static void enter(
+            @Advice.Argument(0) Request request,
+            @Advice.Local("span") Span span) {
+        final String operationName = RequestNameConverter.convert(
+                HighLevelElasticsearchClientInstrumentation.requestClassName.get(),
+                "SyncRequest");
+
+        RequestSizeHistogram.record(request.getEntity());
+        span = Kamon.clientSpanBuilder(operationName, "elasticsearch.client")
+                .tag("elasticsearch.http.endpoint", request.getEndpoint())
+                .tag("elasticsearch.http.method", request.getMethod())
+                .start();
+    }
+
+    @Advice.OnMethodExit
+    public static void exit(
+            @Advice.Local("span") Span span) {
+        span.finish();
+    }
+}

--- a/instrumentation/kamon-elasticsearch/src/main/resources/reference.conf
+++ b/instrumentation/kamon-elasticsearch/src/main/resources/reference.conf
@@ -1,0 +1,23 @@
+# ================================================== #
+# kamon Elasticsearch client reference configuration #
+# ================================================== #
+
+kamon.instrumentation.elasticsearch {
+}
+
+kanela {
+  modules {
+    elasticsearch-driver {
+
+      name = "Elasticsearch Client"
+      description = "Provides tracing of client calls made with the official Elasticsearch Client library."
+      instrumentations = [
+        "kamon.instrumentation.elasticsearch.ESInstrumentation"
+      ]
+
+      within = [
+        "org.elasticsearch.client..*"
+      ]
+    }
+  }
+}

--- a/instrumentation/kamon-elasticsearch/src/main/scala/kamon/instrumentation/elasticsearch/ESInstrumentation.scala
+++ b/instrumentation/kamon-elasticsearch/src/main/scala/kamon/instrumentation/elasticsearch/ESInstrumentation.scala
@@ -1,0 +1,40 @@
+package kamon.instrumentation.elasticsearch
+
+import kamon.Kamon
+import kamon.trace.Span
+import kanela.agent.api.instrumentation.InstrumentationBuilder
+import org.apache.http.HttpEntity
+import org.elasticsearch.client.{Response, ResponseListener}
+
+class ESInstrumentation extends InstrumentationBuilder {
+  onType("org.elasticsearch.client.RestClient")
+    .advise(method("performRequestAsync").and(takesArguments(2)), classOf[AsyncElasticsearchRestClientInstrumentation])
+    .advise(method("performRequest").and(takesArguments(1)), classOf[SyncElasticsearchRestClientInstrumentation])
+
+  onType("org.elasticsearch.client.RestHighLevelClient")
+    .advise(method("internalPerformRequest").and(takesArguments(5)), classOf[HighLevelElasticsearchClientInstrumentation])
+    .advise(method("internalPerformRequestAsync").and(takesArguments(6)), classOf[HighLevelElasticsearchClientInstrumentation])
+}
+
+class InstrumentedListener(inner: ResponseListener, span: Span) extends ResponseListener {
+  override def onSuccess(response: Response): Unit = {
+    span.finish()
+    inner.onSuccess(response)
+  }
+
+  override def onFailure(exception: Exception): Unit = {
+    span.fail(exception)
+    inner.onFailure(exception)
+  }
+}
+
+object RequestSizeHistogram {
+  private val histogram = Kamon.histogram("elastic.request.size").withoutTags()
+
+  def record(entity: HttpEntity): Unit = {
+    Option(entity)
+      .map(_.getContentLength)
+      .filter(_ >= 0)
+      .foreach(histogram.record)
+  }
+}

--- a/instrumentation/kamon-elasticsearch/src/main/scala/kamon/instrumentation/elasticsearch/RequestNameConverter.scala
+++ b/instrumentation/kamon-elasticsearch/src/main/scala/kamon/instrumentation/elasticsearch/RequestNameConverter.scala
@@ -1,0 +1,8 @@
+package kamon.instrumentation.elasticsearch
+
+object RequestNameConverter {
+  def convert(className: String, fallback: String): String = {
+    val requestType = Option(className).getOrElse(fallback)
+    s"elasticsearch/$requestType"
+  }
+}

--- a/instrumentation/kamon-elasticsearch/src/test/resources/application.conf
+++ b/instrumentation/kamon-elasticsearch/src/test/resources/application.conf
@@ -1,0 +1,6 @@
+kamon.instrumentation.elasticsearch {
+}
+kanela {
+#  debug-mode = true
+#  log-level = "DEBUG"
+}

--- a/instrumentation/kamon-elasticsearch/src/test/resources/logback.xml
+++ b/instrumentation/kamon-elasticsearch/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.hyperic" level="OFF"/>
+    <logger name="org.apache" level="OFF"/>
+    <logger name="org.testcontainers" level="OFF"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/instrumentation/kamon-elasticsearch/src/test/scala/kamon/instrumentation/ElasticSearchInstrumentationTest.scala
+++ b/instrumentation/kamon-elasticsearch/src/test/scala/kamon/instrumentation/ElasticSearchInstrumentationTest.scala
@@ -1,0 +1,106 @@
+package kamon.instrumentation
+
+import com.dimafeng.testcontainers.{ElasticsearchContainer, ForAllTestContainer}
+import kamon.tag.Lookups.plain
+import kamon.testkit.{Reconfigure, TestSpanReporter}
+import org.apache.http.HttpHost
+import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
+import org.apache.http.impl.client.{BasicCredentialsProvider, HttpClientBuilder}
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.admin.cluster.node.tasks.list.{ListTasksRequest, ListTasksResponse}
+import org.elasticsearch.client._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.SpanSugar
+import org.scalatest.{BeforeAndAfterAll, Matchers, OptionValues, WordSpec}
+
+
+class ElasticSearchInstrumentationTest
+  extends WordSpec
+    with Matchers
+    with Eventually
+    with SpanSugar
+    with Reconfigure
+    with OptionValues
+    with TestSpanReporter
+    with BeforeAndAfterAll
+    with ForAllTestContainer {
+
+  val endpointTag = "elasticsearch.http.endpoint"
+  val methodTag = "elasticsearch.http.method"
+
+  "The elasticsearch client" should {
+    "records a span for a basic sync request" in {
+      client.performRequest(new Request("GET", "/_cluster/health"))
+
+      eventually(timeout(5 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName should be("elasticsearch/SyncRequest")
+        span.tags.get(plain(endpointTag)) shouldBe "/_cluster/health"
+        span.tags.get(plain(methodTag)) shouldBe "GET"
+      }
+    }
+
+    "records a span for a basic async request" in {
+      client.performRequestAsync(new Request("GET", "/_cluster/health"),
+        new ResponseListener() {
+          override def onSuccess(response: Response): Unit = ()
+          override def onFailure(exception: Exception): Unit = ()
+        })
+
+      eventually(timeout(5 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName should be("elasticsearch/AsyncRequest")
+        span.tags.get(plain(endpointTag)) shouldBe "/_cluster/health"
+        span.tags.get(plain(methodTag)) shouldBe "GET"
+      }
+    }
+
+    "records a span for a high level sync request" in {
+      highLevelClient.tasks().list(new ListTasksRequest(), RequestOptions.DEFAULT)
+
+      eventually(timeout(5 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName should be("elasticsearch/ListTasksRequest")
+        span.tags.get(plain(endpointTag)) shouldBe "/_tasks"
+        span.tags.get(plain(methodTag)) shouldBe "GET"
+      }
+    }
+
+    "records a span for a high level async request" in {
+      val request = new ListTasksRequest()
+      val listener = new ActionListener[ListTasksResponse] {
+        override def onResponse(response: ListTasksResponse): Unit = ()
+        override def onFailure(e: Exception): Unit = ()
+      }
+
+      highLevelClient.tasks().listAsync(request, RequestOptions.DEFAULT, listener)
+
+      eventually(timeout(5 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName should be("elasticsearch/ListTasksRequest")
+        span.tags.get(plain(endpointTag)) shouldBe "/_tasks"
+        span.tags.get(plain(methodTag)) shouldBe "GET"
+      }
+    }
+  }
+
+
+  override val container = ElasticsearchContainer()
+  var client: RestClient = _
+  var highLevelClient: RestHighLevelClient = _
+
+  override protected def beforeAll(): Unit = {
+    container.start()
+
+    client = RestClient
+      .builder(HttpHost.create(container.httpHostAddress))
+      .build
+
+    highLevelClient = new RestHighLevelClient(
+      RestClient.builder(HttpHost.create(container.httpHostAddress)))
+  }
+
+  override protected def afterAll(): Unit = {
+    container.stop()
+  }
+}


### PR DESCRIPTION
Add elasticsearch instrumentation for the official java High and Low level REST client (current version, 7.9). 

Simple implementation, records a span for each sync and async request with 2 tags (endpoint, method), 
and creates histogram of request sizes.