### PR TITLE
Replace play-json with nanojson, leave play-json tests for now.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -468,8 +468,9 @@ lazy val `kamon-datadog` = (project in file("reporters/kamon-datadog"))
   .settings(
     libraryDependencies ++= Seq(
       okHttp,
-      "com.typesafe.play" %% "play-json" % "2.7.4",
+      "com.grack" % "nanojson" % "1.1",
 
+      "com.typesafe.play" %% "play-json" % "2.7.4" % "test",
       scalatest % "test",
       slf4jApi % "test",
       slf4jnop % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,7 @@ lazy val `kamon-status-page` = (project in file("core/kamon-status-page"))
       ShadeRule.rename("fi.iki.elonen.**"       -> "kamon.lib.@0").inAll,
     ),
     libraryDependencies ++= Seq(
-      "com.grack"     %  "nanojson"  % "1.1"   % "provided,shaded",
+      "com.grack"     %  "nanojson"  % "1.6"   % "provided,shaded",
       "org.nanohttpd" %  "nanohttpd" % "2.3.1" % "provided,shaded"
     )
   ).dependsOn(`kamon-core`)
@@ -464,11 +464,14 @@ lazy val reporters = (project in file("reporters"))
 
 
 lazy val `kamon-datadog` = (project in file("reporters/kamon-datadog"))
-  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(AssemblyPlugin)
   .settings(
+    assemblyShadeRules in assembly := Seq(
+      ShadeRule.rename("com.grack.nanojson.**"  -> "kamon.lib.@0").inAll,
+    ),
     libraryDependencies ++= Seq(
       okHttp,
-      "com.grack" % "nanojson" % "1.1",
+      "com.grack" % "nanojson" % "1.6" % "provided,shaded",
 
       "com.typesafe.play" %% "play-json" % "2.7.4" % "test",
       scalatest % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -464,14 +464,11 @@ lazy val reporters = (project in file("reporters"))
 
 
 lazy val `kamon-datadog` = (project in file("reporters/kamon-datadog"))
-  .enablePlugins(AssemblyPlugin)
+  .disablePlugins(AssemblyPlugin)
   .settings(
-    assemblyShadeRules in assembly := Seq(
-      ShadeRule.rename("com.grack.nanojson.**"  -> "kamon.lib.@0").inAll,
-    ),
     libraryDependencies ++= Seq(
       okHttp,
-      "com.grack" % "nanojson" % "1.6" % "provided,shaded",
+      "com.grack" % "nanojson" % "1.6",
 
       "com.typesafe.play" %% "play-json" % "2.7.4" % "test",
       scalatest % "test",

--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/DdSpan.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/DdSpan.scala
@@ -18,7 +18,7 @@ package kamon.datadog
 
 import java.time.Duration
 
-import play.api.libs.json._
+import com.grack.nanojson.JsonObject
 
 case class DdSpan(
   traceId:  BigInt,
@@ -33,31 +33,35 @@ case class DdSpan(
   meta:     Map[String, String],
   error:    Boolean) {
 
-  def toJson(): JsObject = {
-    val json = JsObject(Map(
-      "trace_id" -> JsNumber(BigDecimal(traceId)),
-      "span_id" -> JsNumber(BigDecimal(spanId)),
-      "name" -> JsString(name),
-      "type" -> JsString(spanType),
-      "resource" -> JsString(resource),
-      "service" -> JsString(service),
-      "start" -> JsNumber(BigDecimal(start)),
-      "duration" -> JsNumber(BigDecimal(duration.toNanos)),
-      "meta" -> JsObject(
-        meta.mapValues(JsString(_)).toSeq
-      ),
-      "error" -> JsNumber(if (error) 1 else 0),
-      "metrics" -> JsObject(Map(
+  def toJson(): JsonObject = {
+    val metaBuilder = JsonObject.builder
+    meta.foreach { case (k, v) =>
+      metaBuilder.value(k, v)
+    }
+    val metaObj = metaBuilder.done
+
+    val json = JsonObject.builder
+      .value("trace_id", BigDecimal(traceId))
+      .value("span_id", BigDecimal(spanId))
+      .value("name", name)
+      .value("type", spanType)
+      .value("resource", resource)
+      .value("service", service)
+      .value("start", BigDecimal(start))
+      .value("duration", BigDecimal(duration.toNanos))
+      .`object`("meta", metaObj)
+      .value("error", if (error) 1 else 0)
+      .`object`("metrics")
         // This tells the datadog agent to keep the trace. We've already determined sampling here or we wouldn't
         // be in this method. Keep in mind this DOES NOT respect sampling rates in the datadog agent
         // https://docs.datadoghq.com/tracing/guide/trace_sampling_and_storage/#client-implementation
-        "_sampling_priority_v1" -> JsNumber(1)
-      ))
-    ).toSeq)
+        .value("_sampling_priority_v1", 1)
+      .end
+
     if (parentId.nonEmpty) {
-      json + ("parent_id", JsNumber(BigDecimal(parentId.get)))
+      json.value("parent_id", BigDecimal(parentId.get)).done
     } else {
-      json
+      json.done
     }
   }
 }

--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/package.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/package.scala
@@ -24,7 +24,6 @@ import com.typesafe.config.Config
 import kamon.metric.MeasurementUnit
 import kamon.metric.MeasurementUnit.{ information, time }
 import okhttp3._
-import play.api.libs.json.JsValue
 
 import scala.util.{ Failure, Success, Try }
 
@@ -86,14 +85,14 @@ package object datadog {
       doMethodWithBody("PUT", contentType, contentBody)
     }
 
-    def doJsonPost(contentBody: JsValue): Try[String] = {
+    def doJsonPost(contentBody: String): Try[String] = {
       // Datadog Agent does not accept ";charset=UTF-8", using bytes to send Json posts
-      doPost("application/json", contentBody.toString().getBytes(StandardCharsets.UTF_8))
+      doPost("application/json", contentBody.getBytes(StandardCharsets.UTF_8))
     }
 
-    def doJsonPut(contentBody: JsValue): Try[String] = {
+    def doJsonPut(contentBody: String): Try[String] = {
       // Datadog Agent does not accept ";charset=UTF-8", using bytes to send Json posts
-      doPut("application/json", contentBody.toString().getBytes(StandardCharsets.UTF_8))
+      doPut("application/json", contentBody.getBytes(StandardCharsets.UTF_8))
     }
 
     // Apparently okhttp doesn't require explicit closing of the connection


### PR DESCRIPTION
This is a follow-up from https://github.com/kamon-io/Kamon/discussions/888. The PR removes the dependency on `play-json` and instead writes JSON using https://github.com/mmastrac/nanojson, which is already required by the `kamon-status-page` module.

Since `play-json` is widely used in the Scala community, there's potential for dependency conflicts when a user pulls in both `kamon-datadog` and their own `play-json`. This PR avoids that situation.

A few questions for the maintainers:
- Should we shade the `nanojson` dep, like `kamon-status-page` does?
- I left the tests as they are, using `play-json`. Should we put in the work to port them to `nanojson`? I haven't yet for a few reasons: 
  - to make sure the JSON output was exactly the same while changing the underlying implementation, 
  - `play-json` has some niceties when working in Scala that `nanojson` does not, so replacing it there would be a bit annoying (and I'm lazy :-D )
  - `play-json` can be moved to a test dep so conflicts will no longer be an issue