### PR TITLE
add hsqldb to the kamon-jdbc within packages

### DIFF
--- a/instrumentation/kamon-jdbc/src/main/resources/reference.conf
+++ b/instrumentation/kamon-jdbc/src/main/resources/reference.conf
@@ -57,6 +57,7 @@ kanela.modules {
       "^com.mysql.cj.jdbc..*",
       "^org.h2.Driver",
       "^org.h2.jdbc..*",
+      "^org.hsqldb.jdbc.*",
       "^net.sf.log4jdbc..*",
       "^org.mariadb.jdbc..*",
       "^org.postgresql.jdbc..*",


### PR DESCRIPTION
I was testing the Spring Pet Clinic examples and noticed that we don't have HyperSQL in our list. Added it and worked like a charm so I'm bring it to Kamon :smile: 