### PR TITLE
Stop doubly instrumenting outgoing requests

### DIFF
--- a/instrumentation/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/AkkaHttpClientInstrumentation.scala
+++ b/instrumentation/kamon-akka-http/src/main/scala/kamon/instrumentation/akka/http/AkkaHttpClientInstrumentation.scala
@@ -39,11 +39,6 @@ class AkkaHttpClientInstrumentation extends InstrumentationBuilder with VersionF
       .advise(method("singleRequestImpl"), classOf[HttpExtSingleRequestAdvice])
   }
 
-  onAkkaHttp("10.2") {
-    onType("akka.http.scaladsl.HttpExt")
-      .advise(method("singleRequest"), classOf[HttpExtSingleRequestAdvice])
-  }
-
   onType("akka.http.impl.engine.client.PoolMaster")
     .advise(method("dispatchRequest"), classOf[PoolMasterDispatchRequestAdvice])
 }


### PR DESCRIPTION
The no longer instrumented method just delegates to the PoolMaster