### PR TITLE
Added the possibility to filter out context tags not to propagate

### DIFF
--- a/core/kamon-core-tests/src/test/resources/reference.conf
+++ b/core/kamon-core-tests/src/test/resources/reference.conf
@@ -52,6 +52,7 @@ kamon {
   }
 
   propagation.http.default {
+    tags.filter = []
     tags.mappings {
       "correlation-id" = "x-correlation-id"
     }

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -284,7 +284,15 @@ kamon {
           # Enables automatic inclusion of the "upstream.name" tag in outgoing requests.
           include-upstream-name = yes
 
-          # Provide explicit mappins between context tags and the HTTP headers that will carry them. When there is
+          # Provides the means to filter which tags NOT to propagate as HTTP headers
+          # E.g having stored a tag in the context with the name 'mytag' one can exlude it from being propagated
+          # filter = ["mytag"]
+          # or using Glob patterns
+          # filter = ["my*"]
+          #
+          filter = []
+
+          # Provide explicit mappings between context tags and the HTTP headers that will carry them. When there is
           # an explicit mapping for a tag, it will not be included in the default context header. For example, if
           # you wanted to use the an HTTP header called `X-Correlation-ID` for a context tag with key `correlationID`
           # you would need to include a the following configuration:


### PR DESCRIPTION
This adds the possibility to filter (Glob) out tags NOT to propagate.  
Applications may be using the context for storing tags which one does not want to automatically propagate.
In my case I have certain tags I handle in custom readers/writers and therefore don't want the default propagation to manage them.

By default the filter is empty, i.e. all tags are propagated just as it works now