### PR TITLE
W3C span propagation id fix

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/W3CTraceContextSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/W3CTraceContextSpanPropagationSpec.scala
@@ -14,7 +14,7 @@ class W3CTraceContextSpanPropagationSpec extends WordSpecLike with Matchers with
       val headersMap = mutable.Map.empty[String, String]
       traceContextPropagation.write(testContext(), headerWriterFromMap(headersMap))
 
-      headersMap.get("traceparent").value shouldBe "00-00000000000000000000000001020304-0000000002020202-01"
+      headersMap.get("traceparent").value shouldBe "00-00000000000000000000000001020304-0000000004030201-01"
       headersMap.get("tracestate").value shouldBe ""
     }
 
@@ -31,7 +31,7 @@ class W3CTraceContextSpanPropagationSpec extends WordSpecLike with Matchers with
       )
 
       val spanContext = traceContextPropagation.read(headerReaderFromMap(headersMap), Context.Empty).get(Span.Key)
-      spanContext.parentId.string shouldBe "0000000004030201"
+      spanContext.parentId.string shouldBe empty
       spanContext.trace.id.string shouldBe "00000000000000000000000001020304"
       spanContext.trace.samplingDecision shouldBe SamplingDecision.Sample
     }

--- a/core/kamon-core/src/main/scala/kamon/context/HttpPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/context/HttpPropagation.scala
@@ -249,7 +249,7 @@ object HttpPropagation {
           case (contextKey, componentClass) =>
             val shortcut = s"$contextKey/$componentClass".toLowerCase()
 
-            if (componentClass == "span/w3c" && identifierScheme != "double") {
+            if (shortcut == "span/w3c" && identifierScheme != "double") {
               log.warn("W3C TraceContext propagation should be used only with identifier-scheme = double")
             }
 

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -90,9 +90,9 @@ object W3CTraceContext {
     val traceParentComponents = traceParent.split("-")
 
     if (traceParentComponents.length != 4) None else {
-      val spanID = identityProvider.spanIdFactory.generate()
+      val spanID = identityProvider.spanIdFactory.from(traceParentComponents(2))
       val traceID = identityProvider.traceIdFactory.from(traceParentComponents(1))
-      val parentSpanID = identityProvider.spanIdFactory.from(traceParentComponents(2))
+      val parentSpanID = Identifier.Empty
       val samplingDecision = unpackSamplingDecision(traceParentComponents(3))
 
       Some(Span.Remote(spanID, parentSpanID, Trace(traceID, samplingDecision)))

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -107,7 +107,7 @@ object W3CTraceContext {
 
     val samplingDecision = if (parent.trace.samplingDecision == SamplingDecision.Sample) "01" else "00"
 
-    s"$Version-${idToHex(parent.trace.id, 32)}-${idToHex(parent.parentId, 16)}-${samplingDecision}"
+    s"$Version-${idToHex(parent.trace.id, 32)}-${idToHex(parent.id, 16)}-${samplingDecision}"
   }
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,7 +36,7 @@ object BaseProject extends AutoPlugin {
     val hdrHistogram      = "org.hdrhistogram"      %  "HdrHistogram"    % "2.1.10"
     val okHttp            = "com.squareup.okhttp3"  %  "okhttp"          % "3.14.7"
     val okHttpMockServer  = "com.squareup.okhttp3"  %  "mockwebserver"   % "3.10.0"
-    val oshiCore          = "com.github.oshi"       %  "oshi-core"       % "5.7.0"
+    val oshiCore          = "com.github.oshi"       %  "oshi-core"       % "5.7.5"
 
 
     val kanelaAgentVersion = settingKey[String]("Kanela Agent version")


### PR DESCRIPTION
Propagate the current span id, not the parent span id, according to the spec. 

When reading from headers, don't generate a new ID for the Remote span, but use the existing one.

This is the thread where @dguggemos reported the bug -> https://gitter.im/kamon-io/Kamon?at=60cc4e2cb31731135437e0aa

@pnerg If you have the time, check this out. You initially changed this to use the parentID instead of the spanID. According to the W3C spec, the current span ID should be propagated. 
From the spec https://www.w3.org/TR/trace-context/#a-traceparent-is-received: 
```Update parent-id: The value of property parent-id MUST be set to a value representing the ID of the current operation.```

https://github.com/kamon-io/Kamon/issues/986 I believe this issue originated from the fact that akka-http was being double instrumented.