### PR TITLE
shade kamon-annotation dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -356,11 +356,13 @@ lazy val `kamon-annotation` = (project in file("instrumentation/kamon-annotation
     assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("javax.el.**"    -> "kamon.lib.@0").inAll,
       ShadeRule.rename("com.sun.el.**"  -> "kamon.lib.@0").inAll,
-      ShadeRule.rename("com.github.ben-manes.**"  -> "kamon.lib.@0").inAll,
+      ShadeRule.rename("com.github.benmanes.**"  -> "kamon.lib.@0").inAll,
+      ShadeRule.rename("com.google.errorprone.**"  -> "kamon.lib.@0").inAll,
+      ShadeRule.rename("org.checkerframework.**"  -> "kamon.lib.@0").inAll,
     ),
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
-      "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5" % "provided,shaded", // provided? no?
+      "com.github.ben-manes.caffeine" % "caffeine" % "2.8.5" % "provided,shaded",
       "org.glassfish" % "javax.el" % "3.0.1-b11" % "provided,shaded",
       scalatest % "test",
       logbackClassic % "test",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,7 +35,7 @@ object BaseProject extends AutoPlugin {
     val hdrHistogram      = "org.hdrhistogram"      %  "HdrHistogram"    % "2.1.10"
     val okHttp            = "com.squareup.okhttp3"  %  "okhttp"          % "3.14.7"
     val okHttpMockServer  = "com.squareup.okhttp3"  %  "mockwebserver"   % "3.10.0"
-    val oshiCore          = "com.github.oshi"       %  "oshi-core"       % "5.2.5"
+    val oshiCore          = "com.github.oshi"       %  "oshi-core"       % "5.3.4"
 
 
     val kanelaAgentVersion = settingKey[String]("Kanela Agent version")


### PR DESCRIPTION
Also bump oshi to latest version, per their maintainers advice.

Fixes #889 