### PR TITLE
Replace expiringMap with caffeine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -339,9 +339,11 @@ lazy val `kamon-annotation` = (project in file("instrumentation/kamon-annotation
     assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("javax.el.**"    -> "kamon.lib.@0").inAll,
       ShadeRule.rename("com.sun.el.**"  -> "kamon.lib.@0").inAll,
+      ShadeRule.rename("com.github.ben-manes.**"  -> "kamon.lib.@0").inAll,
     ),
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5" % "provided,shaded", // provided? no?
       "org.glassfish" % "javax.el" % "3.0.1-b11" % "provided,shaded",
       scalatest % "test",
       logbackClassic % "test",

--- a/instrumentation/kamon-annotation/src/main/java/kamon/annotation/instrumentation/cache/AnnotationCache.java
+++ b/instrumentation/kamon-annotation/src/main/java/kamon/annotation/instrumentation/cache/AnnotationCache.java
@@ -38,9 +38,9 @@ import java.util.concurrent.TimeUnit;
 
 public final class AnnotationCache {
 
-  private static ConcurrentMap<MetricKey, Object> metrics = buildCache();
+  private static Map<MetricKey, Object> metrics = buildCache();
 
-  private static ConcurrentMap<MetricKey, Object> buildCache() {
+  private static Map<MetricKey, Object> buildCache() {
     return Caffeine.newBuilder()
             .expireAfterAccess(1, TimeUnit.MINUTES)
             .removalListener(LogExpirationListener())

--- a/instrumentation/kamon-annotation/src/main/java/kamon/annotation/instrumentation/cache/AnnotationCache.java
+++ b/instrumentation/kamon-annotation/src/main/java/kamon/annotation/instrumentation/cache/AnnotationCache.java
@@ -16,6 +16,8 @@
 
 package kamon.annotation.instrumentation.cache;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 import kamon.Kamon;
 import kamon.annotation.api.Time;
 import kamon.annotation.api.TrackConcurrency;
@@ -24,9 +26,6 @@ import kamon.annotation.el.TagsEvaluator;
 import kamon.metric.*;
 import kamon.tag.TagSet;
 import kamon.trace.SpanBuilder;
-import kanela.agent.libs.net.jodah.expiringmap.ExpirationListener;
-import kanela.agent.libs.net.jodah.expiringmap.ExpirationPolicy;
-import kanela.agent.libs.net.jodah.expiringmap.ExpiringMap;
 import kanela.agent.util.log.Logger;
 
 import java.lang.reflect.Method;
@@ -34,19 +33,19 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 public final class AnnotationCache {
 
-  private static Map<MetricKey, Object> metrics = buildCache();
+  private static ConcurrentMap<MetricKey, Object> metrics = buildCache();
 
-  private static Map<MetricKey, Object> buildCache() {
-    return ExpiringMap
-        .builder()
-        .expiration(1, TimeUnit.MINUTES)
-        .expirationPolicy(ExpirationPolicy.ACCESSED)
-        .asyncExpirationListener(ExpirationListener())
-        .build();
+  private static ConcurrentMap<MetricKey, Object> buildCache() {
+    return Caffeine.newBuilder()
+            .expireAfterAccess(1, TimeUnit.MINUTES)
+            .removalListener(LogExpirationListener())
+            .build()
+            .asMap();
   }
 
   public static Gauge getGauge(Method method, Object obj, Class<?> clazz, String className, String methodName) {
@@ -193,8 +192,8 @@ public final class AnnotationCache {
     return (evaluatedString.isEmpty() || evaluatedString.equals("unknown")) ? className + "." + methodName: evaluatedString;
   }
 
-  private static ExpirationListener<MetricKey, Object> ExpirationListener() {
-    return (key, value) ->   {
+  private static RemovalListener<MetricKey, Object> LogExpirationListener() {
+    return (key, value, cause) ->   {
       if(value instanceof Instrument) ((Instrument) value).remove();
       Logger.debug(() -> "Expiring key: " + key + "with value" + value);
     };


### PR DESCRIPTION
Replacing it because of the deadlock bug described in #827 
Not triggered in Kamon, but no reason to keep a library that we know has such a defect