### PR TITLE
Make it easier to expose Prometheus metrics on custom endpints

### DIFF
--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -109,14 +109,14 @@ object PrometheusReporter {
   @volatile private var _lastCreatedInstance: Option[PrometheusReporter] = None
 
   /**
-    * Returns the last PrometheusReporter instance created automatically by Kamon. If you are creating more than one
-    * PrometheusReporter instance you might prefer to keep references to those instances programmatically instead of
-    * using this function.
+    * Returns the latest Prometheus scrape data created by the latest PrometheusReporter instance created automatically
+    * by Kamon. If you are creating more than one PrometheusReporter instance you might prefer to keep references to
+    * those instances programmatically and calling `.scrapeData()` directly on them instead of using this function.
     */
-  def instance(): Option[PrometheusReporter] = {
-    _lastCreatedInstance
+  def latestScrapeData(): Option[String] = {
+    _lastCreatedInstance.map(_.scrapeData())
   }
-  
+
 
   class Factory extends ModuleFactory {
     override def create(settings: ModuleFactory.Settings): Module = {


### PR DESCRIPTION
It often happens that people want to expose the Prometheus scrape data on their own HTTP server and the only way to do it so far is to:
1. Prevent Kamon from auto-starting the Prometheus reporter via settings with `kamon.modules.prometheus-reporter.enabled=false`
2. Create an instance of the reporter programmatically and add it to Kamon via `Kamon.addReporter(...)`, and keep a reference to the reporter
3. Use the reference to call `prometheusReporter.scrapeData()` and return that on the HTTP server

It is kind of annoying. Since we know that in most cases there is only one PrometheusReporter instance created automatically by Kamon, this PR ensures that we keep a reference to that instance and expose it's scrape data via `PrometheusReporter.latestScrapeData()`, so that users can skip all the above when they need to.