### PR TITLE
Added support for opentelemetry trace exporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -476,6 +476,7 @@ lazy val reporters = (project in file("reporters"))
     `kamon-influxdb`,
     `kamon-jaeger`,
     `kamon-newrelic`,
+    `kamon-opentelemetry`,
     `kamon-prometheus`,
     `kamon-statsd`,
     `kamon-zipkin`,
@@ -591,6 +592,16 @@ lazy val `kamon-newrelic` = (project in file("reporters/kamon-newrelic"))
     )
   ).dependsOn(`kamon-core`)
 
+lazy val `kamon-opentelemetry` = (project in file("reporters/kamon-opentelemetry"))
+  .disablePlugins(AssemblyPlugin)
+  .settings(
+    libraryDependencies ++= Seq(
+      "io.opentelemetry" % "opentelemetry-proto" % "0.17.1",
+      "io.grpc" % "grpc-netty" % "1.36.0",
+      scalatest % "test",
+      logbackClassic % "test"
+    )
+  ).dependsOn(`kamon-core`, `kamon-testkit` % "test")
 
 lazy val `kamon-prometheus` = (project in file("reporters/kamon-prometheus"))
   .disablePlugins(AssemblyPlugin)

--- a/reporters/kamon-opentelemetry/README.md
+++ b/reporters/kamon-opentelemetry/README.md
@@ -1,0 +1,10 @@
+# Kamon OpenTelemetry Exporter
+The exporter currently only provides a OpenTelemetry (OTLP) exporter for Kamon spans (metrics to be supported)
+
+The reporter relies on the [opentelemetry-proto](https://github.com/open-telemetry/opentelemetry-proto) library for the gRPC communication with an OpenTelemetry (OTLP) service.
+
+## Trace Exporter
+Converts internal finished Kamon spans to OTEL proto format and exports them the to configured endpoint.
+
+## Metrics Exporter
+To be implemented

--- a/reporters/kamon-opentelemetry/src/main/resources/reference.conf
+++ b/reporters/kamon-opentelemetry/src/main/resources/reference.conf
@@ -1,0 +1,43 @@
+# ======================================== #
+# kamon-otlp reference configuration       #
+# ======================================== #
+
+kamon.otel.trace {
+  # Hostname and port where the OTLP Server is running
+  host = "localhost"
+  port = 4317
+
+  # Decides whether to use HTTP or HTTPS when connecting to the OTel server
+  protocol = "http"
+
+  # default to support the ENV:s as described at
+  # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
+  endpoint = ${kamon.otel.trace.protocol}"://"${kamon.otel.trace.host}":"${kamon.otel.trace.port}
+  endpoint = ${?OTEL_EXPORTER_OTLP_ENDPOINT}
+  endpoint = ${?OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
+
+  # Enable or disable including tags from kamon.environment.tags as resource labels in the exported trace
+  # Any keys containing a hyphen (-) will be converted to a dot (.) as that is the standard.
+  # e.g. service-version becomes service.version
+  # reference: https://github.com/kamon-io/Kamon/blob/master/core/kamon-core/src/main/resources/reference.conf#L23
+  include-environment-tags = no
+
+  # Arbitrary key-value pairs that further identify the environment where this service instance is running.
+  # These are added as KeyValue labels to the Resource part of the exported traces
+  # Requires 'include-environment-tags' to be set to 'yes'
+  #
+  # kamon.environment.tags {
+  #   service-version = "x.x.x"
+  #   service-namespace = "ns"
+  #   service-instance.id = "xxx-yyy"
+  # }
+}
+
+kamon.modules {
+  otel-trace-reporter {
+    enabled = true
+    name = "OpenTelemetry Trace Reporter"
+    description = "Sends trace data to a OpenTelemetry server via gRPC"
+    factory = "kamon.otel.OpenTelemetryTraceReporter$Factory"
+  }
+}

--- a/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/OpenTelemetryTraceReporter.scala
+++ b/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/OpenTelemetryTraceReporter.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import com.typesafe.config.Config
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary
+import io.opentelemetry.proto.resource.v1.Resource
+import io.opentelemetry.proto.trace.v1.ResourceSpans
+import kamon.Kamon
+import kamon.module.{Module, ModuleFactory, SpanReporter}
+import kamon.trace.Span
+import kamon.otel.SpanConverter._
+import org.slf4j.LoggerFactory
+
+import java.util.Collections
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+object OpenTelemetryTraceReporter {
+  private val logger = LoggerFactory.getLogger(classOf[OpenTelemetryTraceReporter])
+  private val kamonVersion = Kamon.status().settings().version
+
+  class Factory extends ModuleFactory {
+    override def create(settings: ModuleFactory.Settings): Module = {
+      logger.info("Creating OpenTelemetry Trace Reporter")
+
+      val module = new OpenTelemetryTraceReporter(GrpcTraceService(_))(settings.executionContext)
+      module.reconfigure(settings.config)
+      module
+    }
+  }
+}
+
+import kamon.otel.OpenTelemetryTraceReporter._
+/**
+ * Converts internal finished Kamon spans to OpenTelemetry format and sends to a configured OpenTelemetry endpoint using gRPC.
+ */
+class OpenTelemetryTraceReporter(traceServiceFactory:Config=>TraceService)(implicit ec:ExecutionContext) extends SpanReporter {
+  private var traceService:Option[TraceService] = None
+  private var spanConverterFunc:Seq[Span.Finished]=>ResourceSpans = (_ => ResourceSpans.newBuilder().build())
+
+  override def reportSpans(spans: Seq[Span.Finished]): Unit = {
+    if(!spans.isEmpty) {
+      val resources = Collections.singletonList(spanConverterFunc(spans)) //all spans should belong to the same single resource
+      val exportTraceServiceRequest = ExportTraceServiceRequest.newBuilder()
+        .addAllResourceSpans(resources)
+        .build()
+
+      traceService.foreach (
+        _.export(exportTraceServiceRequest).onComplete {
+          case Success(_) => logger.debug("Successfully exported traces")
+
+          //TODO is there result for which a retry is relevant? Perhaps a glitch in the receiving service
+          //Keeping logs to debug as other exporters (e.g.Zipkin) won't log anything if it fails to export traces
+          case Failure(t) => logger.debug("Failed to export traces", t)
+        }
+      )
+    }
+  }
+
+  override def reconfigure(newConfig: Config): Unit = {
+    logger.info("Reconfigure OpenTelemetry Trace Reporter")
+
+    //pre-generate the function for converting Kamon span to proto span
+    val instrumentationLibrary:InstrumentationLibrary = InstrumentationLibrary.newBuilder().setName("kamon").setVersion(kamonVersion).build()
+    val resource:Resource = buildResource(newConfig.getBoolean("kamon.otel.trace.include-environment-tags"))
+    this.spanConverterFunc = SpanConverter.toProtoResourceSpan(resource, instrumentationLibrary)
+
+    this.traceService = Option(traceServiceFactory.apply(newConfig))
+  }
+
+  override def stop(): Unit = {
+    logger.info("Stopping OpenTelemetry Trace Reporter")
+    this.traceService.foreach(_.close())
+    this.traceService = None
+  }
+
+  /**
+   * Builds the resource information added as resource labels to the exported traces
+   * @param includeEnvTags
+   * @return
+   */
+  private def buildResource(includeEnvTags:Boolean):Resource = {
+    val env = Kamon.environment
+    val builder = Resource.newBuilder()
+      .addAttributes(stringKeyValue("service.name", env.service))
+      .addAttributes(stringKeyValue("telemetry.sdk.name", "kamon"))
+      .addAttributes(stringKeyValue("telemetry.sdk.language", "scala"))
+      .addAttributes(stringKeyValue("telemetry.sdk.version", kamonVersion))
+
+    //add all kamon.environment.tags as KeyValues to the Resource object
+    if(includeEnvTags) {
+      env.tags.iterator().map(toProtoKeyValue).foreach(builder.addAttributes)
+    }
+
+    builder.build()
+  }
+}

--- a/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/SpanConverter.scala
+++ b/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/SpanConverter.scala
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import com.google.protobuf.ByteString
+import io.opentelemetry.proto.common.v1.{AnyValue, InstrumentationLibrary, KeyValue}
+import io.opentelemetry.proto.resource.v1.Resource
+import io.opentelemetry.proto.trace.v1.{InstrumentationLibrarySpans, ResourceSpans, Status, Span => ProtoSpan}
+import kamon.tag.{Lookups, Tag}
+import kamon.tag.Tag.unwrapValue
+import kamon.trace.Span.{Kind, TagKeys}
+import kamon.trace.{Identifier, Span}
+import org.slf4j.LoggerFactory
+
+import java.time.Instant
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+
+/**
+ * Converts Kamon spans to OpenTelemetry proto Spans
+ */
+private[otel] object SpanConverter {
+  private val logger = LoggerFactory.getLogger(SpanConverter.getClass)
+
+  /** 8-bytes worth of zeroes used to pad 8-byte TraceId's  */
+  private val eightBytePad = Array.fill[Byte](8)(0)
+
+  /** Creates a AnyValue type KeyValue */
+  private[otel] def anyKeyValue(key:String, value:AnyValue):KeyValue = KeyValue.newBuilder().setKey(key.replaceAll("-", ".")).setValue(value).build
+  /** Creates a String type KeyValue */
+  private[otel] def stringKeyValue(key:String, value:String):KeyValue = anyKeyValue(key, AnyValue.newBuilder().setStringValue(value).build())
+  /** Creates a Boolean type KeyValue */
+  private[otel] def booleanKeyValue(key:String, value:Boolean):KeyValue = anyKeyValue(key, AnyValue.newBuilder().setBoolValue(value).build())
+  /** Creates a Long type KeyValue */
+  private[otel] def longKeyValue(key:String, value:Long):KeyValue = anyKeyValue(key,AnyValue.newBuilder().setIntValue(value).build())
+
+  /**
+   * Converts a sequence of Kamon spans to a proto ''ResourceSpans''
+   * @param resource resource information for this instance of the service. Added as resource labels
+   * @param instrumentationLibrary instrumentation library information to add to the exported spans
+   * @param spans The spans to export
+   * @return
+   */
+  private[otel] def toProtoResourceSpan(resource:Resource, instrumentationLibrary:InstrumentationLibrary)(spans:Seq[Span.Finished]):ResourceSpans = {
+    import collection.JavaConverters._
+
+    //it is assumed all spans belong to the same instrumentation library
+    val instrumentationLibrarySpans = InstrumentationLibrarySpans.newBuilder()
+      .setInstrumentationLibrary(instrumentationLibrary)
+      .addAllSpans(spans.map(toProtoSpan).asJava)
+      .build()
+
+    ResourceSpans.newBuilder()
+      .setResource(resource)
+      .addAllInstrumentationLibrarySpans(Collections.singletonList(instrumentationLibrarySpans))
+      .build()
+  }
+
+  /**
+   * Converts a Kamon span to a proto span
+   * @param span the span to convert
+   * @return
+   */
+  private[otel] def toProtoSpan(span:Span.Finished):ProtoSpan = {
+    //converts Kamon span tags to proto KeyValue attributes
+    val attributes:List[KeyValue] = span.tags.iterator.map(toProtoKeyValue).toList
+
+    //converts Kamon span links to proto links
+    val links:Seq[ProtoSpan.Link] = span.links.map(toProtoLink)
+
+    import collection.JavaConverters._
+    val builder = ProtoSpan.newBuilder()
+      .setTraceId(traceIdToByteString(span.trace.id))
+      .setSpanId(spanIdToByteString(span.id))
+      .setName(span.operationName)
+      .setKind(toProtoKind(span.kind))
+      .setStartTimeUnixNano(toEpocNano(span.from))
+      .setEndTimeUnixNano(toEpocNano(span.to))
+      .setStatus(getStatus(span))
+      .addAllAttributes(attributes.asJava)
+      .addAllLinks(links.asJava)
+
+    //TODO add set traceState once we have something to set. Need w3c context
+    //It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
+    //See also https://github.com/w3c/distributed-tracing for more details about this field.
+    //builder.setTraceState()
+
+    //add optional parent
+    val parentId = span.parentId
+    if(!parentId.isEmpty) builder.setParentSpanId(spanIdToByteString(parentId))
+
+    builder.build()
+  }
+
+  /**
+   * Converts the instant to EPOC nanos
+   * @param instant
+   * @return
+   */
+  private[otel] def toEpocNano(instant:Instant):Long = TimeUnit.NANOSECONDS.convert(instant.getEpochSecond, TimeUnit.SECONDS) + instant.getNano
+
+  /**
+   * Creates a proto ''Status'' of the Kamon span status
+   * @param span
+   * @return
+   */
+  private[otel] def getStatus(span:Span.Finished):Status = {
+    //according to the spec the deprecated code needs to be set for backwards compatibility reasons
+    //https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+    val (status, deprecatedStatus) = if(span.hasError) (Status.StatusCode.STATUS_CODE_ERROR_VALUE, Status.DeprecatedStatusCode.DEPRECATED_STATUS_CODE_UNKNOWN_ERROR_VALUE) else (Status.StatusCode.STATUS_CODE_OK_VALUE, Status.DeprecatedStatusCode.DEPRECATED_STATUS_CODE_OK_VALUE)
+    val builder = Status.newBuilder()
+      .setCodeValue(status)
+      .setDeprecatedCodeValue(deprecatedStatus)
+
+    //if there is an error message in the span we add it as status message
+    //spec states: "A developer-facing human readable error message."
+    //https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto
+    span.tags.get(Lookups.option(TagKeys.ErrorMessage)).foreach(builder.setMessage)
+
+    builder.build()
+  }
+
+  /**
+   * Converts a Kamon span kind to a proto span kind
+   * @param kind
+   * @return
+   */
+  private[otel] def toProtoKind(kind:Kind): ProtoSpan.SpanKind = {
+    kind match {
+      case Kind.Client => ProtoSpan.SpanKind.SPAN_KIND_CLIENT
+      case Kind.Consumer => ProtoSpan.SpanKind.SPAN_KIND_CONSUMER
+      case Kind.Internal => ProtoSpan.SpanKind.SPAN_KIND_INTERNAL
+      case Kind.Producer => ProtoSpan.SpanKind.SPAN_KIND_PRODUCER
+      case Kind.Server => ProtoSpan.SpanKind.SPAN_KIND_SERVER
+      case Kind.Unknown => ProtoSpan.SpanKind.SPAN_KIND_UNSPECIFIED
+      case _ => ProtoSpan.SpanKind.UNRECOGNIZED
+    }
+  }
+
+  /**
+   * Converts a Kamon tag to a proto KeyValue
+   * @param tag
+   * @return
+   */
+  private[otel] def toProtoKeyValue(tag: Tag):KeyValue = {
+    tag match {
+      case t: Tag.String  => stringKeyValue(tag.key, t.value)
+      case t: Tag.Boolean => booleanKeyValue(tag.key, t.value)
+      case t: Tag.Long    => longKeyValue(tag.key, t.value)
+      case _ => { //this cannot happen unless new Tag types are added to Kamon core, the code is more of a safeguard for "just in case"
+        logger.warn(s"Failed to map Tag [$tag] to a KeyValue type, will attempt to convert to a string")
+        stringKeyValue(tag.key, unwrapValue(tag).toString) //last resort trying to create a string of this unknown Tag type
+      }
+    }
+  }
+
+  /**
+   * Converts a Kamon span link to a proto span link
+   * @param link
+   * @return
+   */
+  private[otel] def toProtoLink(link:Span.Link):ProtoSpan.Link = {
+    ProtoSpan.Link.newBuilder()
+      .setTraceId(traceIdToByteString(link.trace.id))
+      .setSpanId(spanIdToByteString(link.spanId))
+      .build()
+  }
+
+  /**
+   * Converts the TraceID to a proto ByteString.
+   * Id the identifier is 8-bytes (single) it will be padded to 16-bytes as this is required in OTLP
+   * @param id
+   * @return
+   */
+  private[otel] def traceIdToByteString(id:Identifier):ByteString = toByteString(id, true)
+
+  /**
+   * Converts the SpanID to a proto ByteString
+   * @param id
+   * @return
+   */
+  private[otel] def spanIdToByteString(id:Identifier):ByteString = toByteString(id, false)
+
+  /**
+   * Converts a Kamon identifier to a proto ByteString
+   * @param id The identifier to convert
+   * @param padTo16bytes If the identifier should be padded in case it is 8-bytes (used for traceid's)
+   * @return
+   */
+  private[otel] def toByteString(id:Identifier, padTo16bytes:Boolean):ByteString = {
+    val bytes = id.bytes
+    //OTLP requires 16-bytes trace identifiers, if we have 8-byte traceid it needs to padded with zeroes
+    if(padTo16bytes && id.bytes.length == 8)
+      ByteString.copyFrom(eightBytePad++bytes)
+    else
+      ByteString.copyFrom(bytes)
+  }
+}

--- a/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/TraceService.scala
+++ b/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/TraceService.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import com.google.common.util.concurrent.{FutureCallback, Futures}
+import com.typesafe.config.Config
+import io.grpc.{ManagedChannel, ManagedChannelBuilder}
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc.TraceServiceFutureStub
+import io.opentelemetry.proto.collector.trace.v1.{ExportTraceServiceRequest, ExportTraceServiceResponse, TraceServiceGrpc}
+import org.slf4j.LoggerFactory
+
+import java.io.Closeable
+import java.net.URL
+import java.util.concurrent.{Executors, ThreadFactory, TimeUnit}
+import scala.concurrent.{Future, Promise}
+
+/**
+ * Service for exporting OpenTelemetry traces
+ */
+private[otel] trait TraceService extends Closeable {
+  def export(request:ExportTraceServiceRequest):Future[ExportTraceServiceResponse]
+}
+
+/**
+ * Companion object to [[GrpcTraceService]]
+ */
+private[otel] object GrpcTraceService {
+  private val logger = LoggerFactory.getLogger(classOf[GrpcTraceService])
+  private val executor = Executors.newSingleThreadExecutor(new ThreadFactory {
+    override def newThread(r: Runnable): Thread = new Thread(r, "OpenTelemetryTraceReporterRemote")
+  })
+
+  /**
+   * Builds the gRPC trace exporter using the provided configuration.
+   * @param config
+   * @return
+   */
+  def apply(config: Config): GrpcTraceService = {
+    val otelExporterConfig = config.getConfig("kamon.otel.trace")
+    val protocol = otelExporterConfig.getString("protocol")
+    val endpoint = otelExporterConfig.getString("endpoint")
+    val url = new URL(endpoint)
+
+    //inspiration from https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
+
+    logger.info(s"Configured endpoint for OpenTelemetry trace reporting [${url.getHost}:${url.getPort}]")
+    //TODO : possibly add support for trustedCertificates in case TLS is to be enabled
+    val builder = ManagedChannelBuilder.forAddress(url.getHost, url.getPort)
+    if (protocol.equals("https"))
+      builder.useTransportSecurity()
+    else
+      builder.usePlaintext()
+
+    val channel = builder.build()
+    new GrpcTraceService(
+      channel,
+      TraceServiceGrpc.newFutureStub(channel)
+    )
+  }
+}
+
+import kamon.otel.GrpcTraceService._
+/**
+ * Manages the remote communication over gRPC to the OpenTelemetry service.
+ */
+private[otel] class GrpcTraceService(channel:ManagedChannel, traceService:TraceServiceFutureStub) extends TraceService {
+
+  /**
+   * Exports the trace data asynchronously.
+   * @param request The trace data to export
+   * @return
+   */
+  override def export(request: ExportTraceServiceRequest): Future[ExportTraceServiceResponse] = {
+    val promise = Promise[ExportTraceServiceResponse]()
+    Futures.addCallback(traceService.export(request), exportCallback(promise), executor)
+    promise.future
+  }
+
+  /**
+   * Closes the underlying gRPC channel.
+   */
+  override def close(): Unit = {
+    channel.shutdown()
+    channel.awaitTermination(5, TimeUnit.SECONDS)
+  }
+
+  /**
+   * Wrapper from Java Future to Scala counterpart.
+   * When the Java future completes it completes the provided ''Promise''
+   * @param promise The Promise to complete
+   * @return
+   */
+  private def exportCallback(promise:Promise[ExportTraceServiceResponse]):FutureCallback[ExportTraceServiceResponse] =
+    new FutureCallback[ExportTraceServiceResponse]() {
+      override def onSuccess(result: ExportTraceServiceResponse): Unit = promise.success(result)
+      override def onFailure(t: Throwable): Unit = promise.failure(t)
+    }
+
+}

--- a/reporters/kamon-opentelemetry/src/test/resources/application.conf
+++ b/reporters/kamon-opentelemetry/src/test/resources/application.conf
@@ -1,0 +1,22 @@
+kamon {
+  #force sampling (1 = 100%), normally nothing one sets in the config but used for this demo purpose
+  #setting is from kamon
+  trace.random-sampler.probability = 1
+
+  #configure the OTel exporter
+  otel.trace {
+    include-environment-tags = yes
+  }
+
+  environment {
+    service = "kamon-test-application"
+
+    # These will be added as Resource labels in the trace export
+    tags {
+      service-version = "x.x.x"
+      service-instance-id = "GERF43253FV"
+      env = "kamon-devint"
+    }
+
+  }
+}

--- a/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/CustomMatchers.scala
+++ b/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/CustomMatchers.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import com.google.protobuf.ByteString
+import io.opentelemetry.proto.common.v1.KeyValue
+import kamon.tag.TagSet
+import kamon.trace.Identifier.Factory
+import kamon.trace.Span.Kind
+import kamon.trace.{Identifier, Span, Trace}
+import kamon.trace.Trace.SamplingDecision
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import java.time.Instant
+
+object CustomMatchers {
+  val spanIDFactory = Factory.EightBytesIdentifier
+  val traceIDFactory = Factory.SixteenBytesIdentifier
+
+  /**
+   * Converts the provided byte array to a hex string
+   * @param buf
+   * @return
+   */
+  def asHex(buf: Array[Byte]): String = buf.map("%02X" format _).mkString
+  def now():Long = System.currentTimeMillis()
+  def finishedSpan():Span.Finished = {
+    val tagSet = TagSet.builder()
+      .add("string.tag", "xyz")
+      .add("boolean.tag", true)
+      .add("long.tag", 69)
+      .build()
+    Span.Finished(
+      spanIDFactory.generate(),
+      Trace(traceIDFactory.generate(), SamplingDecision.Sample),
+      Identifier.Empty,
+      "TestOperation",
+      false,
+      false,
+      Instant.ofEpochMilli(now()-500),
+      Instant.now(),
+      Kind.Server,
+      Span.Position.Unknown,
+      tagSet,
+      TagSet.Empty,
+      Nil,
+      Nil
+    )
+  }
+
+  trait ByteStringMatchers {
+    def equal(identifier: Identifier):Matcher[ByteString] = new Matcher[ByteString] {
+      def apply(left: ByteString) = {
+        MatchResult(
+          left.toByteArray.sameElements(identifier.bytes),
+          s"The identifiers don't match [${asHex(left.toByteArray)}] != [${identifier.string}]",
+          "The identifiers match"
+        )
+      }
+    }
+    def be8Bytes:Matcher[ByteString] = beOfLength(8)
+    def be16Bytes:Matcher[ByteString] = beOfLength(16)
+    private def beOfLength(expectedLength:Int):Matcher[ByteString] = new Matcher[ByteString] {
+      def apply(left: ByteString) = {
+        MatchResult(
+          left.toByteArray.size == expectedLength,
+          s"The identifiers did not have expected length [${left.toByteArray.length}] != [$expectedLength]",
+          "The identifier is of correct length"
+        )
+      }
+    }
+  }
+
+  trait KeyValueMatchers {
+    import java.util.{List => JList}
+    import collection.JavaConverters._
+
+    def containsBooleanKV(key:String, expectedValue:Boolean):Matcher[JList[KeyValue]] = new Matcher[JList[KeyValue]] {
+      def apply(left: JList[KeyValue]) = {
+        left.asScala.find(_.getKey.equals(key))
+          .map(_.getValue.getBoolValue)
+          .map(value => compare(key, expectedValue, value))
+          .getOrElse(noSuchKey(key))
+      }
+    }
+
+    def containsLongKV(key:String, expectedValue:Long):Matcher[JList[KeyValue]] = new Matcher[JList[KeyValue]] {
+      def apply(left: JList[KeyValue]) = {
+        left.asScala.find(_.getKey.equals(key))
+          .map(_.getValue.getIntValue)
+          .map(value => compare(key, expectedValue, value))
+          .getOrElse(noSuchKey(key))
+      }
+    }
+
+    def containStringKV(key:String, expectedValue:String):Matcher[JList[KeyValue]] = new Matcher[JList[KeyValue]] {
+      def apply(left: JList[KeyValue]) = {
+        left.asScala.find(_.getKey.equals(key))
+          .map(_.getValue.getStringValue)
+          .map(value => compare(key, expectedValue, value))
+          .getOrElse(noSuchKey(key))
+      }
+    }
+
+    private def compare(key:String, expected:Any, actual:Any) = MatchResult(
+      actual.equals(expected),
+      s"The KeyValue [$key] did not have expected value [$expected] != [$actual]",
+      "The identifier is of correct value"
+    )
+
+    private def noSuchKey(key:String) = MatchResult(
+      false,
+      s"No such Key [$key] found",
+      "..."
+    )
+  }
+}

--- a/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/OpenTelemetryTraceReporterSpec.scala
+++ b/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/OpenTelemetryTraceReporterSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import com.typesafe.config.{Config, ConfigFactory}
+import io.opentelemetry.proto.collector.trace.v1.{ExportTraceServiceRequest, ExportTraceServiceResponse}
+import kamon.Kamon
+import kamon.module.ModuleFactory
+import kamon.otel.CustomMatchers.{ByteStringMatchers, KeyValueMatchers, finishedSpan}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+ * Tests for [[OpenTelemetryTraceReporter]]
+ */
+class OpenTelemetryTraceReporterSpec extends WordSpec with Matchers with OptionValues with ByteStringMatchers with KeyValueMatchers {
+
+  private def openTelemetryTraceReporter():(OpenTelemetryTraceReporter, MockTraceService) = {
+    val traceService = new MockTraceService()
+    val reporter = new OpenTelemetryTraceReporter(_ => traceService)(ExecutionContext.global)
+    reporter.reconfigure(config)
+    (reporter, traceService)
+  }
+
+  private val config = ConfigFactory.defaultApplication().withFallback(ConfigFactory.defaultReference()).resolve()
+  "reporting spans" should {
+    "do nothing in case list of spans is empty" in {
+      val (reporter, _) = openTelemetryTraceReporter()
+      reporter.reportSpans(Nil)
+    }
+
+    "convert spans and export them using the TraceService" in {
+      val (reporter, traceService) = openTelemetryTraceReporter()
+      val span = finishedSpan()
+      reporter.reportSpans(Seq(span))
+      traceService.exportTraceServiceRequest.value.getResourceSpansCount should be(1)
+      val resourceSpans = traceService.exportTraceServiceRequest.value.getResourceSpansList.get(0)
+      val kamonVersion = Kamon.status().settings().version
+      resourceSpans.getResource.getAttributesList should containStringKV("service.name", "kamon-test-application")
+      resourceSpans.getResource.getAttributesList should containStringKV("telemetry.sdk.name", "kamon")
+      resourceSpans.getResource.getAttributesList should containStringKV("telemetry.sdk.language", "scala")
+      resourceSpans.getResource.getAttributesList should containStringKV("telemetry.sdk.version", kamonVersion)
+
+      //all kamon spans should belong to the same instance of InstrumentationLibrarySpans
+      val instSpans = resourceSpans.getInstrumentationLibrarySpansList
+      instSpans.size() should be(1)
+
+      //assert instrumentation labels
+      val instrumentationLibrarySpans = instSpans.get(0)
+      instrumentationLibrarySpans.getInstrumentationLibrary.getName should be("kamon")
+      instrumentationLibrarySpans.getInstrumentationLibrary.getVersion should be(kamonVersion)
+
+      //there should be a single span reported
+      val spans = instSpans.get(0).getSpansList
+      spans.size() should be(1)
+
+      //not doing deeper comparison of the span conversion as these are tested in the SpanConverterSpec
+    }
+  }
+
+  "stopping reporter should close underlying TraceService" in {
+    val (reporter, traceService) = openTelemetryTraceReporter()
+    reporter.stop()
+    traceService.hasBeenClosed should be(true)
+    reporter.stop() //stopping a second time should not matter
+  }
+
+  "building instance with the factory should work" in {
+    val reporter = new OpenTelemetryTraceReporter.Factory().create(ModuleFactory.Settings(config, ExecutionContext.global))
+    reporter.stop()
+  }
+
+  private class MockTraceService extends TraceService{
+    var exportTraceServiceRequest:Option[ExportTraceServiceRequest] = None
+    var hasBeenClosed = false
+    override def export(request: ExportTraceServiceRequest): Future[ExportTraceServiceResponse] = {
+      exportTraceServiceRequest = Option(request)
+      Future.successful(ExportTraceServiceResponse.getDefaultInstance)
+    }
+    override def close(): Unit = hasBeenClosed = true
+  }
+}

--- a/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/SpanConverterSpec.scala
+++ b/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/SpanConverterSpec.scala
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary
+import io.opentelemetry.proto.resource.v1.Resource
+import io.opentelemetry.proto.trace.v1.{Span => ProtoSpan}
+import kamon.tag.{Tag, TagSet}
+import kamon.trace.Span.{Kind, Link}
+import kamon.trace.Trace.SamplingDecision
+import kamon.trace.{Identifier, Span, Trace}
+import kamon.otel.CustomMatchers.{ByteStringMatchers, KeyValueMatchers, _}
+import kamon.otel.SpanConverter._
+import org.scalatest.{Matchers, WordSpec}
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for [[SpanConverter]]
+ */
+class SpanConverterSpec extends WordSpec with Matchers with ByteStringMatchers with KeyValueMatchers {
+  private val resource =  Resource.newBuilder()
+    .addAttributes(stringKeyValue("service.name", "TestService"))
+    .addAttributes(stringKeyValue("telemetry.sdk.name", "kamon"))
+    .addAttributes(stringKeyValue("telemetry.sdk.language", "scala"))
+    .addAttributes(stringKeyValue("telemetry.sdk.version", "0.0.0"))
+    .build()
+  private val instrumentationLibrary = InstrumentationLibrary.newBuilder().setName("kamon").setVersion("0.0.0").build()
+
+  "The span converter" when {
+    "using value creator functions" should {
+      "create boolean/false value" in {
+        val v = booleanKeyValue("key.bool.false", false)
+        v.getKey shouldBe "key.bool.false"
+        v.getValue.getBoolValue shouldBe false
+      }
+      "create boolean/true value" in {
+        val v = booleanKeyValue("key.bool.true", true)
+        v.getKey shouldBe "key.bool.true"
+        v.getValue.getBoolValue shouldBe true
+      }
+      "create long value" in {
+        val v = longKeyValue("key.long", 69)
+        v.getKey shouldBe "key.long"
+        v.getValue.getIntValue shouldBe 69
+      }
+      "create string value" in {
+        val v = stringKeyValue("key.string", "hello world!")
+        v.getKey shouldBe "key.string"
+        v.getValue.getStringValue shouldBe "hello world!"
+      }
+    }
+
+    "converting Kamon span kind to proto counterpart" should {
+      "map Kamon.Client to ProtoSpan.SPAN_KIND_CLIENT" in {
+        toProtoKind(Kind.Client) shouldBe ProtoSpan.SpanKind.SPAN_KIND_CLIENT
+      }
+      "map Kamon.Consumer to ProtoSpan.SPAN_KIND_CONSUMER" in {
+        toProtoKind(Kind.Consumer) shouldBe ProtoSpan.SpanKind.SPAN_KIND_CONSUMER
+      }
+      "map Kamon.Internal to ProtoSpan.SPAN_KIND_INTERNAL" in {
+        toProtoKind(Kind.Internal) shouldBe ProtoSpan.SpanKind.SPAN_KIND_INTERNAL
+      }
+      "map Kamon.Producer to ProtoSpan.SPAN_KIND_PRODUCER" in {
+        toProtoKind(Kind.Producer) shouldBe ProtoSpan.SpanKind.SPAN_KIND_PRODUCER
+      }
+      "map Kamon.Server to ProtoSpan.SPAN_KIND_SERVER" in {
+        toProtoKind(Kind.Server) shouldBe ProtoSpan.SpanKind.SPAN_KIND_SERVER
+      }
+      "map Kamon.Unknown to ProtoSpan.SPAN_KIND_UNSPECIFIED" in {
+        toProtoKind(Kind.Unknown) shouldBe ProtoSpan.SpanKind.SPAN_KIND_UNSPECIFIED
+      }
+      "map undefined value to ProtoSpan.UNRECOGNIZED" in {
+        toProtoKind(null) shouldBe ProtoSpan.SpanKind.UNRECOGNIZED
+      }
+    }
+  }
+
+  "should convert a Kamon link to the proto counterpart" in {
+    val spanId = spanIDFactory.generate()
+    val traceId = traceIDFactory.generate()
+    val trace = Trace(traceId, SamplingDecision.Sample)
+    val link = Span.Link(Link.Kind.FollowsFrom, trace, spanId)
+    val protoLink = toProtoLink(link)
+    protoLink.getTraceId shouldEqual toByteString(traceId, true)
+    protoLink.getSpanId shouldEqual toByteString(spanId, false)
+  }
+
+  "converting a Kamon identifier to a proto bytestring" should {
+    def padded(id:Identifier):Array[Byte] = Array.fill[Byte](8)(0)++id.bytes
+    "return a 16 byte array for a 16 byte identifier, padding enabled" in {
+      val id = traceIDFactory.generate()
+      toByteString(id, true) should be16Bytes
+      toByteString(id, true) should equal(id)
+    }
+    "return a 16 byte array for a 16 byte identifier, padding disabled" in {
+      val id = traceIDFactory.generate()
+      toByteString(id, false) should be16Bytes
+      toByteString(id, false) should equal(id)
+    }
+    "return a 16 byte array for a 8 byte identifier, padding enabled" in {
+      val id = spanIDFactory.generate()
+      toByteString(id, true) should be16Bytes
+      toByteString(id, true).toByteArray shouldBe padded(id)
+    }
+    "return a 8 byte array for a 8 byte identifier, padding disabled" in {
+      val id = spanIDFactory.generate()
+      toByteString(id, false) should be8Bytes
+      toByteString(id, false) should equal(id)
+    }
+    "return a 16 byte array for a 16 byte identifier, using traceIdToByteString" in {
+      val id = traceIDFactory.generate()
+      traceIdToByteString(id) should be16Bytes
+      traceIdToByteString(id) should equal(id)
+    }
+    "return a 16 byte array for a 8 byte identifier, using traceIdToByteString" in {
+      val id = spanIDFactory.generate()
+      traceIdToByteString(id) should be16Bytes
+      traceIdToByteString(id).toByteArray shouldBe padded(id)
+    }
+    "return a 8 byte array for a 8 byte identifier, using spanIdToByteString" in {
+      val id = spanIDFactory.generate()
+      spanIdToByteString(id) should be8Bytes
+      spanIdToByteString(id) should equal(id)
+    }
+  }
+
+  "should convert an Instant into nanos since EPOC" in {
+    val now = System.currentTimeMillis()
+    toEpocNano(Instant.ofEpochMilli(now)) shouldBe TimeUnit.NANOSECONDS.convert(now, TimeUnit.MILLISECONDS)
+    toEpocNano(Instant.ofEpochMilli(100)) shouldBe 100*1000000
+  }
+
+  "converting a Kamon tag to a proto KeyValue" should {
+    "convert a string tag to a KeyValue of string type" in {
+      val kv = toProtoKeyValue(TagSet.builder().add("key", "value").build().iterator().next())
+      kv.getKey should be("key")
+      kv.getValue.getStringValue should be("value")
+    }
+    "convert a long tag to a KeyValue of long type" in {
+      val kv = toProtoKeyValue(TagSet.builder().add("key", 69).build().iterator().next())
+      kv.getKey should be("key")
+      kv.getValue.getIntValue should be(69)
+    }
+    "convert a boolean tag to a KeyValue of boolean type" in {
+      val kv = toProtoKeyValue(TagSet.builder().add("key", true).build().iterator().next())
+      kv.getKey should be("key")
+      kv.getValue.getBoolValue should be(true)
+    }
+  }
+
+  "converting a Kamon to proto span" should {
+    "result in a valid span for a successful kamon span" in {
+      val kamonSpan = finishedSpan()
+      val protoSpan = toProtoSpan(kamonSpan)
+      compareSpans(kamonSpan, protoSpan)
+    }
+  }
+
+  "converting a list of Kamon spans" should {
+    "result in a valid ResourceSpans" in {
+      val kamonSpan = finishedSpan()
+      //assert resource labels
+      val resourceSpans = toProtoResourceSpan(resource, instrumentationLibrary)(Seq(kamonSpan))
+      resourceSpans.getResource.getAttributesList should containStringKV("service.name", "TestService")
+      resourceSpans.getResource.getAttributesList should containStringKV("telemetry.sdk.name", "kamon")
+      resourceSpans.getResource.getAttributesList should containStringKV("telemetry.sdk.language", "scala")
+      resourceSpans.getResource.getAttributesList should containStringKV("telemetry.sdk.version", "0.0.0")
+
+      //all kamon spans should belong to the same instance of InstrumentationLibrarySpans
+      val instSpans = resourceSpans.getInstrumentationLibrarySpansList
+      instSpans.size() should be(1)
+
+      //assert instrumentation labels
+      val instrumentationLibrarySpans = instSpans.get(0)
+      instrumentationLibrarySpans.getInstrumentationLibrary.getName should be("kamon")
+      instrumentationLibrarySpans.getInstrumentationLibrary.getVersion should be("0.0.0")
+
+      //there should be a single span reported
+      val spans = instSpans.get(0).getSpansList
+      spans.size() should be(1)
+
+      //assert span contents
+      compareSpans(kamonSpan, spans.get(0))
+    }
+  }
+
+  def compareSpans(expected:Span.Finished, actual:ProtoSpan) = {
+    actual.getTraceId should equal(expected.trace.id)
+    actual.getSpanId should equal(expected.id)
+
+    val keyValues = actual.getAttributesList
+    expected.tags.all().foreach{
+      case t: Tag.String  => keyValues should containStringKV(t.key, t.value)
+      case t: Tag.Boolean =>  keyValues should containsBooleanKV(t.key, t.value)
+      case t: Tag.Long    =>  keyValues should containsLongKV(t.key, t.value)
+    }
+  }
+}

--- a/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/TraceServiceSpec.scala
+++ b/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/TraceServiceSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kamon.otel
+
+import com.typesafe.config.ConfigFactory
+import io.grpc.StatusRuntimeException
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.proto.common.v1.InstrumentationLibrary
+import io.opentelemetry.proto.resource.v1.Resource
+import kamon.otel.CustomMatchers._
+import kamon.otel.SpanConverter.stringKeyValue
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{Matchers, WordSpec}
+
+import java.util.Collections
+
+/**
+ * Tests for the [[TraceService]]
+ */
+class TraceServiceSpec extends WordSpec with Matchers with ScalaFutures {
+  private implicit val defaultPatience = PatienceConfig(timeout =  Span(2, Seconds), interval = Span(15, Millis))
+
+  private val resource =  Resource.newBuilder()
+    .addAttributes(stringKeyValue("service.name", "TestService"))
+    .addAttributes(stringKeyValue("telemetry.sdk.name", "kamon"))
+    .addAttributes(stringKeyValue("telemetry.sdk.language", "scala"))
+    .addAttributes(stringKeyValue("telemetry.sdk.version", "0.0.0"))
+    .build()
+  private val instrumentationLibrary = InstrumentationLibrary.newBuilder().setName("kamon").setVersion("0.0.0").build()
+  private val config = ConfigFactory.defaultApplication().withFallback(ConfigFactory.defaultReference()).resolve()
+
+  "exporting traces" should {
+    "fail in case the remote service is not operable" in {
+      val traceService = GrpcTraceService(config)
+
+      //the actual data does not really matter as this will fail due to connection issues
+      val resources = SpanConverter.toProtoResourceSpan(resource, instrumentationLibrary)(Seq(finishedSpan()))
+      val export = ExportTraceServiceRequest.newBuilder()
+        .addAllResourceSpans(Collections.singletonList(resources))
+        .build()
+      val f = traceService.export(export)
+      whenReady(f.failed) { e =>
+        e shouldBe a [StatusRuntimeException]
+      }
+    }
+  }
+
+  "closing service should execute without errors" in {
+    GrpcTraceService(config).close()
+  }
+}


### PR DESCRIPTION
# Overview
This PR adds an exporter for exporting traces/spans according to [OpenTelemetry Protocol (OTLP)](https://github.com/open-telemetry/opentelemetry-proto) as requested in #973.
The code has been tested against an instance of the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)

# What is not supported from the OTEL spec
* metrics (should be done at some point as a separate exporter in the same sbt sub-module)
* logs (spec still in draft and probably not for Kamon anyways)

# What is not implemented in this first draft
Some things were left out for sake of getting something out there.

## Support for custom trust store for managing TLS
The exporter supports HTTP (default) and HTTPS but there is no way to add custom trust store or keychains

## No labels/tags/keyvalues are dropped 
The spec allows for dropping meta-information in case if. 
  * the meta-data is too long
  * there's too many instances of meta-data (e.g tags)
  
But dropping meta-information requires that the exporter notes how many were dropped.
So for sake of simplicity the exporter includes all environment/span tags

# Assumptions made on the OTLP model
The data model for exporting spans looks like:
```
ExportServiceRequest - -> *  ResourceSpans
ResourceSpans -->* InstrumentationLibrarySpans
ResourceSpans -->1 Resource
InstrumentationLibrarySpans --> * Span
InstrumentationLibrarySpans --> 1 InstrumentationLibrary
```
1- is 1-1
*- is one to many

So one `ExportServiceRequest` can have multiple`ResourceSpans`which in turn can have multiple `InstrumentationLibrarySpans`which finally has multiple `Spans`

I've assumed that always is a single resource (i.e. the application itself) and there is only one instrumentation library (kamon) and all spans belong in that chain.
So the meta-information in the `Resource` belonging to `ResourceSpans` comes largely from optional Kamon env tags.
The meta-information in the instrumentation library is info on Kamon.

# Local testing
I've used the OTEL collector in a container and provided it with config to just print all traces it receives
otel-collector.yaml
```yaml
receivers:
  otlp:
    protocols:
      grpc:
        endpoint: 0.0.0.0:55690

exporters:
  logging:
    loglevel: debug

processors:
  batch:

service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch]
      exporters: [logging]
```
Then just run this command  (requires Docker)
```bash
docker run --rm -p 55690:55690 \
-v "${PWD}/otel-collector.yaml":/otel-local-config.yaml \
--name otelcol otel/opentelemetry-collector \
--config otel-local-config.yaml; \
```

## Example printout from OTEL collector
Note the _Resource labels_ as they're from the Kamon env tags apart from `telemetry.sdk.*` which we always add.
The _InstrumentationLibrary kamon 2.1.14_ is the `InstrumentationLibrary` meta-info provided
```
Resource labels:
     -> service.name: STRING(otlp-test-app)
     -> telemetry.sdk.name: STRING(kamon)
     -> telemetry.sdk.language: STRING(scala)
     -> telemetry.sdk.version: STRING(2.1.14)
     -> notset: STRING(/Users/peter.nerg)
     -> env: STRING(staging)
     -> service.instance.id: STRING(xxx-yyy)
     -> service.namespace: STRING(namespace-1)
     -> service.version: STRING(x.x.x)
InstrumentationLibrarySpans #0
InstrumentationLibrary kamon 2.1.14
Span #0
    Trace ID       : 4a7e482ebab331570cfbfc070dd5e70f
    Parent ID      : 
    ID             : 2c47181be9a542a2
    Name           : /purchase-item/{id}
    Kind           : SPAN_KIND_SERVER
    Start time     : 2021-03-30 12:48:37.244977523 +0000 UTC
    End time       : 2021-03-30 12:48:37.593127187 +0000 UTC
    Status code    : STATUS_CODE_OK
    Status message : 
Attributes:
     -> method: STRING(POST)
Span #1
    Trace ID       : 4a7e482ebab331570cfbfc070dd5e70f
    Parent ID      : 2c47181be9a542a2
    ID             : 4ccac7b8965abd99
    Name           : add-order
    Kind           : SPAN_KIND_CLIENT
    Start time     : 2021-03-30 12:48:37.288737377 +0000 UTC
    End time       : 2021-03-30 12:48:37.592803111 +0000 UTC
    Status code    : STATUS_CODE_OK
    Status message : 
Attributes:
     -> method: STRING(put)
Span #2
    Trace ID       : 4a7e482ebab331570cfbfc070dd5e70f
    Parent ID      : 2c47181be9a542a2
    ID             : c9c8937819d35d41
    Name           : check-credits
    Kind           : SPAN_KIND_CLIENT
    Start time     : 2021-03-30 12:48:37.258310723 +0000 UTC
    End time       : 2021-03-30 12:48:37.284974414 +0000 UTC
    Status code    : STATUS_CODE_OK
    Status message : 
Attributes:
     -> method: STRING(query)

```