### PR TITLE
The instrumentation should work when using only http1 protocol

### DIFF
--- a/instrumentation/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/FlowOpsMapAsyncAdvice.java
+++ b/instrumentation/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/FlowOpsMapAsyncAdvice.java
@@ -1,0 +1,35 @@
+package kamon.instrumentation.akka.http;
+
+import akka.NotUsed;
+import akka.http.scaladsl.model.HttpRequest;
+import akka.http.scaladsl.model.HttpResponse;
+import akka.stream.scaladsl.Flow;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+
+public class FlowOpsMapAsyncAdvice {
+
+  public static class EndpointInfo {
+    public final String listenInterface;
+    public final int listenPort;
+
+    public EndpointInfo(String listenInterface, int listenPort) {
+      this.listenInterface = listenInterface;
+      this.listenPort = listenPort;
+    }
+  }
+
+  public static ThreadLocal<EndpointInfo> currentEndpoint = new ThreadLocal<>();
+
+  @Advice.OnMethodExit
+  public static void onExit(@Advice.Return(readOnly = false) akka.stream.scaladsl.FlowOps returnedFlow) {
+    EndpointInfo bindAndHandlerEndpoint = currentEndpoint.get();
+
+    if(bindAndHandlerEndpoint != null) {
+      returnedFlow = ServerFlowWrapper.apply(
+          (Flow<HttpRequest, HttpResponse, NotUsed>) returnedFlow,
+          bindAndHandlerEndpoint.listenInterface,
+          bindAndHandlerEndpoint.listenPort
+      );
+    }
+  }
+}

--- a/instrumentation/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/Http2ExtBindAndHandleAdvice.java
+++ b/instrumentation/kamon-akka-http/src/main/java/kamon/instrumentation/akka/http/Http2ExtBindAndHandleAdvice.java
@@ -29,6 +29,12 @@ public class Http2ExtBindAndHandleAdvice {
      @Advice.Argument(1) String iface,
      @Advice.Argument(2) Integer port) {
 
+    FlowOpsMapAsyncAdvice.currentEndpoint.set(new FlowOpsMapAsyncAdvice.EndpointInfo(iface, port));
     handler = new Http2BlueprintInterceptor.HandlerWithEndpoint(iface, port, handler);
+  }
+
+  @Advice.OnMethodExit
+  public static void onExit() {
+    FlowOpsMapAsyncAdvice.currentEndpoint.remove();
   }
 }

--- a/instrumentation/kamon-akka-http/src/main/resources/reference.conf
+++ b/instrumentation/kamon-akka-http/src/main/resources/reference.conf
@@ -245,7 +245,9 @@ kanela.modules {
 
     within = [
       "akka.http.*",
-      "akka.grpc.internal.*"
+      "akka.grpc.internal.*",
+      "akka.stream.scaladsl.Flow",
+      "akka.stream.scaladsl.FlowOps"
     ]
   }
 }

--- a/instrumentation/kamon-akka-http/src/main/scala-2.11/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
+++ b/instrumentation/kamon-akka-http/src/main/scala-2.11/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
@@ -77,6 +77,13 @@ class AkkaHttpServerInstrumentation extends InstrumentationBuilder {
     .intercept(method("redirect"), classOf[ResolveOperationNameOnRouteInterceptor])
     .intercept(method("failWith"), classOf[ResolveOperationNameOnRouteInterceptor])
 
+  /**
+    * Support for HTTP/1 and HTTP/2 at the same time.
+    */
+
+  onType("akka.stream.scaladsl.Flow")
+    .advise(method("mapAsync"), classOf[FlowOpsMapAsyncAdvice])
+
 }
 
 trait HasMatchingContext {

--- a/instrumentation/kamon-akka-http/src/main/scala-2.12/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
+++ b/instrumentation/kamon-akka-http/src/main/scala-2.12/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
@@ -41,7 +41,6 @@ import akka.NotUsed
 import akka.http.scaladsl.server.RouteResult.Rejected
 import akka.stream.scaladsl.Flow
 import kamon.context.Context
-import kanela.agent.libs.net.bytebuddy.asm.Advice
 import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.isPublic
 
 import scala.collection.immutable
@@ -103,6 +102,14 @@ class AkkaHttpServerInstrumentation extends InstrumentationBuilder {
   onType("akka.http.scaladsl.Http2Ext")
     .advise(method("bindAndHandleAsync") and isPublic(), classOf[Http2ExtBindAndHandleAdvice])
 
+
+  /**
+    * Support for HTTP/1 and HTTP/2 at the same time.
+    *
+    */
+
+  onType("akka.stream.scaladsl.FlowOps")
+    .advise(method("mapAsync"), classOf[FlowOpsMapAsyncAdvice])
 }
 
 trait HasMatchingContext {

--- a/instrumentation/kamon-akka-http/src/main/scala-2.13/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
+++ b/instrumentation/kamon-akka-http/src/main/scala-2.13/kamon/instrumentation/akka/http/AkkaHttpServerInstrumentation.scala
@@ -25,7 +25,6 @@ import akka.NotUsed
 import akka.http.scaladsl.server.RouteResult.Rejected
 import akka.stream.scaladsl.Flow
 import kamon.context.Context
-import kanela.agent.libs.net.bytebuddy.asm.Advice
 import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.isPublic
 
 import scala.collection.immutable
@@ -86,6 +85,13 @@ class AkkaHttpServerInstrumentation extends InstrumentationBuilder {
   onType("akka.http.scaladsl.Http2Ext")
     .advise(method("bindAndHandleAsync") and isPublic(), classOf[Http2ExtBindAndHandleAdvice])
 
+  /**
+    * Support for HTTP/1 and HTTP/2 at the same time.
+    *
+    */
+
+  onType("akka.stream.scaladsl.FlowOps")
+    .advise(method("mapAsync"), classOf[FlowOpsMapAsyncAdvice])
 }
 
 trait HasMatchingContext {


### PR DESCRIPTION
This is just a PR to demonstrate a problem that I think I found with the akka-http instrumentation...

AFAICT akka-http with http2 preview support enabled should support both http1/1 and http2. However the instrumentation does not seem to kick in when http1/1 is used...

I will try to explore this in the next few days, but decided to raise the topic before I dig deeper...