### PR TITLE
Add Storage.CrossThreadLocal

### DIFF
--- a/core/kamon-core/src/main/scala/kamon/ContextStorage.scala
+++ b/core/kamon-core/src/main/scala/kamon/ContextStorage.scala
@@ -141,8 +141,10 @@ object ContextStorage {
     * instrumentation follows them around.
     */
   private val _contextStorage: Storage = {
-    if(sys.props("kamon.context.debug") == "true")
+    if (sys.props("kamon.context.debug") == "true")
       Storage.Debug()
+    else if (sys.props("kamon.context.crossThread") == "true")
+      Storage.CrossThreadLocal()
     else
       Storage.ThreadLocal()
   }

--- a/core/kamon-core/src/main/scala/kamon/ContextStorage.scala
+++ b/core/kamon-core/src/main/scala/kamon/ContextStorage.scala
@@ -141,11 +141,18 @@ object ContextStorage {
     * instrumentation follows them around.
     */
   private val _contextStorage: Storage = {
+    val storageTypeStr = Option(sys.props("kamon.context.storageType"))
+
     if (sys.props("kamon.context.debug") == "true")
       Storage.Debug()
-    else if (sys.props("kamon.context.crossThread") == "true")
-      Storage.CrossThreadLocal()
-    else
-      Storage.ThreadLocal()
+    else {
+      storageTypeStr match {
+        case None => Storage.CrossThreadLocal()
+        case Some("debug") => Storage.Debug()
+        case Some("sameThreadScope") => Storage.ThreadLocal()
+        case Some("default") => Storage.CrossThreadLocal()
+        case Some(other) => throw new IllegalArgumentException(s"Unrecognized kamon.context.storageType value: $other")
+      }
+    }
   }
 }

--- a/core/kamon-core/src/main/scala/kamon/context/Storage.scala
+++ b/core/kamon-core/src/main/scala/kamon/context/Storage.scala
@@ -58,10 +58,42 @@ object Storage {
   }
 
   /**
+    * A ThreadLocal context storage that allows the scope to be closed in a different
+    * thread than the thread where store(..) was called.
+    * This is roughly 25% slower than [[kamon.context.Storage.ThreadLocal]] but is required for certain
+    * library integrations such as cats-effect IO or Monix.
+    * Turn this on by setting the System Property "kamon.context.crossThread" to "true".
+    */
+  class CrossThreadLocal extends Storage {
+    private val tls = new java.lang.ThreadLocal[Context]() {
+      override def initialValue(): Context = Context.Empty
+    }
+
+    override def current(): Context =
+      tls.get()
+
+    override def store(newContext: Context): Scope = {
+      val previousContext = tls.get()
+      tls.set(newContext)
+
+      new Scope {
+        override def context: Context = newContext
+        override def close(): Unit = tls.set(previousContext)
+      }
+    }
+  }
+
+  object CrossThreadLocal {
+    def apply(): Storage.CrossThreadLocal =
+      new Storage.CrossThreadLocal()
+  }
+
+  /**
     * Wrapper that implements an optimized ThreadLocal access pattern ideal for heavily used ThreadLocals. It is faster
     * to use a mutable holder object and always perform ThreadLocal.get() and never use ThreadLocal.set(), because the
     * value is more likely to be found in the ThreadLocalMap direct hash slot and avoid the slow path of
-    * ThreadLocalMap.getEntryAfterMiss().
+    * ThreadLocalMap.getEntryAfterMiss(). Closing of the returned Scope **MUST** be called in the same thread as
+    * store(..) was originally called.
     *
     * Credit to @trask from the FastThreadLocal in glowroot. One small change is that we don't use an kamon-defined
     * holder object as that would prevent class unloading.
@@ -104,6 +136,8 @@ object Storage {
     * different stack traces for every store/close operation pair. Do not use this for any reason other than debugging
     * Context propagation issues (like, dirty Threads) in a controlled environment.
     *
+    * Note: Similar to the default ThreadLocal storage, the scope must be closed in the same thread as where store(..)
+    * was called, otherwise you are potentially modifying the context of another thread.
     */
   class Debug extends Storage {
     import Debug._


### PR DESCRIPTION
This storage implements the "unoptimized" version of thread local storage which allows for the scope to be closed in another thread, as it re-resolves the thread local context in `close`

Rerunning the benchmark:

```
[info] # JMH version: 1.21
[info] # VM version: JDK 1.8.0_282, OpenJDK 64-Bit Server VM GraalVM CE 21.0.0.2, 25.282-b07-jvmci-21.0-b06
[info] # VM invoker: /usr/lib/jvm/java-8-graalvm/jre/bin/java
[info] # VM options: -XX:MaxInlineLevel=24 -XX:MaxInlineSize=270
[info] # Warmup: 3 iterations, 10 s each
[info] # Measurement: 5 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 2 threads, will synchronize iterations
[info] # Benchmark mode: Average time, time/op
[info] # Benchmark: kamon.bench.ThreadLocalStorageBenchmark.crossThreadLocal
[info] # Run progress: 0.00% complete, ETA 00:02:40
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: -XX:MaxInlineLevel=24 -XX:MaxInlineSize=270
[info] # Warmup Iteration   1: 13.610 ns/op
[info] # Warmup Iteration   2: 13.379 ns/op
[info] # Warmup Iteration   3: 14.535 ns/op
[info] Iteration   1: 14.325 ns/op
[info] Iteration   2: 14.308 ns/op
[info] Iteration   3: 14.341 ns/op
[info] Iteration   4: 14.323 ns/op
[info] Iteration   5: 14.383 ns/op
[info] Result "kamon.bench.ThreadLocalStorageBenchmark.crossThreadLocal":
[info]   14.336 ±(99.9%) 0.110 ns/op [Average]
[info]   (min, avg, max) = (14.308, 14.336, 14.383), stdev = 0.029
[info]   CI (99.9%): [14.226, 14.446] (assumes normal distribution)
[info] # JMH version: 1.21
[info] # VM version: JDK 1.8.0_282, OpenJDK 64-Bit Server VM GraalVM CE 21.0.0.2, 25.282-b07-jvmci-21.0-b06
[info] # VM invoker: /usr/lib/jvm/java-8-graalvm/jre/bin/java
[info] # VM options: -XX:MaxInlineLevel=24 -XX:MaxInlineSize=270
[info] # Warmup: 3 iterations, 10 s each
[info] # Measurement: 5 iterations, 10 s each
[info] # Timeout: 10 min per iteration
[info] # Threads: 2 threads, will synchronize iterations
[info] # Benchmark mode: Average time, time/op
[info] # Benchmark: kamon.bench.ThreadLocalStorageBenchmark.fastThreadLocal
[info] # Run progress: 50.00% complete, ETA 00:01:20
[info] # Fork: 1 of 1
[info] Picked up JAVA_TOOL_OPTIONS: -XX:MaxInlineLevel=24 -XX:MaxInlineSize=270
[info] # Warmup Iteration   1: 12.372 ns/op
[info] # Warmup Iteration   2: 12.327 ns/op
[info] # Warmup Iteration   3: 12.380 ns/op
[info] Iteration   1: 12.363 ns/op
[info] Iteration   2: 12.541 ns/op
[info] Iteration   3: 12.448 ns/op
[info] Iteration   4: 13.155 ns/op
[info] Iteration   5: 13.782 ns/op
[info] Result "kamon.bench.ThreadLocalStorageBenchmark.fastThreadLocal":
[info]   12.858 ±(99.9%) 2.323 ns/op [Average]
[info]   (min, avg, max) = (12.363, 12.858, 13.782), stdev = 0.603
[info]   CI (99.9%): [10.534, 15.181] (assumes normal distribution)
[info] # Run complete. Total time: 00:02:40
[info] Benchmark                                     Mode  Cnt   Score   Error  Units
[info] ThreadLocalStorageBenchmark.crossThreadLocal  avgt    5  14.336 ± 0.110  ns/op
[info] ThreadLocalStorageBenchmark.fastThreadLocal   avgt    5  12.858 ± 2.323  ns/op
```

TBH, I don't think the "gain" of the optimized threadlocal implementation is worth keeping (the large variability of the fastThreadLocal is especially interesting). But I'm biased as I primarily work with the Typelevel stack so I'd like to minimize the steps required to get it working with Kamon, especially when failing to do so will lead to horrible cross-thread context contamination