### PR TITLE
Shade okhttp in kamon-datadog

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -563,11 +563,19 @@ lazy val reporters = (project in file("reporters"))
 
 
 lazy val `kamon-datadog` = (project in file("reporters/kamon-datadog"))
-  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(AssemblyPlugin)
   .settings(
     crossScalaVersions += scala3Version,
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", xs @ _*)  => MergeStrategy.discard
+      case _                              => MergeStrategy.first
+    },
+    assembly / assemblyShadeRules := Seq(
+      ShadeRule.rename("okhttp3.**"                -> "kamon.lib.@1").inAll,
+      ShadeRule.rename("okio.**"                   -> "kamon.lib.@1").inAll
+    ),
     libraryDependencies ++= Seq(
-      okHttp,
+      okHttp % "shaded,provided",
       "com.grack" % "nanojson" % "1.6",
 
       ("com.typesafe.play" %% "play-json" % "2.7.4" % "test").cross(CrossVersion.for3Use2_13),
@@ -576,7 +584,6 @@ lazy val `kamon-datadog` = (project in file("reporters/kamon-datadog"))
       slf4jnop % "test",
       okHttpMockServer % "test"
     )
-
   ).dependsOn(`kamon-core`, `kamon-testkit` % "test")
 
 
@@ -790,6 +797,7 @@ val `kamon-bundle` = (project in file("bundle/kamon-bundle"))
     `kamon-redis` % "shaded",
     `kamon-okhttp` % "shaded",
     `kamon-caffeine` % "shaded",
+    `kamon-datadog` % "shaded",
 )
 
 lazy val `bill-of-materials` = (project in file("bill-of-materials"))

--- a/build.sbt
+++ b/build.sbt
@@ -797,7 +797,6 @@ val `kamon-bundle` = (project in file("bundle/kamon-bundle"))
     `kamon-redis` % "shaded",
     `kamon-okhttp` % "shaded",
     `kamon-caffeine` % "shaded",
-    `kamon-datadog` % "shaded",
 )
 
 lazy val `bill-of-materials` = (project in file("bill-of-materials"))


### PR DESCRIPTION
Hi. I don't know if there's an appetite to shade arbitrary libraries in Kamon instrumentations like this, but it would be really helpful since the okhttp dependency is rather ubiquitous in other libraries (at least the libs I use).

BTW, the link to the "spray commit guidelines" is broken and I'm not sure if it's hosted somewhere else.

https://github.com/kamon-io/Kamon/blob/master/CONTRIBUTING.md?plain=1#L34