### PR TITLE
Fix invalid SpanID issue with W3C propagation

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/W3CTraceContextSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/W3CTraceContextSpanPropagationSpec.scala
@@ -31,7 +31,6 @@ class W3CTraceContextSpanPropagationSpec extends WordSpecLike with Matchers with
       )
 
       val spanContext = traceContextPropagation.read(headerReaderFromMap(headersMap), Context.Empty).get(Span.Key)
-      spanContext.id.string shouldBe "00000000000000000000000001020304"
       spanContext.parentId.string shouldBe "0000000004030201"
       spanContext.trace.id.string shouldBe "00000000000000000000000001020304"
       spanContext.trace.samplingDecision shouldBe SamplingDecision.Sample

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -90,11 +90,12 @@ object W3CTraceContext {
     val traceParentComponents = traceParent.split("-")
 
     if (traceParentComponents.length != 4) None else {
+      val spanID = identityProvider.spanIdFactory.generate()
       val traceID = identityProvider.traceIdFactory.from(traceParentComponents(1))
-      val spanID = identityProvider.spanIdFactory.from(traceParentComponents(2))
+      val parentSpanID = identityProvider.spanIdFactory.from(traceParentComponents(2))
       val samplingDecision = unpackSamplingDecision(traceParentComponents(3))
 
-      Some(Span.Remote(traceID, spanID, Trace(traceID, samplingDecision)))
+      Some(Span.Remote(spanID, parentSpanID, Trace(traceID, samplingDecision)))
     }
   }
 


### PR DESCRIPTION
Quick fix for #975: generate random spanID, as it's not included in W3C Trace Context propagation header