### PR TITLE
Future instrumentation rollback

### DIFF
--- a/instrumentation/kamon-akka-http/src/main/resources/reference.conf
+++ b/instrumentation/kamon-akka-http/src/main/resources/reference.conf
@@ -238,6 +238,8 @@ kanela.modules {
     name = "Akka HTTP Instrumentation"
     description = "Provides context propagation, distributed tracing and HTTP client and server metrics for Akka HTTP"
 
+    # Add "kamon.instrumentation.akka.http.FastFutureInstrumentation" to the instrumentation list if you need to
+    # use the Future Chaining instrumentation in Kamon 2.2.x. It will be fully removed in Kamon 2.3.0.
     instrumentations = [
       "kamon.instrumentation.akka.http.AkkaHttpServerInstrumentation"
       "kamon.instrumentation.akka.http.AkkaHttpClientInstrumentation"

--- a/instrumentation/kamon-akka-http/src/test/scala/kamon/akka/http/FastFutureInstrumentationSpec.scala
+++ b/instrumentation/kamon-akka-http/src/test/scala/kamon/akka/http/FastFutureInstrumentationSpec.scala
@@ -18,7 +18,16 @@ import scala.util.Try
 
 class FastFutureInstrumentationSpec extends WordSpec with Matchers {
 
-  "the FastFuture instrumentation" should {
+  /**
+    *  DEPRECATED
+    *
+    *  This spec is ignored since Kamon 2.2.0, along with the deprecation of the Future Chaining instrumentation, and
+    *  should be completely removed before releasing Kamon 2.3.0.
+    *
+    *  We are keeping this spec only for the rare case that we might need to fix a bug on the Future Chaining
+    *  instrumentation while we keep it in maintenance mode.
+    */
+  "the FastFuture instrumentation" ignore {
     "keep the Context captured by the Future from which it was created" when {
       "calling .map/.flatMap/.onComplete and the original Future has not completed yet" in {
         val completeSignal = new CountDownLatch(1)

--- a/instrumentation/kamon-executors/src/main/resources/reference.conf
+++ b/instrumentation/kamon-executors/src/main/resources/reference.conf
@@ -27,7 +27,6 @@ kanela.modules {
       "^com.sun.tools.*",
       "^sbt.internal.*",
       "^com.intellij.rt.*",
-      "^scala.concurrent.*",
       "^org.jboss.netty.*",
       "^com.google.common.base.internal.Finalizer",
       "^kamon.module.*",

--- a/instrumentation/kamon-scala-future/src/main/resources/reference.conf
+++ b/instrumentation/kamon-scala-future/src/main/resources/reference.conf
@@ -21,10 +21,16 @@ kamon.instrumentation.futures.scala {
 }
 
 kanela.modules {
+  executor-service {
+    within += "scala.concurrent.impl.CallbackRunnable"
+    within += "scala.concurrent.impl.Future\\$PromiseCompletingRunnable"
+    within += "scala.concurrent.impl.Promise\\$Transformation"
+  }
 
   scala-future {
-    name = "Scala Future Instrumentation"
+    name = "Scala Future Chaining Instrumentation (Deprecated)"
     order = 1
+    enabled = false
     description = "Deprecated since Kamon 2.1.21, will be removed in Kamon 2.3.0. Provides automatic context propagation to the thread executing a Scala Future's body and callbacks"
     instrumentations = [
       "kamon.instrumentation.futures.scala.FutureChainingInstrumentation"

--- a/instrumentation/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureChainingInstrumentationSpec.scala
+++ b/instrumentation/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureChainingInstrumentationSpec.scala
@@ -1,0 +1,173 @@
+/* ===================================================
+ * Copyright © 2013 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ========================================================== */
+package kamon.instrumentation.futures.scala
+
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
+
+import kamon.Kamon
+import kamon.tag.Lookups.plain
+import kamon.context.Context
+import kamon.instrumentation.context.HasContext
+import kamon.testkit.TestSpanReporter
+import org.scalatest.{Matchers, OptionValues, WordSpec}
+import org.scalatest.concurrent.{Eventually, PatienceConfiguration, ScalaFutures}
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+class FutureChainingInstrumentationSpec extends WordSpec with ScalaFutures with Matchers with PatienceConfiguration
+    with OptionValues with Eventually with TestSpanReporter {
+
+  import kamon.instrumentation.futures.scala.ScalaFutureInstrumentation.{traceBody, traceFunc}
+  implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(1))
+
+  /**
+    *  DEPRECATED
+    *
+    *  This spec is ignored since Kamon 2.2.0, along with the deprecation of the Future Chaining instrumentation, and
+    *  should be completely removed before releasing Kamon 2.3.0.
+    *
+    *  We are keeping this spec only for the rare case that we might need to fix a bug on the Future Chaining
+    *  instrumentation while we keep it in maintenance mode.
+    */
+  "a Scala Future" ignore {
+    "manually instrumented" should {
+      "create Delayed Spans for a traced future and traced callbacks" in {
+        Future(traceBody("future-body")("this is the future body"))
+          .map(traceFunc("first-callback")(_.length))
+          .map(_ * 10)
+          .flatMap(traceFunc("second-callback")(Future(_)))
+          .map(_ * 10)
+          .filter(traceFunc("third-callback")(_.toString.length > 10))
+
+        val spans = testSpanReporter.spans(200 millis)
+        val bodySpan = spans.find(_.operationName == "future-body").get
+        val firstCallbackSpan = spans.find(_.operationName == "first-callback").get
+        val secondCallbackSpan = spans.find(_.operationName == "second-callback").get
+        val thirdCallbackSpan = spans.find(_.operationName == "third-callback").get
+
+        firstCallbackSpan.trace shouldBe bodySpan.trace
+        secondCallbackSpan.trace shouldBe bodySpan.trace
+        thirdCallbackSpan.trace shouldBe bodySpan.trace
+
+        firstCallbackSpan.parentId shouldBe bodySpan.id
+        secondCallbackSpan.parentId shouldBe firstCallbackSpan.id
+        thirdCallbackSpan.parentId shouldBe secondCallbackSpan.id
+
+        testSpanReporter.clear()
+        ensureExecutionContextIsClean()
+      }
+
+      "propagate the last chained Context when failures happen" in {
+        Future(traceBody("future-body")("this is the future body"))
+          .map(traceFunc("first-callback")(_.length))
+          .map(_ / 0)
+          .flatMap(traceFunc("second-callback")(Future(_))) // this will never happen
+          .map(_ * 10)
+          .recover { case _ => "recovered" }
+          .map(traceFunc("third-callback")(_.toString))
+
+        val spans = testSpanReporter.spans(200 millis)
+        val bodySpan = spans.find(_.operationName == "future-body").get
+        val firstCallbackSpan = spans.find(_.operationName == "first-callback").get
+        val thirdCallbackSpan = spans.find(_.operationName == "third-callback").get
+
+        firstCallbackSpan.trace shouldBe bodySpan.trace
+        thirdCallbackSpan.trace shouldBe bodySpan.trace
+        spans.find(_.operationName == "second-callback") shouldBe empty
+
+        testSpanReporter.clear()
+        ensureExecutionContextIsClean()
+      }
+
+      "be usable when working with for comprehensions" in {
+        for {
+          first <- Future(traceBody("first-future")("this is the future body"))
+          second <- Future(traceBody("second-future")(first.length))
+          third <- Future(traceBody("third-future")(second * 10))
+        } yield traceBody("yield") {
+          Kamon.currentSpan().tag("location", "atTheYield")
+          "Hello World! " * third
+        }
+
+        val spans = testSpanReporter.spans(200 millis)
+        val firstFutureSpan = spans.find(_.operationName == "first-future").get
+        val secondFutureSpan = spans.find(_.operationName == "second-future").get
+        val thirdFutureSpan = spans.find(_.operationName == "third-future").get
+        val yieldSpan = spans.find(_.operationName == "yield").get
+
+        firstFutureSpan.trace shouldBe yieldSpan.trace
+        secondFutureSpan.trace shouldBe yieldSpan.trace
+        thirdFutureSpan.trace shouldBe yieldSpan.trace
+
+        secondFutureSpan.parentId shouldBe firstFutureSpan.id
+        thirdFutureSpan.parentId shouldBe secondFutureSpan.id
+        yieldSpan.parentId shouldBe thirdFutureSpan.id
+
+        testSpanReporter.clear()
+        ensureExecutionContextIsClean()
+      }
+    }
+
+    "instrumented with the default bytecode instrumentation" should {
+      "propagate the context to the thread executing the future's body" in {
+        val context = Context.of("key", "value")
+        val contextTag = Kamon.runWithContext(context) {
+          Future(Kamon.currentContext().getTag(plain("key")))
+        }
+
+        whenReady(contextTag)(tagValue => tagValue shouldBe "value")
+        ensureExecutionContextIsClean()
+      }
+
+      "propagate the context to the thread executing callbacks on the future" in {
+        val context = Context.of("key", "value")
+        val tagAfterTransformation = Kamon.runWithContext(context) {
+            Future("Hello Kamon!")
+              // The current context is expected to be available during all intermediate processing.
+              .map(_.length)
+              .flatMap(len => Future(len.toString))
+              .map(_ => Kamon.currentContext().getTag(plain("key")))
+          }
+
+        whenReady(tagAfterTransformation)(tagValue => tagValue shouldBe "value")
+        ensureExecutionContextIsClean()
+      }
+    }
+  }
+
+  def ensureExecutionContextIsClean(): Unit = {
+    val ref = new AtomicReference[Option[Context]](None)
+    val contextReturn = new ContextReturningRunnable(ref)
+
+    // Ensure that our test Runnable is not being instrumented
+    contextReturn.isInstanceOf[HasContext] shouldBe false
+    ec.execute(contextReturn)
+
+    val contextInThreadPool = eventually {
+      ref.get().value
+    }
+
+    contextInThreadPool shouldBe Context.Empty
+  }
+}
+
+class ContextReturningRunnable(ref: AtomicReference[Option[Context]]) extends Runnable {
+  override def run(): Unit = {
+    ref.set(Some(Kamon.currentContext()))
+  }
+}


### PR DESCRIPTION
This PR rolls back the Future Chaining Instrumentation we introduced on Kamon 2.x, and goes back to the same behavior we had on Kamon 1.x. All the Kamon 2.x instrumentation is kept, but deprecated and disabled by defaults, but users could enable them manually if necessary via configuration.

This is expected to be released with Kamon 2.2.0, and requires #1033 and #1034 to be merged first.

For reference, if anybody wanted to enable the Future Chaining instrumentation in 2.2.0+ they would need to add these settings:

```
kanela.modules {
  executor-service {
    exclude += "scala.concurrent.impl.*"
  }

  scala-future {
    enabled = true
  }
  
  akka-http {
    instrumentations += "kamon.instrumentation.akka.http.FastFutureInstrumentation"
  }  
}
```

All the code related to the Future Chaining instrumentation will be removed in Kamon 2.3.0.