### PR TITLE
try to bind Status Page on a different port if the configured port is busy

### DIFF
--- a/core/kamon-status-page/src/main/resources/reference.conf
+++ b/core/kamon-status-page/src/main/resources/reference.conf
@@ -5,6 +5,13 @@ kamon {
     listen {
       hostname = "0.0.0.0"
       port = 5266
+
+      # Makes the Status Page try to bind to a different (random) port number when the configured listen
+      # port number is not available. This might happen if you have several applications running on the
+      # same host and sharing the same network interface.
+      #
+      # The actual listen address will be logged when the Status Page initializes.
+      retry-on-random-port = true
     }
   }
 


### PR DESCRIPTION
This ensures that no errors will be thrown when users start more than one Kamon-instrumented application on the same host and network.