### PR TITLE
Akka typed actor tag and auto-grouping changes

### DIFF
--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorCellInfo.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorCellInfo.scala
@@ -84,6 +84,10 @@ object ActorCellInfo {
     }}
   }
 
+  def isTyped(className: Class[_]): Boolean = {
+    simpleClassName(className) == "ActorAdapter"
+  }
+
   private def hasRouterProps(props: Props): Boolean =
     props.deploy.routerConfig != NoRouter
 

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorMonitor.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorMonitor.scala
@@ -152,7 +152,7 @@ object ActorMonitor {
       cellInfo.systemName,
       cellInfo.dispatcherName,
       cellInfo.actorOrRouterClass,
-      cellInfo.routeeClass.map(_.getName).getOrElse("Unknown")
+      cellInfo.routeeClass.filterNot(ActorCellInfo.isTyped).map(_.getName).getOrElse("Unknown")
     )
 
     new TrackedRoutee(routerMetrics, groupMetrics, cellInfo)

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorMonitor.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorMonitor.scala
@@ -96,7 +96,9 @@ object ActorMonitor {
         val trackingGroups: Seq[ActorGroupInstruments] = if (cell.isRootSupervisor) List() else {
           val configuredMatchingGroups = AkkaInstrumentation.matchingActorGroups(cell.path)
 
-          if (configuredMatchingGroups.isEmpty && !isTracked && settings.autoGrouping && !cell.isRouter && !cell.isRoutee) {
+          if (configuredMatchingGroups.isEmpty && !isTracked
+            && settings.autoGrouping && !cell.isRouter
+            && !cell.isRoutee && !ActorCellInfo.isTyped(cell.actorOrRouterClass)) {
             if (!trackedFilter.excludes(cell.path) && Kamon.filter(TrackAutoGroupFilterName).accept(autoGroupingPath))
               List(AkkaMetrics.forGroup(autoGroupingPath, system.name))
             else

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/RouterMonitor.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/RouterMonitor.scala
@@ -54,7 +54,7 @@ object RouterMonitor {
           cell.path,
           cell.systemName,
           cell.dispatcherName,
-          cell.actorOrRouterClass.getName,
+          cell.actorOrRouterClass,
           cell.routeeClass.map(_.getName).getOrElse("Unknown")
         )
       )

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/RouterMonitor.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/RouterMonitor.scala
@@ -55,7 +55,7 @@ object RouterMonitor {
           cell.systemName,
           cell.dispatcherName,
           cell.actorOrRouterClass,
-          cell.routeeClass.map(_.getName).getOrElse("Unknown")
+          cell.routeeClass.filterNot(ActorCellInfo.isTyped).map(_.getName).getOrElse("Unknown")
         )
       )
     else NoOpRouterMonitor

--- a/instrumentation/kamon-akka/src/test-common/scala/kamon/instrumentation/akka/MessageTracingSpec.scala
+++ b/instrumentation/kamon-akka/src/test-common/scala/kamon/instrumentation/akka/MessageTracingSpec.scala
@@ -34,7 +34,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
         spanTags("component") shouldBe "akka.actor"
-        span.operationName shouldBe("tell(TracingTestActor, String)")
+        span.operationName shouldBe("tell(String)")
         spanTags("akka.actor.path") shouldNot include ("filteredout")
         spanTags("akka.actor.path") should be ("MessageTracing/user/traced-probe-1")
       }
@@ -48,7 +48,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
       eventually(timeout(2 seconds)) {
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
-        span.operationName shouldBe("tell(TracingTestActor, String)")
+        span.operationName shouldBe("tell(String)")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced"
@@ -62,7 +62,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
       eventually(timeout(2 seconds)) {
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
-        span.operationName shouldBe("ask(TracingTestActor, String)")
+        span.operationName shouldBe("ask(String)")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced"
@@ -83,7 +83,6 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
 
-        span.operationName should include("tell(TracingTestActor")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-first"
@@ -97,7 +96,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
         span.parentId shouldBe firstSpanID
-        span.operationName should include("tell(TracingTestActor, String)")
+        span.operationName should include("tell(String)")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-second"
@@ -118,7 +117,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
       val firstSpanID = eventually(timeout(2 seconds)) {
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
-        span.operationName shouldBe("tell(TracingTestActor, Tuple2)")
+        span.operationName shouldBe("tell(Tuple2)")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-chain-first"
@@ -133,7 +132,7 @@ class MessageTracingSpec extends TestKit(ActorSystem("MessageTracing")) with Wor
         val span = testSpanReporter.nextSpan().value
         val spanTags = stringTag(span) _
         span.parentId shouldBe firstSpanID
-        span.operationName shouldBe("tell(TracingTestActor, String)")
+        span.operationName shouldBe("tell(String)")
         spanTags("component") shouldBe "akka.actor"
         spanTags("akka.system") shouldBe "MessageTracing"
         spanTags("akka.actor.path") shouldBe "MessageTracing/user/traced-chain-last"


### PR DESCRIPTION
This PR makes changes based on the fact that typed actors get converted to ActorAdapter class, rendering some tags and existing behaviour pointless.

# Changes 
* akka.actor.class tag is not used when the actor is typed, because all typed actor would have the same tag (`ActorAdapter`)
* operation name now only contains the message class, instead of both the message and actor class
* auto-grouping is disabled when the actor is typed, because all typed actors on the same level would be in the same group. Typed actors can still be targeted by group filters