### PR TITLE
Ensure scheduler startup in Play applications

### DIFF
--- a/core/kamon-core/src/main/scala/kamon/Init.scala
+++ b/core/kamon-core/src/main/scala/kamon/Init.scala
@@ -55,7 +55,25 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     self.moduleRegistry().init()
 
   }
-  
+
+  /**
+    * Initializes Kamon without trying to attach the instrumentation agent from the Kamon Bundle.
+    */
+  def initWithoutAttaching(): Unit = {
+    self.initScheduler()
+    self.loadModules()
+    self.moduleRegistry().init()
+  }
+
+  /**
+    * Initializes Kamon without trying to attach the instrumentation agent from the Kamon Bundle.
+    */
+  def initWithoutAttaching(config: Config): Unit = {
+    self.reconfigure(config)
+    self.initWithoutAttaching()
+  }
+
+
   def stop(): Future[Unit] = {
     self.clearRegistry()
     self.stopScheduler()

--- a/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/GuiceModule.scala
+++ b/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/GuiceModule.scala
@@ -36,8 +36,7 @@ object GuiceModule {
     Logger(classOf[KamonLoader]).info("Reconfiguring Kamon with Play's Config")
     Logger(classOf[KamonLoader]).info(configuration.underlying.getString("play.server.provider"))
     Logger(classOf[KamonLoader]).info(configuration.underlying.getString("kamon.trace.tick-interval"))
-    Kamon.reconfigure(configuration.underlying)
-    Kamon.loadModules()
+    Kamon.initWithoutAttaching(configuration.underlying)
 
     lifecycle.addStopHook { () =>
       Logger(classOf[KamonLoader]).info("Stopping Kamon")


### PR DESCRIPTION
In Kamon 2.3.0 we added an extra initialization step that start Kamon's scheduler, but we didn't update Play's GuiceModule so that those methods get called as well in a Play application. This PR fixes that.

Thanks to @ihostage for bringing this up in our Discord chat.