### PR TITLE
hexencode identifiers in lower char for w3c propagation (#985)

### DIFF
--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -102,7 +102,7 @@ object W3CTraceContext {
   def encodeTraceParent(parent: Span): String = {
     def idToHex(identifier: Identifier, length: Int): String = {
       val leftPad = (string: String) => "0" * (length - string.length) + string
-      leftPad(identifier.bytes.map("%02X" format _).mkString)
+      leftPad(identifier.bytes.map("%02x" format _).mkString)
     }
 
     val samplingDecision = if (parent.trace.samplingDecision == SamplingDecision.Sample) "01" else "00"


### PR DESCRIPTION
This PR is for fixing issue #985 : W3C context propagation hex encodes in capital letters causing failure to read the identifiers 