### PR TITLE
(status page) Fix scroll offset

### DIFF
--- a/core/kamon-status-page/src/main/vue/src/views/Overview.vue
+++ b/core/kamon-status-page/src/main/vue/src/views/Overview.vue
@@ -112,15 +112,15 @@ export default class Overview extends Vue {
   }
 
   public goToInstrumentation(): void {
-    this.$vuetify.goTo('.js-instrumentation')
+    this.$vuetify.goTo('.js-instrumentation', { offset: 80 })
   }
 
   public goToReporters(): void {
-    this.$vuetify.goTo('.js-reporters')
+    this.$vuetify.goTo('.js-reporters', { offset: 80 })
   }
 
   public goToMetrics(): void {
-    this.$vuetify.goTo('.js-metrics')
+    this.$vuetify.goTo('.js-metrics', { offset: 80 })
   }
 
   private refreshData(): void {


### PR DESCRIPTION
Adjust scroll offset when clicking on the headers to scroll to a location where the heading is visible, rather than just the content.