### PR TITLE
fix: ignore doJsonPut failure result

### DIFF
--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
@@ -12,6 +12,8 @@ import kamon.util.{ EnvironmentTags, Filter }
 import org.slf4j.LoggerFactory
 import play.api.libs.json.{ JsObject, Json }
 
+import scala.util.{ Failure, Success }
+
 trait KamonDataDogTranslator {
   def translate(span: Span.Finished, additionalTags: TagSet, tagFilter: Filter): DdSpan
 }
@@ -88,7 +90,11 @@ class DatadogSpanReporter(@volatile private var configuration: Configuration) ex
       .groupBy { _.\("trace_id").get.toString() }
       .values
       .toList
-    configuration.httpClient.doJsonPut(Json.toJson(spanList))
+    configuration.httpClient.doJsonPut(Json.toJson(spanList)) match {
+      case Failure(exception) =>
+        throw exception
+      case _ => ()
+    }
   }
 
   logger.info("Started the Kamon DataDog span reporter")

--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/DatadogSpanReporter.scala
@@ -12,7 +12,7 @@ import kamon.util.{ EnvironmentTags, Filter }
 import org.slf4j.LoggerFactory
 import play.api.libs.json.{ JsObject, Json }
 
-import scala.util.{ Failure, Success }
+import scala.util.{ Failure }
 
 trait KamonDataDogTranslator {
   def translate(span: Span.Finished, additionalTags: TagSet, tagFilter: Filter): DdSpan


### PR DESCRIPTION
i fixed `httpClient.doJsonPut` result `Try`'s Failure case ignored.
threw exception is catched by caller method and Failure case is output to log by this fix.

