### PR TITLE
(prometheus) Added the possibility to generate gauge metrics from distribution based metrics

### DIFF
--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -60,7 +60,7 @@ kamon.prometheus {
   }
 
   summaries {
-    # Names of the histogram, timer and range sampler metrics that must be exported as summaries. All patterns are treared as Glob patterns.
+    # Names of the histogram, timer and range sampler metrics that must be exported as summaries. All patterns are treated as Glob patterns.
     metrics = [
       # example:
       # "request*",
@@ -74,6 +74,17 @@ kamon.prometheus {
       0.95,
       0.99,
       0.999
+    ]
+  }
+
+  gauges {
+    # Names of the histogram, timer and range sampler metrics that shall be exported as a gauges as well.
+    # For each matching metric there will be three gauges representing the current seen distribution (min, max, avg)
+    # All patterns are treated as Glob patterns.
+    metrics = [
+      # example:
+      # "http.server*",
+      # "*akka*"
     ]
   }
 

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -62,6 +62,7 @@ class PrometheusReporter(configPath: String = DefaultConfigPath, initialConfig: 
 
     scrapeDataBuilder.appendCounters(currentData.counters)
     scrapeDataBuilder.appendGauges(currentData.gauges)
+    scrapeDataBuilder.appendDistributionMetricsAsGauges(snapshot.rangeSamplers ++ snapshot.histograms ++ snapshot.timers)
     scrapeDataBuilder.appendHistograms(currentData.histograms)
     scrapeDataBuilder.appendHistograms(currentData.timers)
     scrapeDataBuilder.appendHistograms(currentData.rangeSamplers)

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
@@ -31,13 +31,16 @@ object PrometheusSettings {
     informationBuckets: Seq[java.lang.Double],
     customBuckets: Map[String, Seq[java.lang.Double]],
     includeEnvironmentTags: Boolean,
-    summarySettings: SummarySettings
+    summarySettings: SummarySettings,
+    gaugeSettings: GaugeSettings
   )
 
   case class SummarySettings(
     quantiles: Seq[java.lang.Double],
     metricMatchers: Seq[Glob]
   )
+
+  case class GaugeSettings(metricMatchers: Seq[Glob])
 
   def readSettings(prometheusConfig: Config): Generic = {
     Generic(
@@ -49,6 +52,9 @@ object PrometheusSettings {
       summarySettings = SummarySettings(
         quantiles = prometheusConfig.getDoubleList("summaries.quantiles").asScala.toSeq,
         metricMatchers = prometheusConfig.getStringList("summaries.metrics").asScala.map(Glob).toSeq
+      ),
+      gaugeSettings = GaugeSettings(
+        metricMatchers = prometheusConfig.getStringList("gauges.metrics").asScala.map(Glob).toSeq
       )
     )
   }


### PR DESCRIPTION
This is hopefully the answer to several discussions (#899, #914) around why some of the measurements are using range sampler and not gauge.

This PR adds the possibility to configure (by name pattern) for which distribution based (range, time, histogram) metrics to also generate gauge metrics

E.g. configuring something like this:
```
kamon.prometheus.gauges.metrics = ["http.server.*"]
```
Would also render gauge metrics for all `http-server` metrics. 
The existing histogram/summary metrics will still remain, these gauges are add-ons.

For each distribution metric that matches the configured filter three gauges are created
* `min`- representing the min value seen in the distribution of the snapshot
* `max`- representing the max value seen in the distribution of the snapshot
* `sum`- representing the sum of all values seen in the distribution  of the snapshot. Which is relevant to understand how many of something (e.g. connections) there has been measured in the interval

E.g. running with akka-http and enabling gauge metrics according to the above configuration I'd get something like this for the range metric `http.server.connection.open`
```
# HELP http_server_connection_open_min Number of open connections
# TYPE http_server_connection_open_min gauge
http_server_connection_open_min{port="9696",interface="0.0.0.0",component="akka.http.server"} 0.0
# HELP http_server_connection_open_max Number of open connections
# TYPE http_server_connection_open_max gauge
http_server_connection_open_max{port="9696",interface="0.0.0.0",component="akka.http.server"} 4.0
# HELP http_server_connection_open_sum Number of open connections
# TYPE http_server_connection_open_sum gauge
http_server_connection_open_sum{port="9696",interface="0.0.0.0",component="akka.http.server"} 600.0
```

When I stop running requests the gauges eventually drop to zero

I think this is a non-intrusive way of providing more suitable metric formats for Prometheus for some of the use cases where one just wants an easy way to see what is going on in the app here and now.