### PR TITLE
Revert passivate tracking to fix #944

### DIFF
--- a/instrumentation/kamon-akka/build.sbt
+++ b/instrumentation/kamon-akka/build.sbt
@@ -2,7 +2,7 @@ import sbt.Tests.{Group, SubProcess}
 import Def.Initialize
 
 val `Akka-2.4-version` = "2.4.20"
-val `Akka-2.5-version` = "2.5.26"
+val `Akka-2.5-version` = "2.5.32"
 val `Akka-2.6-version` = "2.6.11"
 
 /**

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/remote/ShardingInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/remote/ShardingInstrumentation.scala
@@ -39,7 +39,6 @@ class ShardingInstrumentation extends InstrumentationBuilder with VersionFilteri
       .advise(method("onLeaseAcquired"), ShardInitializedAdvice)
       .advise(method("postStop"), ShardPostStopStoppedAdvice)
       .advise(method("getOrCreateEntity"), ShardGetOrCreateEntityAdvice)
-      .advise(method("passivateCompleted"), ShardEntityTerminatedAdvice)
       .advise(method("entityTerminated"), ShardEntityTerminatedAdvice)
       .advise(method("akka$cluster$sharding$Shard$$deliverMessage"), ShardDeliverMessageAdvice)
       .advise(method("deliverMessage"), ShardDeliverMessageAdvice)


### PR DESCRIPTION
The problem here is that it's very hard to replicate the error locally. 
Since it's just a simple revert, it'll go out in the next release, but I'd sleep better at night if someone (who can reproduce this _not in prod_) were to try this out on an app that's currently showing the bug 

If you're up for it, checkout this branch, start sbt and do the following:
```
set version in ThisBuild := "944-fix"
+publishLocal
```

or if you're using maven 

```
set version in ThisBuild := "944-fix"
+publishM2
```
and add the kamon version `944-fix` to you app :)