### PR TITLE
(status page) Add missing api key state

### DIFF
--- a/core/kamon-status-page/src/main/vue/package-lock.json
+++ b/core/kamon-status-page/src/main/vue/package-lock.json
@@ -9026,9 +9026,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {

--- a/core/kamon-status-page/src/main/vue/package.json
+++ b/core/kamon-status-page/src/main/vue/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "ts-option": "1.1.5",
-    "underscore": "1.9.1",
+    "underscore": "^1.9.1",
     "vue": "2.6.10",
     "vue-class-component": "7.0.2",
     "vue-property-decorator": "8.1.0",
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@fortawesome/fontawesome-free": "5.8.1",
-    "@types/underscore": "1.8.14",
+    "@types/underscore": "^1.8.14",
     "@vue/cli-plugin-typescript": "3.6.0",
     "@vue/cli-service": "3.6.0",
     "fstream": ">=1.0.12",
@@ -27,7 +27,7 @@
     "sass": "^1.32.0",
     "sass-loader": "^7.1.0",
     "tar": ">=2.2.2",
-    "typescript": "3.4.5",
+    "typescript": "3.9.7",
     "vue-cli-plugin-vuetify": "~2.1.0",
     "vue-template-compiler": "2.6.10",
     "vuetify-loader": "^1.7.0"

--- a/core/kamon-status-page/src/main/vue/src/components/ModuleList.vue
+++ b/core/kamon-status-page/src/main/vue/src/components/ModuleList.vue
@@ -21,6 +21,7 @@
         :key="reporter.name"
         :module="reporter"
         :is-missing-key="isMisconfiguredApmModule(reporter)"
+        @show:api-key="$emit('show:api-key')"
       />
       <div v-if="!hasApmModule" class="apm-suggestion">
         <a href="https://kamon.io/apm/?utm_source=kamon&utm_medium=status-page&utm_campaign=kamon-status" target="_blank">

--- a/core/kamon-status-page/src/main/vue/src/components/ModuleList.vue
+++ b/core/kamon-status-page/src/main/vue/src/components/ModuleList.vue
@@ -16,7 +16,12 @@
         </div>
       </template>
 
-      <module-status-card v-for="reporter in reporterModules" :key="reporter.name" :module="reporter" />
+      <module-status-card
+        v-for="reporter in reporterModules"
+        :key="reporter.name"
+        :module="reporter"
+        :is-missing-key="isMisconfiguredApmModule(reporter)"
+      />
       <div v-if="!hasApmModule" class="apm-suggestion">
         <a href="https://kamon.io/apm/?utm_source=kamon&utm_medium=status-page&utm_campaign=kamon-status" target="_blank">
           <module-status-card :isSuggestion="true" :module="apmModuleSuggestion" />
@@ -31,11 +36,17 @@
 </template>
 
 <script lang="ts">
+import { Option } from 'ts-option'
 import { Component, Prop, Vue } from 'vue-property-decorator'
+
 import {Module, ModuleKind} from '../api/StatusApi'
 import ModuleStatusCard from './ModuleStatusCard.vue'
 import StatusSection from './StatusSection.vue'
 
+const VALID_API_KEY_PATTERN = /^[a-zA-Z0-9]{26}$/
+const KNOWN_APM_CLASSES = [
+  'kamon.apm.KamonApm'
+]
 
 @Component({
   components: {
@@ -45,6 +56,8 @@ import StatusSection from './StatusSection.vue'
 })
 export default class ModuleList extends Vue {
   @Prop() private modules!: Module[]
+  @Prop({ required: true }) private config!: Option<any>
+
   private apmModuleSuggestion: Module = {
     name: 'Kamon APM Reporter',
     description: 'See your metrics and trace data for free with a Starter account.',
@@ -79,15 +92,29 @@ export default class ModuleList extends Vue {
   }
 
   get hasApmModule(): boolean {
-    const knownApmClasses = [
-      'kamon.apm.KamonApm'
-    ]
+    return this.modules.some(m => KNOWN_APM_CLASSES.includes(m.clazz))
+  }
 
-    return this.modules.some(m => knownApmClasses.includes(m.clazz))
+  get missingApmApiKey(): boolean {
+    if (this.config.isEmpty) {
+      return false
+    }
+
+    if (!this.hasApmModule) {
+      return false
+    }
+
+    const apiKey = this.config.get?.kamon?.apm?.['api-key']
+
+    return apiKey == null || !VALID_API_KEY_PATTERN.test(apiKey)
   }
 
   private isReporter(module: Module): boolean {
     return [ModuleKind.Combined, ModuleKind.Span, ModuleKind.Metric].includes(module.kind)
+  }
+
+  private isMisconfiguredApmModule(m: Module) {
+    return KNOWN_APM_CLASSES.includes(m.clazz) && this.missingApmApiKey
   }
 }
 </script>

--- a/core/kamon-status-page/src/main/vue/src/components/ModuleStatusCard.vue
+++ b/core/kamon-status-page/src/main/vue/src/components/ModuleStatusCard.vue
@@ -101,7 +101,7 @@ export default class ModuleStatusCard extends Vue {
   }
 
   public showApmApiKey() {
-    window.open('https://apm.kamon.io?envinfo=show')
+    this.$emit('show:api-key')
   }
 }
 </script>

--- a/core/kamon-status-page/src/main/vue/src/views/Overview.vue
+++ b/core/kamon-status-page/src/main/vue/src/views/Overview.vue
@@ -16,7 +16,7 @@
       </v-col>
 
       <v-col cols="12" class="js-reporters">
-        <module-list :modules="modules"/>
+        <module-list :config="config" :modules="modules"/>
       </v-col>
 
       <v-col cols="12" class="js-instrumentation">
@@ -105,6 +105,10 @@ export default class Overview extends Vue {
 
   get environment(): Option<Environment> {
     return this.settings.map(s => s.environment)
+  }
+
+  get config(): Option<any> {
+    return this.settings.map(s => s.config)
   }
 
   public mounted() {


### PR DESCRIPTION
Add a special state for Kamon APM reporter that guides the user in case
their API key is not configured or is invalid.

Update Typescript and underscore to allow for modern dev practices.

The link itself will change once we have the new onboarding. We could wait to merge this until then.