### PR TITLE
Make jaeger endpoint configurable

### DIFF
--- a/reporters/kamon-jaeger/src/main/resources/reference.conf
+++ b/reporters/kamon-jaeger/src/main/resources/reference.conf
@@ -11,6 +11,9 @@ kamon {
     #   - udp: Sends spans using jaeger.thrift compact over UDP. Aimed to used with a Jaeger Agent.
     protocol = http
 
+    # for http and https, this is the full url to be used
+    http-url = ${kamon.jaeger.protocol}"://"${kamon.jaeger.host}":"${kamon.jaeger.port}"/api/traces"
+
     # Enable or disable including tags from kamon.environment as labels
     include-environment-tags = no
   }

--- a/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerClient.scala
+++ b/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerClient.scala
@@ -38,7 +38,7 @@ object JaegerClient {
     val protocol = jaegerConfig.getString("protocol")
     val host = jaegerConfig.getString("host")
     val port = jaegerConfig.getInt("port")
-    val httpUrl = jaegerConfig.getInt("http-url")
+    val httpUrl = jaegerConfig.getString("http-url")
     val includeEnvTags = jaegerConfig.getBoolean("include-environment-tags")
 
     protocol match {

--- a/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerClient.scala
+++ b/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerClient.scala
@@ -38,11 +38,12 @@ object JaegerClient {
     val protocol = jaegerConfig.getString("protocol")
     val host = jaegerConfig.getString("host")
     val port = jaegerConfig.getInt("port")
+    val httpUrl = jaegerConfig.getInt("http-url")
     val includeEnvTags = jaegerConfig.getBoolean("include-environment-tags")
 
     protocol match {
       case "udp"            => buildAgentClient(host, port, includeEnvTags)
-      case "http" | "https" => buildCollectorClient(host, port, protocol, includeEnvTags)
+      case "http" | "https" => buildCollectorClient(httpUrl, includeEnvTags)
       case anyOther         =>
         log.warn("Unknown protocol [{}] found in the configuration, falling back to UDP", anyOther)
         buildAgentClient(host, port, includeEnvTags)
@@ -57,8 +58,7 @@ object JaegerClient {
     new JaegerClient(Some(agentMaxPacketSize - agentBatchOverhead), jaegerSender)
   }
 
-  private def buildCollectorClient(host: String, port: Int, scheme: String, includeEnvTags: Boolean): JaegerClient = {
-    val endpoint = s"$scheme://$host:$port/api/traces"
+  private def buildCollectorClient(endpoint: String, includeEnvTags: Boolean): JaegerClient = {
     val sender = new HttpSender.Builder(endpoint).build()
     val jaegerSender = new JaegerSender(sender, includeEnvTags)
     new JaegerClient(None, jaegerSender)


### PR DESCRIPTION
Update the jaeger exporter to have a configurable endpoint. This is similar to what zipkin has.