### PR TITLE
Kafka Consumer instrumentation issue

### DIFF
--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
@@ -65,5 +65,6 @@ private[kafka] object RecordProcessor {
   private def resolve(groupId: AnyRef): Option[String] = groupId match {
       case opt: Optional[String] => if (opt.isPresent) Some(opt.get()) else None
       case value: String => Option(value)
+      case _ => None
     }
 }


### PR DESCRIPTION
Handle case where consumer has no group.id set.
In one particular case, `globalConsumer` used by  KafkaStreams when restoring global state.