### PR TITLE
add automatic tail sampling based on latency and error count thresholds

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/LocalTailSamplerSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/LocalTailSamplerSpec.scala
@@ -1,0 +1,141 @@
+/* =========================================================================================
+ * Copyright © 2013-2021 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.trace
+
+import kamon.Kamon
+import kamon.testkit.{InitAndStopKamonAfterAll, Reconfigure, SpanInspection, TestSpanReporter}
+import org.scalactic.TimesOnInt.convertIntToRepeater
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.Instant
+
+
+class LocalTailSamplerSpec extends AnyWordSpec with Matchers with OptionValues with SpanInspection.Syntax with Eventually
+    with SpanSugar with TestSpanReporter with Reconfigure with InitAndStopKamonAfterAll {
+
+
+  "the Kamon local tail sampler" should {
+    "keep traces that match the error count threshold" in {
+      applyConfig(
+        """
+          |kamon.trace {
+          |  sampler = never
+          |  span-reporting-delay = 1 second
+          |
+          |  local-tail-sampler {
+          |    enabled = yes
+          |    error-count-threshold = 3
+          |  }
+          |}
+          |""".stripMargin)
+
+      val parentSpan = Kamon.spanBuilder("parent-with-errors").start()
+
+      5 times {
+        Kamon.spanBuilder("child")
+          .asChildOf(parentSpan)
+          .start()
+          .fail("failing for tests")
+          .finish()
+      }
+
+      parentSpan.finish()
+      var spansFromParentTrace = 0
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.trace.id shouldBe parentSpan.trace.id
+        spansFromParentTrace += 1
+        spansFromParentTrace shouldBe 6 // The parent Span plus five child Spans
+      }
+    }
+
+    "keep traces that match the latency threshold" in {
+      applyConfig(
+        """
+          |kamon.trace {
+          |  sampler = never
+          |  span-reporting-delay = 1 second
+          |
+          |  local-tail-sampler {
+          |    enabled = yes
+          |    latency-threshold = 3 seconds
+          |  }
+          |}
+          |""".stripMargin)
+
+      val startInstant = Instant.now()
+      val parentSpan = Kamon.spanBuilder("parent-with-high-latency").start(startInstant)
+
+      5 times {
+        Kamon.spanBuilder("child")
+          .asChildOf(parentSpan)
+          .start()
+          .finish()
+      }
+
+      parentSpan.finish(startInstant.plusSeconds(5))
+      var spansFromParentTrace = 0
+
+      eventually(timeout(5 seconds)) {
+        val reportedSpan = testSpanReporter().nextSpan().value
+        reportedSpan.trace.id shouldBe parentSpan.trace.id
+        spansFromParentTrace += 1
+        spansFromParentTrace shouldBe 6 // The parent Span plus five child Spans
+      }
+    }
+
+    "not keep traces when tail sampling is disabled, even if they meet the criteria" in {
+      applyConfig(
+        """
+          |kamon.trace {
+          |  sampler = never
+          |  span-reporting-delay = 1 second
+          |
+          |  local-tail-sampler {
+          |    enabled = no
+          |    error-count-threshold= 1
+          |    latency-threshold = 3 seconds
+          |  }
+          |}
+          |""".stripMargin)
+
+      val startInstant = Instant.now()
+      val parentSpan = Kamon.spanBuilder("parent-with-disabled-tail-sampler").start(startInstant)
+
+      5 times {
+        Kamon.spanBuilder("child")
+          .asChildOf(parentSpan)
+          .start()
+          .fail("failure that shouldn't cause the trace to be sampled")
+          .finish()
+      }
+
+      parentSpan.finish(startInstant.plusSeconds(5))
+
+      4 times {
+        val allSpans = testSpanReporter().spans()
+        allSpans.find(_.operationName == parentSpan.operationName()) shouldBe empty
+
+        Thread.sleep(1000) // Should be enough time since all spans would be flushed after 1 second
+      }
+    }
+  }
+}

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -241,6 +241,30 @@ kamon {
       }
     }
 
+    # Automatically change the sampling decision for a trace based on the either the number of errors in a trace, or a
+    # fixed latency threshold. The local tail sampler will only work when the `span-reporting-delay` setting is set to a
+    # value greater than zero.
+    #
+    # Important things to keep in mind:
+    #   - The sampling decision override happens only in the current process. This means that any requests sent to other
+    #     services before the sampling decision override happened might be missing from the resulting trace.
+
+    #   - Try to set `span-reporting-delay` to a value slightly higher than your application's timeout to ensure all the
+    #     local spans related to the trace will still be kept in memory when the sampling override happens
+    #
+    local-tail-sampler {
+
+      # Turns the local tail sampler logic on or off.
+      enabled = no
+
+      # Overrides the sampling decision to "Sample" when a trace contains at least this number of errors when the local
+      # Root Span finishes processing.
+      error-count-threshold = 1
+
+      # Overrides the sampling decision to "Sample" when the local Root Span took more than this time to complete.
+      latency-threshold = 1 second
+    }
+
     # Settings that influence the tags applied to the "span.processing-time" metric for all finished spans with metric
     # tracking enabled.
     #


### PR DESCRIPTION
I originally shared this idea on our [Discord server](https://discord.com/channels/866301994074243132/866652723810140191/909891800938999810) and I'm copy/pasting it here:

> There is an idea that came to mind after chatting with one of our users and related to trying to keep "interesting" traces only.. where "interesting" means that they are either high latency or contain errors. We already got a span-reporting-delay setting (see https://github.com/kamon-io/Kamon/blob/master/core/kamon-core/src/main/resources/reference.conf#L148-L156) a few versions ago that can keep Spans in memory for a few extra seconds, so that users can add a bit of extra logic in their controllers and decide whether to keep or drop a trace. The issue there is that users MUST add some extra logic by hand.
> 
> I would like to add three things here:
> - An error counter on our Trace object. This counter will be incremented when any Span for a trace is marked as failed. 
> - A small piece of logic that runs after Spans finish and figures out whether the trace should be marked for keeping or not. 
> - A configuration format that allows users to set this up with configuration only. Something like saying "try to keep all traces with at least 2 errors, or with latency of 1+ seconds"
> 
> For starters I think we can apply this logic only when Local Root spans are finished, and then we can try to expand this with a bit more functionality, like setting different rules for different operations, or maybe even trying to keep traces for different latency buckets. Many ideas come to mind but I think it would be good to keep it simple and see where it goes 😄 
> 
> This would work really well for people using Kamon for monolith-like applications, but the "forced" traces would be partial if you are doing distributed traces. Still, I think it is better to have a partial trace than no trace at all. If you have the trace and trace ID maybe you can gather some extra data from logs if they are correlated. And, not everybody is doing microservices!

This PR is implementing the idea from above, allowing to force keep traces with a minimum error count or latency threshold. I still need to write some tests and ensure everything works fine. Fortunately the implementation is pretty simple. 