### PR TITLE
Bring back buffer pool metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
-      - uses: olafurpg/setup-scala@v2
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.8.0-242
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
-      - uses: olafurpg/setup-scala@v2
+      - uses: olafurpg/setup-scala@v10
       - name: Release
         run: csbt release
         shell: bash

--- a/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
+++ b/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
@@ -19,7 +19,7 @@ package kamon.instrumentation.system.jvm
 import java.lang.management.ManagementFactory
 
 import kamon.Kamon
-import kamon.instrumentation.system.jvm.JvmMetrics.MemoryUsageInstruments.MemoryRegionInstruments
+import kamon.instrumentation.system.jvm.JvmMetrics.MemoryUsageInstruments.{BufferPoolInstruments, MemoryRegionInstruments}
 import kamon.instrumentation.system.jvm.JvmMetricsCollector.{Collector, MemoryPool}
 import kamon.metric.{Gauge, Histogram, InstrumentGroup, MeasurementUnit}
 import kamon.tag.TagSet
@@ -124,6 +124,22 @@ object JvmMetrics {
     description = "Total number od classes currently loaded"
   )
 
+  val BufferPoolCount = Kamon.gauge(
+    name = s"jvm.memory.buffer-pool.count",
+    description = "Estimated number of buffers in the pool"
+  )
+  val BufferPoolUsage = Kamon.gauge(
+    name = s"jvm.memory.buffer-pool.usage",
+    description = "Estimate of memory used by the JVM for this buffer pool in bytes",
+    unit = MeasurementUnit.information.bytes
+  )
+  val BufferPoolCapacity = Kamon.gauge(
+    name = s"jvm.memory.buffer-pool.capacity",
+    description = "Estimate of the total capacity of this pool in bytes",
+    unit = MeasurementUnit.information.bytes
+  )
+
+
   class GarbageCollectionInstruments(tags: TagSet) extends InstrumentGroup(tags) {
     private val _collectorCache = mutable.Map.empty[String, Histogram]
 
@@ -144,6 +160,7 @@ object JvmMetrics {
   class MemoryUsageInstruments(tags: TagSet) extends InstrumentGroup(tags) {
     private val _memoryRegionsCache = mutable.Map.empty[String, MemoryRegionInstruments]
     private val _memoryPoolsCache = mutable.Map.empty[String, MemoryRegionInstruments]
+    private val _memoryBuffersCache = mutable.Map.empty[String, BufferPoolInstruments]
 
     def regionInstruments(regionName: String): MemoryRegionInstruments =
       _memoryRegionsCache.getOrElseUpdate(regionName, {
@@ -168,6 +185,22 @@ object JvmMetrics {
           register(MemoryPoolMax, region)
         )
       })
+
+    def bufferPoolInstruments(poolName: String): BufferPoolInstruments = {
+      _memoryBuffersCache.getOrElseUpdate(poolName, {
+        val commonTags = tags
+          .withTag("pool", poolName)
+        val usageTags = commonTags.withTag("measure", "used")
+        val capacityTags = commonTags.withTag("measure", "capacity")
+
+        BufferPoolInstruments(
+          register(BufferPoolCount, commonTags),
+          register(BufferPoolUsage, usageTags),
+          register(BufferPoolCapacity, capacityTags)
+        )
+      })
+    }
+
   }
 
   class ClassLoadingInstruments(tags: TagSet) extends InstrumentGroup(tags) {
@@ -183,11 +216,17 @@ object JvmMetrics {
   }
 
   object MemoryUsageInstruments {
-    case class MemoryRegionInstruments(
+    case class MemoryRegionInstruments (
       used: Histogram,
       free: Histogram,
       committed: Gauge,
       max: Gauge
+    )
+
+    case class BufferPoolInstruments (
+      count: Gauge,
+      used: Gauge,
+      capacity: Gauge
     )
   }
 }

--- a/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
+++ b/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
@@ -128,17 +128,18 @@ object JvmMetrics {
     name = s"jvm.memory.buffer-pool.count",
     description = "Estimated number of buffers in the pool"
   )
-  val BufferPoolUsage = Kamon.gauge(
-    name = s"jvm.memory.buffer-pool.usage",
+
+  val BufferPoolUsed = Kamon.gauge(
+    name = s"jvm.memory.buffer-pool.used",
     description = "Estimate of memory used by the JVM for this buffer pool in bytes",
     unit = MeasurementUnit.information.bytes
   )
+
   val BufferPoolCapacity = Kamon.gauge(
     name = s"jvm.memory.buffer-pool.capacity",
     description = "Estimate of the total capacity of this pool in bytes",
     unit = MeasurementUnit.information.bytes
   )
-
 
   class GarbageCollectionInstruments(tags: TagSet) extends InstrumentGroup(tags) {
     private val _collectorCache = mutable.Map.empty[String, Histogram]
@@ -188,19 +189,16 @@ object JvmMetrics {
 
     def bufferPoolInstruments(poolName: String): BufferPoolInstruments = {
       _memoryBuffersCache.getOrElseUpdate(poolName, {
-        val commonTags = tags
+        val bufferTags = tags
           .withTag("pool", poolName)
-        val usageTags = commonTags.withTag("measure", "used")
-        val capacityTags = commonTags.withTag("measure", "capacity")
 
         BufferPoolInstruments(
-          register(BufferPoolCount, commonTags),
-          register(BufferPoolUsage, usageTags),
-          register(BufferPoolCapacity, capacityTags)
+          register(BufferPoolCount, bufferTags),
+          register(BufferPoolUsed, bufferTags),
+          register(BufferPoolCapacity, bufferTags)
         )
       })
     }
-
   }
 
   class ClassLoadingInstruments(tags: TagSet) extends InstrumentGroup(tags) {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -35,7 +35,7 @@ object BaseProject extends AutoPlugin {
     val hdrHistogram      = "org.hdrhistogram"      %  "HdrHistogram"    % "2.1.10"
     val okHttp            = "com.squareup.okhttp3"  %  "okhttp"          % "3.14.7"
     val okHttpMockServer  = "com.squareup.okhttp3"  %  "mockwebserver"   % "3.10.0"
-    val oshiCore          = "com.github.oshi"       %  "oshi-core"       % "5.3.4"
+    val oshiCore          = "com.github.oshi"       %  "oshi-core"       % "5.3.6"
 
 
     val kanelaAgentVersion = settingKey[String]("Kanela Agent version")


### PR DESCRIPTION
Fixes #893 by bringing back buffer pool metrics.

Reference implementation: 
https://github.com/kamon-io/kamon-system-metrics/blob/724bb63b1bf47b0a1b23d0c9820452444095a04c/src/main/scala/kamon/system/jvm/MemoryUsageMetrics.scala#L100