### PR TITLE
Ensure pool entry is not null when instrumenting it

### DIFF
--- a/instrumentation/kamon-jdbc/src/main/scala/kamon/instrumentation/jdbc/HikariInstrumentation.scala
+++ b/instrumentation/kamon-jdbc/src/main/scala/kamon/instrumentation/jdbc/HikariInstrumentation.scala
@@ -113,7 +113,7 @@ object HikariPoolCreatePoolEntryMethodAdvice {
 
   @Advice.OnMethodExit
   def exit(@This hikariPool: HasConnectionPoolTelemetry, @Advice.Return poolEntry: Any): Unit = {
-    if(hikariPool != null) {
+    if(hikariPool != null && poolEntry != null) {
       poolEntry.asInstanceOf[HasConnectionPoolTelemetry].setConnectionPoolTelemetry(hikariPool.connectionPoolTelemetry)
 
       val poolTelemetry = hikariPool.connectionPoolTelemetry.get


### PR DESCRIPTION
If an exception is thrown in the createPoolEntry method in the HikariPool then null will be returned (https://github.com/brettwooldridge/HikariCP/blob/dev/src/main/java/com/zaxxer/hikari/pool/HikariPool.java#L507).
This causes a NPE in the instrumentation which swallows the original exception eventually.

Fixes: https://github.com/kamon-io/Kamon/issues/662

