### PR TITLE
add a convenience function for span creation

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/QuickSpanCreationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/QuickSpanCreationSpec.scala
@@ -34,6 +34,21 @@ class QuickSpanCreationSpec extends WordSpec with Matchers with OptionValues wit
       }
     }
 
+    "finish and fail Spans if an exception is thrown while running the wrapped code" in {
+      intercept[Throwable] {
+        span("failSpanWithThrowable") {
+          throw new Throwable()
+          "I'm never going to finish nicely"
+        }
+      }
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.operationName shouldBe "failSpanWithThrowable"
+        reportedSpan.hasError shouldBe true
+      }
+    }
+
     "apply the component tag, if provided" in {
       span("finishSimpleSpanWithComponent", "customComponentTag") {
         "I'm done right away"

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/QuickSpanCreationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/QuickSpanCreationSpec.scala
@@ -1,0 +1,85 @@
+package kamon.trace
+
+import kamon.tag.Lookups._
+import kamon.testkit.{Reconfigure, SpanInspection, TestSpanReporter}
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.SpanSugar
+
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class QuickSpanCreationSpec extends WordSpec with Matchers with OptionValues with SpanInspection.Syntax with Eventually
+  with SpanSugar with TestSpanReporter with Reconfigure {
+
+  import kamon.Kamon.{span, currentSpan}
+
+  "the kamon.Tracing.span function" should {
+    "create a Span and set it as the current Span while running the provided function" in {
+      span("makeCurrent") {
+        currentSpan().operationName() shouldBe "makeCurrent"
+      }
+    }
+
+    "finish Spans automatically" in {
+      span("finishSimpleSpan") {
+        "I'm done right away"
+      }
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.operationName shouldBe "finishSimpleSpan"
+      }
+    }
+
+    "apply the component tag, if provided" in {
+      span("finishSimpleSpanWithComponent", "customComponentTag") {
+        "I'm done right away"
+      }
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.operationName shouldBe "finishSimpleSpanWithComponent"
+        reportedSpan.metricTags.get(any("component")) should be ("customComponentTag")
+      }
+    }
+
+    "finish Spans automatically after the returned Scala Future finishes" in {
+      span("finishScalaFuture") {
+        Future {
+          Thread.sleep(1000)
+          "I'm done after a second"
+        }
+      }
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.operationName shouldBe "finishScalaFuture"
+        Duration.between(reportedSpan.from, reportedSpan.to).toMillis should be >= 1000L
+      }
+    }
+
+    "finish Spans automatically after the returned CompletionStage finishes" in {
+      span("finishCompletionStage") {
+
+        val completableFuture = new CompletableFuture[String]
+        global.execute(new Runnable {
+          override def run(): Unit = {
+            Thread.sleep(1000)
+            completableFuture.complete("I'm done after a second")
+          }
+        })
+
+        completableFuture
+      }
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.operationName shouldBe "finishCompletionStage"
+        Duration.between(reportedSpan.from, reportedSpan.to).toMillis should be >= 1000L
+      }
+    }
+  }
+}

--- a/core/kamon-core/src/main/java/kamon/util/CompletionStageSpanFinisher.java
+++ b/core/kamon-core/src/main/java/kamon/util/CompletionStageSpanFinisher.java
@@ -1,0 +1,21 @@
+package kamon.util;
+
+import kamon.trace.Span;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Tiny helper to bypass Scala type issues when trying to create a BiFunction for CompletionStage.handle(...).
+ */
+public class CompletionStageSpanFinisher {
+
+    public static CompletionStage<?> finishWhenDone(CompletionStage<?> cs, Span span) {
+        return cs.handle((a, t) -> {
+            if(t != null)
+                span.fail(t);
+            span.finish();
+
+            return cs;
+        });
+    }
+}

--- a/core/kamon-core/src/main/scala/kamon/Tracing.scala
+++ b/core/kamon-core/src/main/scala/kamon/Tracing.scala
@@ -16,7 +16,13 @@
 
 package kamon
 
-import kamon.trace.{Identifier, SpanBuilder, Tracer}
+import kamon.trace.{Identifier, Span, SpanBuilder, Tracer}
+import kamon.util.{CallingThreadExecutionContext, CompletionStageSpanFinisher}
+
+import java.util.concurrent.CompletionStage
+import java.util.function.BiFunction
+import scala.concurrent.Future
+import scala.util.Failure
 
 /**
   * Exposes the Tracing APIs using a built-in, globally shared tracer.
@@ -83,6 +89,74 @@ trait Tracing { self: Configuration with Utilities with ContextStorage =>
     */
   def spanBuilder(operationName: String): SpanBuilder =
     _tracer.spanBuilder(operationName)
+
+
+  /**
+    * Creates an Internal Span that finishes automatically when the provided function finishes execution. If the
+    * provided function returns a scala.concurrent.Future or java.util.concurrent.CompletionStage implementation then
+    * the Span will be finished with the Future/CompletionState completes.
+    *
+    * You can get access to the created Span within the provided function using Kamon.currentSpan. For example, if you
+    * wanted to add a tag to a Span created with this function you could do it as follows:
+    *
+    *   span("fetchUserDetails") {
+    *     Kamon.currentSpan.tag("user.id", userId)
+    *
+    *     // Your business logic...
+    *   }
+    *
+    * If you need more customization options for the Span or complete control over Context propagation and Span
+    * lifecycle then create a SpanBuilder instead.
+    */
+  def span[A](operationName: String)(f: => A): A =
+    span(operationName, null)(f)
+
+
+  /**
+    * Creates an Internal Span that finishes automatically when the provided function finishes execution. If the
+    * provided function returns a scala.concurrent.Future or java.util.concurrent.CompletionStage implementation then
+    * the Span will be finished with the Future/CompletionState completes.
+    *
+    * You can get access to the created Span within the provided function using Kamon.currentSpan. For example, if you
+    * wanted to add a tag to a Span created with this function you could do it as follows:
+    *
+    *   span("fetchUserDetails") {
+    *     Kamon.currentSpan.tag("user.id", userId)
+    *
+    *     // Your business logic...
+    *   }
+    *
+    * If you need more customization options for the Span or complete control over Context propagation and Span
+    * lifecycle then create a SpanBuilder instead.
+    */
+  def span[A](operationName: String, component: String)(f: => A): A = {
+    val span = Kamon.spanBuilder(operationName)
+      .kind(Span.Kind.Internal)
+      .tagMetrics(Span.TagKeys.Component, component)
+      .start()
+
+    runWithSpan(span, finishSpan = false)(f) match {
+      case future: Future[_] =>
+        future.onComplete {
+          case Failure(t) =>
+            span
+              .fail(t)
+              .finish()
+
+          case _ =>
+              span.finish()
+        }(CallingThreadExecutionContext)
+
+        future.asInstanceOf[A]
+
+      case cs: CompletionStage[_] =>
+        CompletionStageSpanFinisher.finishWhenDone(cs, span).asInstanceOf[A]
+
+      case other =>
+        span.finish()
+        other
+    }
+  }
 
 
   /** The Tracer instance is only exposed to other Kamon components that need it like the Module Registry and Status */


### PR DESCRIPTION
This PR brings a simple function to create a Span to wrap the execution of code blocks, with two special behaviors:
- The function stores the created Span in the current context while the function is executed.
- The function will always finish the Span after the wrapped code finishes execution, with special handling for Scala Futures and CompletionStage instances. If the wrapped code returns a Future or CompletionStage, the created Span will be finished when the returned Future/CompletionStage completes.

This function should be enough to replace the soon-to-be-deprecated functions in `ScalaFutureInstrumentation`. More info here: https://github.com/kamon-io/Kamon/issues/1021.

Also, this simplifies cases where people want a simple Span for a block of code and end up having to write something like this:

```
Kamon.runWithSpan(Kamon.spanBuilder(....).start()) {

}
```

