### PR TITLE
send links to Jaeger reporter, if set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,8 +332,8 @@ lazy val `kamon-elasticsearch` = (project in file("instrumentation/kamon-elastic
       "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % "7.9.1" % "provided",
       scalatest % "test",
       logbackClassic % "test",
-      "com.dimafeng" %% "testcontainers-scala" % "0.38.3" % "test",
-      "com.dimafeng" %% "testcontainers-scala-elasticsearch" % "0.38.3" % "test"
+      "com.dimafeng" %% "testcontainers-scala" % "0.39.3" % "test",
+      "com.dimafeng" %% "testcontainers-scala-elasticsearch" % "0.39.3" % "test"
     )
   ).dependsOn(`kamon-core`, `kamon-instrumentation-common`, `kamon-testkit` % "test")
 

--- a/core/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -380,6 +380,11 @@ object Span {
         * necessarily should be part of the original trace.
         */
       case object FollowsFrom extends Link.Kind
+      /**
+        * Indicates that the the current Span is a child of the linked Span. A use case for
+        * this link kind is when performing batch operations that aggregate the results of multiple parent spans
+        */
+      case object Child extends Link.Kind
     }
   }
 

--- a/core/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -376,8 +376,8 @@ object Span {
 
       /**
         * Indicates that the the current Span is a continuation of the work started by the linked Span. A use case for
-        * this link kind is when having secondary or fire-and-forget operations spawned from a Trace but that do not
-        * necessarily should be part of the original trace.
+        * this link kind is when having secondary or fire-and-forget operations spawned from a Trace but that should not
+        * necessarily be part of the original trace.
         */
       case object FollowsFrom extends Link.Kind
       /**

--- a/core/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -384,7 +384,7 @@ object Span {
         * Indicates that the the current Span is a child of the linked Span. A use case for
         * this link kind is when performing batch operations that aggregate the results of multiple parent spans
         */
-      case object Child extends Link.Kind
+      case object ChildOf extends Link.Kind
     }
   }
 

--- a/core/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -382,7 +382,7 @@ object Span {
       case object FollowsFrom extends Link.Kind
       /**
         * Indicates that the the current Span is a child of the linked Span. A use case for
-        * this link kind is when performing batch operations that aggregate the results of multiple parent spans
+        * this link kind is when performing batch operations that logically have multiple parent spans
         */
       case object ChildOf extends Link.Kind
     }

--- a/core/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -376,15 +376,10 @@ object Span {
 
       /**
         * Indicates that the the current Span is a continuation of the work started by the linked Span. A use case for
-        * this link kind is when having secondary or fire-and-forget operations spawned from a Trace but that should not
-        * necessarily be part of the original trace.
+        * this link kind is when having secondary or fire-and-forget operations spawned from a Trace but that do not
+        * necessarily should be part of the original trace.
         */
       case object FollowsFrom extends Link.Kind
-      /**
-        * Indicates that the the current Span is a child of the linked Span. A use case for
-        * this link kind is when performing batch operations that logically have multiple parent spans
-        */
-      case object ChildOf extends Link.Kind
     }
   }
 

--- a/reporters/kamon-datadog/src/test/scala/kamon/datadog/DatadogSpanReporterSpec.scala
+++ b/reporters/kamon-datadog/src/test/scala/kamon/datadog/DatadogSpanReporterSpec.scala
@@ -1,6 +1,7 @@
 package kamon.datadog
 
-import java.net.SocketTimeoutException
+import java.io.IOException
+import java.net.{SocketException, SocketTimeoutException}
 import java.time.{Duration, Instant}
 import java.util.concurrent.TimeUnit
 
@@ -200,9 +201,10 @@ class DatadogSpanReporterSpec extends AbstractHttpReporter with Matchers with Re
       val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK").setBody("OK").throttleBody(1, 6, TimeUnit.SECONDS))
       applyConfig("kamon.datadog.trace.http.api-url = \"" + baseUrl + "\"")
       reporter.reconfigure(Kamon.config())
-      assertThrows[SocketTimeoutException] {
+      val exception = intercept[IOException] {
         reporter.reportSpans(firstSpan)
       }
+      assert(exception.isInstanceOf[SocketException] || exception.isInstanceOf[SocketTimeoutException])
 
     }
 

--- a/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
+++ b/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
 
 import io.jaegertracing.thriftjava.{Log, SpanRef, SpanRefType, Tag, TagType, Span => JaegerSpan}
 import kamon.trace.{Identifier, Span}
-import kamon.trace.Span.Link.Kind.{ChildOf, FollowsFrom}
+import kamon.trace.Span.Link.Kind.FollowsFrom
 import kamon.util.Clock
 
 import scala.util.Try
@@ -87,7 +87,6 @@ object JaegerSpanConverter {
 
   private def convertLinkToReference(identifier: Span.Link): SpanRef = {
     val refType = identifier.kind match {
-      case ChildOf => SpanRefType.CHILD_OF
       case FollowsFrom => SpanRefType.FOLLOWS_FROM
     }
     val (traceIdHigh, traceIdLow) = convertDoubleSizeIdentifier(identifier.trace.id)

--- a/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
+++ b/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
@@ -18,8 +18,9 @@ package kamon.jaeger
 
 import java.nio.ByteBuffer
 
-import io.jaegertracing.thriftjava.{Log, Tag, TagType, Span => JaegerSpan}
+import io.jaegertracing.thriftjava.{Log, SpanRef, SpanRefType, Tag, TagType, Span => JaegerSpan}
 import kamon.trace.{Identifier, Span}
+import kamon.trace.Span.Link.Kind.{Child, FollowsFrom}
 import kamon.util.Clock
 
 import scala.util.Try
@@ -65,6 +66,8 @@ object JaegerSpanConverter {
       )
     }
 
+    if (kamonSpan.links.nonEmpty) convertedSpan.setReferences(kamonSpan.links.map(convertLinkToReference).asJava)
+
     convertedSpan
   }
 
@@ -81,4 +84,13 @@ object JaegerSpanConverter {
     } getOrElse {
       (0L, convertIdentifier(identifier))
     }
+
+  private def convertLinkToReference(identifier: Span.Link): SpanRef = {
+    val refType = identifier.kind match {
+      case Child => SpanRefType.CHILD_OF
+      case FollowsFrom => SpanRefType.FOLLOWS_FROM
+    }
+    val (traceIdHigh, traceIdLow) = convertDoubleSizeIdentifier(identifier.trace.id)
+    new SpanRef(refType, traceIdLow, traceIdHigh, convertIdentifier(identifier.spanId))
+  }
 }

--- a/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
+++ b/reporters/kamon-jaeger/src/main/scala/kamon/jaeger/JaegerSpanConverter.scala
@@ -20,7 +20,7 @@ import java.nio.ByteBuffer
 
 import io.jaegertracing.thriftjava.{Log, SpanRef, SpanRefType, Tag, TagType, Span => JaegerSpan}
 import kamon.trace.{Identifier, Span}
-import kamon.trace.Span.Link.Kind.{Child, FollowsFrom}
+import kamon.trace.Span.Link.Kind.{ChildOf, FollowsFrom}
 import kamon.util.Clock
 
 import scala.util.Try
@@ -87,7 +87,7 @@ object JaegerSpanConverter {
 
   private def convertLinkToReference(identifier: Span.Link): SpanRef = {
     val refType = identifier.kind match {
-      case Child => SpanRefType.CHILD_OF
+      case ChildOf => SpanRefType.CHILD_OF
       case FollowsFrom => SpanRefType.FOLLOWS_FROM
     }
     val (traceIdHigh, traceIdLow) = convertDoubleSizeIdentifier(identifier.trace.id)


### PR DESCRIPTION
Also:
- ~Add a 'ChildOf' link type~ Removed for now
- Bump com.dimafeng libs in elasticsearch module to help the failing test
- Made the datadog test a little more forgiving (it appears that the type of exception thrown depends on the architecture or something)

Enables the following view in recent versions of Jaeger UI
<img width="1245" alt="Screenshot 2021-03-06 at 13 36 28" src="https://user-images.githubusercontent.com/2494489/110210295-e5252180-7e88-11eb-97cc-c3361de319f3.png">
