### PR TITLE
Kamon-redis: make it work for jedis 2.x

### DIFF
--- a/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
+++ b/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
@@ -20,7 +20,6 @@ import kamon.Kamon
 import kamon.trace.Span
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.asm.Advice
-import redis.clients.jedis.commands.ProtocolCommand
 
 class JedisInstrumentation extends InstrumentationBuilder {
   onType("redis.clients.jedis.Protocol")
@@ -32,13 +31,9 @@ class SendCommandAdvice
 object SendCommandAdvice {
   @Advice.OnMethodEnter(suppress = classOf[Throwable])
   def enter(@Advice.Argument(1) command: Any): Span = {
-    command match {
-      case command: ProtocolCommand =>
-        val spanName = s"redis.command.$command"
-        Kamon.clientSpanBuilder(spanName, "redis.client.jedis")
-          .start()
-      case _ => Span.Empty
-    }
+    val spanName = s"redis.command.$command"
+    Kamon.clientSpanBuilder(spanName, "redis.client.jedis")
+      .start()
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable], suppress = classOf[Throwable])

--- a/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
+++ b/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
@@ -20,10 +20,12 @@ import kamon.Kamon
 import kamon.trace.Span
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.asm.Advice
+import kanela.agent.libs.net.bytebuddy.description.method.MethodDescription
+import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.isPublic
 
 class JedisInstrumentation extends InstrumentationBuilder {
   onType("redis.clients.jedis.Protocol")
-    .advise(method("sendCommand"), classOf[SendCommandAdvice])
+    .advise(method("sendCommand").and(isPublic[MethodDescription]), classOf[SendCommandAdvice])
 }
 
 class SendCommandAdvice

--- a/instrumentation/kamon-redis/src/test/scala/kamon/instrumentation/combined/RedisInstrumentationsSpec.scala
+++ b/instrumentation/kamon-redis/src/test/scala/kamon/instrumentation/combined/RedisInstrumentationsSpec.scala
@@ -53,6 +53,7 @@ class RedisInstrumentationsSpec extends AnyWordSpec
         val span = testSpanReporter().nextSpan().get
         span.operationName shouldBe "redis.command.SET"
         span.kind shouldBe Kind.Client
+        testSpanReporter().spans() shouldBe empty
       }
 
       testSpanReporter().clear()
@@ -62,6 +63,7 @@ class RedisInstrumentationsSpec extends AnyWordSpec
         val span = testSpanReporter().nextSpan().get
         span.operationName shouldBe "redis.command.GET"
         span.kind shouldBe Kind.Client
+        testSpanReporter().spans() shouldBe empty
       }
     }
   }


### PR DESCRIPTION
In Jedis 2.x the type is `redis.clients.jedis.Protocol.Command`
while in Jedis 3.x is `redis.clients.jedis.commands.ProtocolCommand`
(and `redis.clients.jedis.Protocol.Command` is the only subclass of `ProtocolCommand`)

However we dont need to match on it since we just use toString...