### PR TITLE
Add configurable endpoint for Prometheus scraping

### DIFF
--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -82,7 +82,7 @@ kamon.prometheus {
     # Hostname and port used by the embedded web server to publish the scraping enpoint.
     hostname = "0.0.0.0"
     port = 9095
-    metrics_path = "/metrics"
+    metrics-path = "/metrics"
 
     # embedded server impl
     # choose between

--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -82,7 +82,7 @@ kamon.prometheus {
     # Hostname and port used by the embedded web server to publish the scraping enpoint.
     hostname = "0.0.0.0"
     port = 9095
-    path = "/metrics"
+    metrics_path = "/metrics"
 
     # embedded server impl
     # choose between

--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -82,6 +82,7 @@ kamon.prometheus {
     # Hostname and port used by the embedded web server to publish the scraping enpoint.
     hostname = "0.0.0.0"
     port = 9095
+    path = "/metrics"
 
     # embedded server impl
     # choose between

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -74,9 +74,12 @@ class PrometheusReporter(configPath: String = DefaultConfigPath, initialConfig: 
   private def startEmbeddedServerIfEnabled(): Unit = {
     if (_reporterSettings.startEmbeddedServer) {
       val server = _reporterSettings.createEmbeddedHttpServerClass()
-          .getConstructor(Array[Class[_]](classOf[String], classOf[Int], classOf[ScrapeSource], classOf[Config]): _*)
-          .newInstance(_reporterSettings.embeddedServerHostname, _reporterSettings.embeddedServerPort:Integer, this, _config)
-      _logger.info(s"Started the embedded HTTP server on http://${_reporterSettings.embeddedServerHostname}:${_reporterSettings.embeddedServerPort}")
+          .getConstructor(Array[Class[_]](classOf[String], classOf[Int], classOf[String], classOf[ScrapeSource], classOf[Config]): _*)
+          .newInstance(_reporterSettings.embeddedServerHostname,
+            _reporterSettings.embeddedServerPort:Integer,
+            _reporterSettings.embeddedServerPath,
+            this, _config)
+      _logger.info(s"Started the embedded HTTP server on http://${_reporterSettings.embeddedServerHostname}:${_reporterSettings.embeddedServerPort}${_reporterSettings.embeddedServerPath}")
       _embeddedHttpServer = Some(server)
     }
   }
@@ -101,6 +104,7 @@ object PrometheusReporter {
                          startEmbeddedServer: Boolean,
                          embeddedServerHostname: String,
                          embeddedServerPort: Int,
+                         embeddedServerPath: String,
                          embeddedServerImpl: String,
                          generic: PrometheusSettings.Generic
                      ) {
@@ -120,6 +124,7 @@ object PrometheusReporter {
         startEmbeddedServer = prometheusConfig.getBoolean("start-embedded-http-server"),
         embeddedServerHostname = prometheusConfig.getString("embedded-server.hostname"),
         embeddedServerPort = prometheusConfig.getInt("embedded-server.port"),
+        embeddedServerPath = prometheusConfig.getString("embedded-server.path"),
         embeddedServerImpl = prometheusConfig.getString("embedded-server.impl"),
         generic = PrometheusSettings.readSettings(prometheusConfig)
       )

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -124,7 +124,7 @@ object PrometheusReporter {
         startEmbeddedServer = prometheusConfig.getBoolean("start-embedded-http-server"),
         embeddedServerHostname = prometheusConfig.getString("embedded-server.hostname"),
         embeddedServerPort = prometheusConfig.getInt("embedded-server.port"),
-        embeddedServerPath = prometheusConfig.getString("embedded-server.path"),
+        embeddedServerPath = prometheusConfig.getString("embedded-server.metrics_path"),
         embeddedServerImpl = prometheusConfig.getString("embedded-server.impl"),
         generic = PrometheusSettings.readSettings(prometheusConfig)
       )

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -124,7 +124,7 @@ object PrometheusReporter {
         startEmbeddedServer = prometheusConfig.getBoolean("start-embedded-http-server"),
         embeddedServerHostname = prometheusConfig.getString("embedded-server.hostname"),
         embeddedServerPort = prometheusConfig.getInt("embedded-server.port"),
-        embeddedServerPath = prometheusConfig.getString("embedded-server.metrics_path"),
+        embeddedServerPath = prometheusConfig.getString("embedded-server.metrics-path"),
         embeddedServerImpl = prometheusConfig.getString("embedded-server.impl"),
         generic = PrometheusSettings.readSettings(prometheusConfig)
       )

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/EmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/EmbeddedHttpServer.scala
@@ -19,6 +19,6 @@ package kamon.prometheus.embeddedhttp
 import com.typesafe.config.Config
 import kamon.prometheus.ScrapeSource
 
-abstract class EmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSource: ScrapeSource, config: Config) {
+abstract class EmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSource, config: Config) {
   def stop(): Unit
 }

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/EmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/EmbeddedHttpServer.scala
@@ -19,6 +19,6 @@ package kamon.prometheus.embeddedhttp
 import com.typesafe.config.Config
 import kamon.prometheus.ScrapeSource
 
-abstract class EmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSource, config: Config) {
+abstract class EmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSource: ScrapeSource, config: Config) {
   def stop(): Unit
 }

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
@@ -29,7 +29,7 @@ import java.util.zip.GZIPOutputStream
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-class SunEmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSource: ScrapeSource, config: Config) extends EmbeddedHttpServer(hostname, port, path, scrapeSource, config) {
+class SunEmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSource: ScrapeSource, config: Config) extends EmbeddedHttpServer(hostname, port, scrapeSource, config) {
   private val server = {
     val s = HttpServer.create(new InetSocketAddress(InetAddress.getByName(hostname), port), 0)
     s.setExecutor(null)

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
@@ -29,13 +29,13 @@ import java.util.zip.GZIPOutputStream
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-class SunEmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSource, config: Config) extends EmbeddedHttpServer(hostname, port, scrapeSource, config) {
+class SunEmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSource: ScrapeSource, config: Config) extends EmbeddedHttpServer(hostname, port, path, scrapeSource, config) {
   private val server = {
     val s = HttpServer.create(new InetSocketAddress(InetAddress.getByName(hostname), port), 0)
     s.setExecutor(null)
     val handler = new HttpHandler {
       override def handle(httpExchange: HttpExchange): Unit = {
-        if (httpExchange.getRequestURI.getPath == "/metrics") {
+        if (httpExchange.getRequestURI.getPath == path) {
           val data = scrapeSource.scrapeData()
           val bytes = data.getBytes(StandardCharsets.UTF_8)
           var os: OutputStream = null
@@ -55,7 +55,7 @@ class SunEmbeddedHttpServer(hostname: String, port: Int, scrapeSource: ScrapeSou
       }
     }
 
-    s.createContext("/metrics", handler)
+    s.createContext(path, handler)
     s.start()
     s
   }

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/EmbeddedHttpServerSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/EmbeddedHttpServerSpec.scala
@@ -120,6 +120,6 @@ abstract class EmbeddedHttpServerSpecSuite extends WordSpec
 
   private def changeEndpoint(path: String): Config = {
     ConfigFactory.parseString(
-      s"""kamon.prometheus.embedded-server.metrics_path = ${path}""").withFallback(testConfig)
+      s"""kamon.prometheus.embedded-server.metrics-path = ${path}""").withFallback(testConfig)
   }
 }

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/EmbeddedHttpServerSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/EmbeddedHttpServerSpec.scala
@@ -120,6 +120,6 @@ abstract class EmbeddedHttpServerSpecSuite extends WordSpec
 
   private def changeEndpoint(path: String): Config = {
     ConfigFactory.parseString(
-      s"""kamon.prometheus.embedded-server.path = ${path}""").withFallback(testConfig)
+      s"""kamon.prometheus.embedded-server.metrics_path = ${path}""").withFallback(testConfig)
   }
 }


### PR DESCRIPTION
Introduces new setting to keep backwards compatibility for kamon-prometheus endpoint