### PR TITLE
Fix typos in the metric descriptions 

### DIFF
--- a/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/host/HostMetrics.scala
+++ b/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/host/HostMetrics.scala
@@ -112,13 +112,13 @@ object HostMetrics {
 
   val StorageDeviceRead = Kamon.counter(
     name = "host.storage.device.data.read",
-    description = "Counts the amount of byes that have been read from a storage device",
+    description = "Counts the amount of bytes that have been read from a storage device",
     unit = MeasurementUnit.information.bytes
   )
 
   val StorageDeviceWrite = Kamon.counter(
     name = "host.storage.device.data.write",
-    description = "Counts the amount of byes that have been written to a storage device",
+    description = "Counts the amount of bytes that have been written to a storage device",
     unit = MeasurementUnit.information.bytes
   )
 


### PR DESCRIPTION
in `host.storage.device.data.read` and `host.storage.device.data.write`.