### PR TITLE
Add source mappings from custom configurations

### DIFF
--- a/instrumentation/kamon-akka/build.sbt
+++ b/instrumentation/kamon-akka/build.sbt
@@ -102,6 +102,21 @@ mappings in packageBin in Compile := Def.taskDyn {
       ) ++ joinProducts((unmanagedResourceDirectories in Common).value)}
 }.value
 
+// Ensure that the packaged sources contains the instrumentation for all Akka versions.
+mappings in packageSrc in Compile := Def.taskDyn {
+  if(scalaBinaryVersion.value == "2.11") {
+    Def.task {
+      (mappings in packageSrc in `Compile-Akka-2.5`).value ++
+        (mappings in packageSrc in Common).value
+    }
+  } else
+    Def.task {
+      (mappings in packageSrc in `Compile-Akka-2.5`).value ++
+        (mappings in packageSrc in `Compile-Akka-2.6`).value ++
+        (mappings in packageSrc in Common).value
+    }
+  }.value
+
 // Compile will return the compile analysis for the Common configuration but will run on all Akka configurations.
 compile in Compile := Def.taskDyn {
   if(scalaBinaryVersion.value == "2.11")


### PR DESCRIPTION
The [published sources](https://repo1.maven.org/maven2/io/kamon/kamon-akka_2.13/2.1.18/kamon-akka_2.13-2.1.18-sources.jar) contain nothing but a MANIFEST.MF.

I suspect that this is because of how the custom configurations have been done.

This works with `kamon-akka/publishLocal`.