### PR TITLE
fix for w3c propagation of the proper parentSpanId (#986)

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/W3CTraceContextSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/W3CTraceContextSpanPropagationSpec.scala
@@ -14,7 +14,7 @@ class W3CTraceContextSpanPropagationSpec extends WordSpecLike with Matchers with
       val headersMap = mutable.Map.empty[String, String]
       traceContextPropagation.write(testContext(), headerWriterFromMap(headersMap))
 
-      headersMap.get("traceparent").value shouldBe "00-00000000000000000000000001020304-0000000004030201-01"
+      headersMap.get("traceparent").value shouldBe "00-00000000000000000000000001020304-0000000002020202-01"
       headersMap.get("tracestate").value shouldBe ""
     }
 

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -107,7 +107,7 @@ object W3CTraceContext {
 
     val samplingDecision = if (parent.trace.samplingDecision == SamplingDecision.Sample) "01" else "00"
 
-    s"$Version-${idToHex(parent.trace.id, 32)}-${idToHex(parent.id, 16)}-${samplingDecision}"
+    s"$Version-${idToHex(parent.trace.id, 32)}-${idToHex(parent.parentId, 16)}-${samplingDecision}"
   }
 }
 


### PR DESCRIPTION
This PR fixes the issue described in #986.
Using the same test rig as in the linked issue/ticket I now get
```
Got request for '/forward' with 'traceparent' header [None] and parsed/generated context traceId[3e6740b3d532cc6a748754b77c1a3fa1], spanId[8bcb0b40af42c363], parentSpanId[]
Got request for '/hello' with 'traceparent' header [Some(00-3e6740b3d532cc6a748754b77c1a3fa1-8bcb0b40af42c363-00)] and parsed/generated context traceId[3e6740b3d532cc6a748754b77c1a3fa1], spanId[15f8a0e8a247597f], parentSpanId[8bcb0b40af42c363]
```
Note that the parentSpan sent to _/hello_ now has the same value as the spanId generated when entering _/forward_


Note: For the sake of the testing I applied the patch from PR #987 as well as otherwise the identifiers are not properly propagated.