### PR TITLE
added missing span marks to otel exporter #1047

### DIFF
--- a/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/SpanConverter.scala
+++ b/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/SpanConverter.scala
@@ -80,6 +80,8 @@ private[otel] object SpanConverter {
 
     //converts Kamon span links to proto links
     val links:Seq[ProtoSpan.Link] = span.links.map(toProtoLink)
+    //converts Kamon span marks to proto events
+    val events:Seq[ProtoSpan.Event] = span.marks.map(toProtoEvent)
 
     import collection.JavaConverters._
     val builder = ProtoSpan.newBuilder()
@@ -92,6 +94,7 @@ private[otel] object SpanConverter {
       .setStatus(getStatus(span))
       .addAllAttributes(attributes.asJava)
       .addAllLinks(links.asJava)
+      .addAllEvents(events.asJava)
 
     //TODO add set traceState once we have something to set. Need w3c context
     //It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
@@ -176,6 +179,18 @@ private[otel] object SpanConverter {
     ProtoSpan.Link.newBuilder()
       .setTraceId(traceIdToByteString(link.trace.id))
       .setSpanId(spanIdToByteString(link.spanId))
+      .build()
+  }
+
+  /**
+    * Converts a Kamon Mark to a proto span event
+    * @param mark
+    * @return
+    */
+  private[otel] def toProtoEvent(mark:Span.Mark):ProtoSpan.Event = {
+    ProtoSpan.Event.newBuilder()
+      .setName(mark.key)
+      .setTimeUnixNano(toEpocNano(mark.instant))
       .build()
   }
 

--- a/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/SpanConverterSpec.scala
+++ b/reporters/kamon-opentelemetry/src/test/scala/kamon/otel/SpanConverterSpec.scala
@@ -100,6 +100,13 @@ class SpanConverterSpec extends WordSpec with Matchers with ByteStringMatchers w
     protoLink.getSpanId shouldEqual toByteString(spanId, false)
   }
 
+  "should convert a Kamon mark to the proto event" in {
+    val mark = Span.Mark(Instant.now(), "some-key")
+    val protoEvent = toProtoEvent(mark)
+    protoEvent.getName shouldEqual mark.key
+    protoEvent.getTimeUnixNano shouldEqual toEpocNano(mark.instant)
+  }
+
   "converting a Kamon identifier to a proto bytestring" should {
     def padded(id:Identifier):Array[Byte] = Array.fill[Byte](8)(0)++id.bytes
     "return a 16 byte array for a 16 byte identifier, padding enabled" in {


### PR DESCRIPTION
Converted any `Mark` data from the Kamon span and added to the OTEL exported data as `Event`.  
This is a fix for issue #1047 