### PR TITLE
delete the extracted Kanela file after exiting

### DIFF
--- a/bundle/kamon-bundle/src/main/scala/kamon/bundle/Bundle.scala
+++ b/bundle/kamon-bundle/src/main/scala/kamon/bundle/Bundle.scala
@@ -49,6 +49,8 @@ object Bundle {
       withInstrumentationClassLoader(springBootClassLoader.orNull) {
         ByteBuddyAgent.attach(temporaryAgentFile.toFile, pid())
       }
+
+      temporaryAgentFile.toFile.deleteOnExit()
     }
   }
 


### PR DESCRIPTION
This should ensure that the temporary Kanela agent file extracted by the Bundle will be deleted after the JVM exits. Still need to test this out, though. I don't even get a single temporary file on my machine!