### PR TITLE
introduce Span Reporting delay

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/SpanReportingDelaySpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/SpanReportingDelaySpec.scala
@@ -1,0 +1,86 @@
+/* =========================================================================================
+ * Copyright © 2013-2017 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.trace
+
+import kamon.Kamon
+import kamon.testkit.{Reconfigure, SpanInspection, TestSpanReporter}
+import org.scalactic.TimesOnInt.convertIntToRepeater
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.SpanSugar
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+
+
+class SpanReportingDelaySpec extends WordSpec with Matchers with OptionValues with SpanInspection.Syntax with Eventually
+    with SpanSugar with TestSpanReporter with Reconfigure {
+
+  "the Kamon tracer" when {
+    "has span reporting delay disabled" should {
+      "keep spans with a positive sampling decision" in {
+        val span = Kamon.spanBuilder("positive-span-without-delay").start()
+        span.trace.keep()
+        span.finish()
+
+        eventually(timeout(5 seconds)) {
+          val reportedSpan = testSpanReporter().nextSpan().value
+          reportedSpan.operationName shouldBe span.operationName()
+        }
+      }
+
+      "not report spans with a negative sampling decision" in {
+        val span = Kamon.spanBuilder("negative-span-without-delay").start()
+        span.trace.drop()
+        span.finish()
+        span.trace.keep() // Should not have any effect
+
+        5 times {
+          val allSpans = testSpanReporter().spans()
+          allSpans.find(_.operationName == span.operationName()) shouldBe empty
+
+          Thread.sleep(100) // Should be enough because Spans are reported every millisecond in tests
+        }
+      }
+    }
+
+    "has span reporting delay enabled" should {
+      "keep spans with a positive sampling decision" in {
+        applyConfig("kamon.trace.span-reporting-delay = 2 seconds")
+        val span = Kamon.spanBuilder("overwrite-to-positive-with-delay").start()
+        span.trace.drop()
+        span.finish()
+        span.trace.keep() // Should force the Span to be reported, even though it was dropped before finising
+
+        eventually(timeout(5 seconds)) {
+          val reportedSpan = testSpanReporter().nextSpan().value
+          reportedSpan.operationName shouldBe span.operationName()
+        }
+      }
+
+      "not report spans with a negative sampling decision" in {
+        val span = Kamon.spanBuilder("negative-span-without-delay").start()
+        span.trace.keep()
+        span.finish()
+        span.trace.drop() // Should force the Span to be dropped, even though it was sampled before finishing
+
+        5 times {
+          val allSpans = testSpanReporter().spans()
+          allSpans.find(_.operationName == span.operationName()) shouldBe empty
+
+          Thread.sleep(100) // Should be enough because Spans are reported every millisecond in tests
+        }
+      }
+    }
+  }
+}

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -145,6 +145,16 @@ kamon {
     # reporter has a separate queue.
     reporter-queue-size = 4096
 
+    # Decide for how long should the tracer wait to report Spans after they are finished. This setting helps keeping
+    # Spans in memory for a few seconds after they finished, in case users want to manually override the sampling
+    # decision for the trace later on. Keep in mind that:
+    #   - Overriding the sampling decision is a local-only action, any Spans from other connected services will not be
+    #     retained or affected in any way.
+    #   - This will introduce additional memory consumption proportional to the reporting delay and the Spans volume.
+    #
+    # Setting this value to "0 seconds" disables the reporting delay.
+    span-reporting-delay = 0 seconds
+
     # Decide whether a new, locally created Span should have the same Span Identifier as it's remote parent (if any) or
     # get a new local identifier. Certain tracing systems use the same Span Identifier to represent both sides (client
     # and server) of a RPC call, if you are reporting data to such systems then this option should be enabled. This


### PR DESCRIPTION
This PR introduces the `kamon.trace.span-reporting-delay` setting to allow users to keep Spans in memory for a period of time before reporting them, in case the they want to change a Trace's sampling decision programmatically. 

The idea is to allow people to do tail-based sampling, at least at the local service level. The reporting delay is zero by default because it doesn't make sense to delay Spans in case folks explicitly want to change sampling decisions.