### PR TITLE
Add finagle client instrumentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -547,7 +547,7 @@ lazy val `kamon-finagle` = (project in file("instrumentation/kamon-finagle"))
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
       "com.twitter" %% "finagle-http" % "21.12.0" % "provided",
-      "com.twitter" %% "bijection-util" % "0.9.5" % "provided",
+      "com.twitter" %% "bijection-util" % "0.9.5" % "test",
       scalatest % "test",
       logbackClassic % "test",
     )

--- a/build.sbt
+++ b/build.sbt
@@ -539,6 +539,20 @@ lazy val `kamon-caffeine` = (project in file("instrumentation/kamon-caffeine"))
     )
   ).dependsOn(`kamon-core`, `kamon-testkit` % "test")
 
+lazy val `kamon-finagle` = (project in file("instrumentation/kamon-finagle"))
+  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(JavaAgent)
+  .settings(instrumentationSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      kanelaAgent % "provided",
+      "com.twitter" %% "finagle-http" % "21.12.0" % "provided",
+      "com.twitter" %% "bijection-util" % "0.9.5" % "provided",
+      scalatest % "test",
+      logbackClassic % "test",
+    )
+  ).dependsOn(`kamon-core`, `kamon-instrumentation-common`, `kamon-testkit` % "test")
+
 /**
  * Reporters
  */

--- a/build.sbt
+++ b/build.sbt
@@ -544,6 +544,7 @@ lazy val `kamon-finagle` = (project in file("instrumentation/kamon-finagle"))
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
   .settings(
+    crossScalaVersions := Seq("2.12.11", "2.13.1"),
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
       "com.twitter" %% "finagle-http" % "21.12.0" % "provided",
@@ -811,6 +812,7 @@ val `kamon-bundle` = (project in file("bundle/kamon-bundle"))
     `kamon-redis` % "shaded",
     `kamon-okhttp` % "shaded",
     `kamon-caffeine` % "shaded",
+    `kamon-finagle` % "shaded",
 )
 
 lazy val `bill-of-materials` = (project in file("bill-of-materials"))

--- a/build.sbt
+++ b/build.sbt
@@ -549,7 +549,7 @@ lazy val `kamon-finagle` = (project in file("instrumentation/kamon-finagle"))
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
       "com.twitter" %% "finagle-http" % "21.12.0" % "provided",
-      "com.twitter" %% "bijection-util" % "0.9.5" % "test",
+      "com.twitter" %% "bijection-util" % "0.9.7" % "test",
       scalatest % "test",
       logbackClassic % "test",
     )

--- a/build.sbt
+++ b/build.sbt
@@ -140,6 +140,7 @@ val instrumentationProjects = Seq[ProjectReference](
   `kamon-tapir`,
   `kamon-redis`,
   `kamon-caffeine`,
+  `kamon-finagle`,
 )
 
 lazy val instrumentation = (project in file("instrumentation"))

--- a/instrumentation/kamon-finagle/src/main/resources/reference.conf
+++ b/instrumentation/kamon-finagle/src/main/resources/reference.conf
@@ -1,0 +1,2 @@
+kamon.instrumentation.finagle.http.client {
+}

--- a/instrumentation/kamon-finagle/src/main/scala/com/twitter/finagle/http/filter/Export.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/com/twitter/finagle/http/filter/Export.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.twitter.finagle.http.filter
 
 import com.twitter.finagle.Stack

--- a/instrumentation/kamon-finagle/src/main/scala/com/twitter/finagle/http/filter/Export.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/com/twitter/finagle/http/filter/Export.scala
@@ -1,0 +1,8 @@
+package com.twitter.finagle.http.filter
+
+import com.twitter.finagle.Stack
+
+// access workaround for Finagle internals
+object Export {
+  val httpTracingFilterRole: Stack.Role = HttpTracingFilter.Role
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/BroadcastRequestHandler.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/BroadcastRequestHandler.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.context.Contexts

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/BroadcastRequestHandler.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/BroadcastRequestHandler.scala
@@ -1,0 +1,13 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.context.Contexts
+import kamon.instrumentation.finagle.client.FinagleHttpInstrumentation.KamonRequestHandler
+
+private[finagle] object BroadcastRequestHandler {
+  private val RequestHandlerKey: Contexts.local.Key[KamonRequestHandler] = new Contexts.local.Key[KamonRequestHandler]
+
+  def get: Option[KamonRequestHandler] = Contexts.local.get(RequestHandlerKey)
+
+  def let[R](requestHandler: KamonRequestHandler)(f: => R): R =
+    Contexts.local.let(RequestHandlerKey, requestHandler)(f)
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/ClientStatusTraceFilter.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/ClientStatusTraceFilter.scala
@@ -34,7 +34,6 @@ object ClientStatusTraceFilter {
         BroadcastRequestHandler.get.foreach { handler =>
           response match {
             case Return(r) =>
-              Tags.setHttpResponseCategory(handler.span, r.status)
               if (isError(r.status))
                 handler.span.fail(s"Error HTTP response code '${r.status.code}'")
               // processResponse will finish the span

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/ClientStatusTraceFilter.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/ClientStatusTraceFilter.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/ClientStatusTraceFilter.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/ClientStatusTraceFilter.scala
@@ -1,0 +1,39 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.{Service, ServiceFactory, SimpleFilter, Stack}
+import com.twitter.finagle.http.{Response, Status}
+import com.twitter.util.{Return, Throw}
+
+/**
+ * Extract and report response HTTP status codes and exception conditions that may have been raised finishes processing
+ * the active span.
+ */
+object ClientStatusTraceFilter {
+
+  private def isError(status: Status): Boolean = status.code >= 400 && status.code < 600
+
+  def filter[Req, Rep <: Response]: SimpleFilter[Req, Rep] = (request: Req, service: Service[Req, Rep]) => {
+    service(request)
+      .respond { response =>
+        BroadcastRequestHandler.get.foreach { handler =>
+          response match {
+            case Return(r) =>
+              Tags.setHttpResponseCategory(handler.span, r.status)
+              if (isError(r.status))
+                handler.span.fail(s"Error HTTP response code '${r.status.code}'")
+              // processResponse will finish the span
+              FinagleHttpInstrumentation.processResponse(r, handler)
+            case Throw(e) => handler.span.fail(e)
+          }
+        }
+      }
+  }
+}
+
+final class ClientStatusTraceFilter[Req, Rep <: Response] extends Stack.Module0[ServiceFactory[Req, Rep]] {
+  val role: Stack.Role = Stack.Role("StatusTraceFilter")
+  val description: String = "Exposes responses' status to the finagle trace framework"
+
+  override def make(next: ServiceFactory[Req, Rep]): ServiceFactory[Req, Rep] =
+    ClientStatusTraceFilter.filter.andThen(next)
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/FinagleHttpInstrumentation.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/FinagleHttpInstrumentation.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.http.Request

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/FinagleHttpInstrumentation.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/FinagleHttpInstrumentation.scala
@@ -1,0 +1,48 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.{Response => FinagleResponse}
+import kamon.Kamon
+import kamon.instrumentation.http.HttpClientInstrumentation
+import kamon.instrumentation.http.HttpMessage
+
+object FinagleHttpInstrumentation {
+  type KamonRequestHandler = HttpClientInstrumentation.RequestHandler[Request]
+
+  Kamon.onReconfigure(_ => rebuildHttpClientInstrumentation(): Unit)
+
+  @volatile var httpClientInstrumentation: HttpClientInstrumentation = rebuildHttpClientInstrumentation
+
+  private[finagle] def rebuildHttpClientInstrumentation(): HttpClientInstrumentation = {
+    val httpClientConfig = Kamon.config().getConfig("kamon.instrumentation.finagle.http.client")
+    httpClientInstrumentation = HttpClientInstrumentation.from(httpClientConfig, "finagle.http.client.request")
+    httpClientInstrumentation
+  }
+
+  private[finagle] def createHandler(request: Request): KamonRequestHandler = {
+    val builder = new RequestBuilder(request)
+    val context = Kamon.currentContext()
+    httpClientInstrumentation.createHandler(builder, context)
+  }
+
+  private[finagle] def processResponse(response: FinagleResponse, handler: KamonRequestHandler): Unit = {
+    val builder = new Response(response)
+    handler.processResponse(builder)
+  }
+
+  final private class RequestBuilder(request: Request) extends HttpMessage.RequestBuilder[Request] {
+    override def url: String = request.uri
+    override def path: String = request.path
+    override def method: String = request.method.name
+    override def host: String = request.remoteHost
+    override def port: Int = request.remotePort
+    override def build(): Request = request
+    override def write(header: String, value: String): Unit = request.headerMap.put(header, value)
+    override def read(header: String): Option[String] = request.headerMap.get(header)
+    override def readAll(): Map[String, String] = request.headerMap.toMap
+  }
+
+  final private class Response(response: FinagleResponse) extends HttpMessage.Response {
+    override def statusCode: Int = response.statusCode
+  }
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/IdConversionOps.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/IdConversionOps.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.tracing.SpanId

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/IdConversionOps.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/IdConversionOps.scala
@@ -1,0 +1,42 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.tracing.SpanId
+import com.twitter.finagle.tracing.Trace
+import com.twitter.finagle.tracing.TraceId
+import kamon.trace.Span
+import kamon.trace.Trace.SamplingDecision
+
+private[finagle] object IdConversionOps {
+
+  /**
+   * Convert a [[kamon.trace.Span] to a [[com.twitter.finagle.tracing.TraceId]] when possible.
+   * If the [[Span]] has no span ID or trace ID, this method returns a new random TraceId using [[TraceId#nextId]]
+   */
+  final implicit class KamonSpanOps(private val span: kamon.trace.Span) extends AnyVal {
+    def toTraceId: TraceId = toTraceId(None)
+    def toTraceId(parent: Span): TraceId = parent match {
+      case Span.Empty => toTraceId
+      case _ => toTraceId(Some(parent))
+    }
+    private def toTraceId(parent: Option[Span]): TraceId = {
+      if (span.id.isEmpty || span.trace.id.isEmpty) Trace.nextId
+      else {
+        TraceId(
+          traceId = Some(SpanId(span.trace.id.toLongId)),
+          parentId = parent.map(p => SpanId(p.id.toLongId)),
+          spanId = SpanId(span.id.toLongId),
+          sampled = span.trace.samplingDecision match {
+            case SamplingDecision.Sample => Some(true)
+            case SamplingDecision.DoNotSample => Some(false)
+            case _ => None
+          }
+        )
+      }
+    }
+  }
+
+  final implicit class KamonIdOps(private val id: kamon.trace.Identifier) extends AnyVal {
+    def toLongId: Long = BigInt(id.string, 16).toLong
+    def toUnsignedStringId: String = BigInt(id.string, 16).toString
+  }
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/KamonFinagleTracer.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/KamonFinagleTracer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.tracing.Annotation

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/KamonFinagleTracer.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/KamonFinagleTracer.scala
@@ -1,0 +1,50 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.tracing.Annotation
+import com.twitter.finagle.tracing.Record
+import com.twitter.finagle.tracing.TraceId
+import com.twitter.finagle.tracing.Tracer
+import kamon.trace.Span
+import org.slf4j.LoggerFactory
+
+final class KamonFinagleTracer extends Tracer {
+  lazy val log = LoggerFactory.getLogger(getClass)
+
+  override def record(record: Record): Unit =
+    BroadcastRequestHandler.get.fold(sys.error("There must be a BroadcastRequestHandler defined!")) {
+      requestHandler =>
+        recordToSpan(record, requestHandler.span)
+    }
+
+  private def recordToSpan(record: Record, span: Span): Unit = {
+    record.annotation match {
+      case Annotation.Rpc(name) => span.tag(Tags.Keys.ResourceName, name)
+      case Annotation.Message(msg) => span.tag("message", msg)
+      case Annotation.BinaryAnnotation(name, s: String) => span.tag(name, s)
+      case Annotation.BinaryAnnotation(name, i: Int) => span.tag(name, i)
+      case Annotation.BinaryAnnotation(name, i: Long) => span.tag(name, i)
+      case Annotation.BinaryAnnotation(name, b: Boolean) => span.tag(name, b)
+      case Annotation.BinaryAnnotation(name, t: Throwable) => span.fail(name, t)
+      case Annotation.BinaryAnnotation(name, other) => span.tag(name, other.toString)
+      case Annotation.WireSend => Tags.mark(span, "wire/send", record.timestamp)
+      case Annotation.WireRecv => Tags.mark(span, "wire/recv", record.timestamp)
+      case Annotation.WireRecvError(msg) => Tags.fail(span, "wire/recv_error", msg, record.timestamp)
+      case Annotation.ClientAddr(addr) => Tags.setPeer(span, addr)
+      case Annotation.ClientSend => Tags.mark(span, "client/send", record.timestamp)
+      case Annotation.ClientRecv => Tags.mark(span, "client/recv", record.timestamp)
+      case Annotation.ClientRecvError(msg) => Tags.fail(span, s"client/recv_error", msg, record.timestamp)
+      case Annotation.ServerAddr(addr) => Tags.setPeer(span, addr)
+      case Annotation.ServerRecv => Tags.mark(span, "server/recv", record.timestamp)
+      case Annotation.ServerSend => Tags.mark(span, "server/send", record.timestamp)
+      case Annotation.ServerSendError(msg) => Tags.fail(span, "server/send_error", msg, record.timestamp)
+      case Annotation.LocalAddr(addr) =>
+        span
+          .tag("local.hostname", addr.getHostString)
+          .tag("local.port", addr.getPort)
+      case Annotation.ServiceName(name) => span.tag("finagle.service_name", name)
+      case annotation => log.debug(s"dropping unhandled annotation $annotation")
+    }
+  }
+
+  override def sampleTrace(traceId: TraceId): Option[Boolean] = traceId.sampled
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/SpanInitializer.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/SpanInitializer.scala
@@ -64,8 +64,6 @@ final class SpanInitializer[Req <: Request, Res]
       val handler = FinagleHttpInstrumentation.createHandler(req)
       val span = handler.span
 
-      Tags.setHttpClientTags(span)
-
       letTracerAndSpan(span, parent, finagleTracer) {
         BroadcastRequestHandler.let(handler) {
           // finish the span when the Future completes if it's not already finished by processResponse

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/SpanInitializer.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/SpanInitializer.scala
@@ -1,0 +1,62 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.{Filter, ServiceFactory, Stack}
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.tracing.{Trace, Tracer}
+import kamon.Kamon
+import kamon.instrumentation.finagle.client.IdConversionOps.KamonSpanOps
+import kamon.trace.Span
+
+/**
+ * Initialize a new Kamon request handler for each request. The request handler will create a child span for the Finagle
+ * HTTP request, and that span is converted into a Finagle [[com.twitter.finagle.tracing.TraceId]] to integrate with
+ * Finagle's tracing infrastructure.
+ */
+object SpanInitializer {
+  private[kamon] val role = Stack.Role("SpanInitializer")
+  /**
+   * Set a Finagle trace for the duration of the call to `f`.
+   *
+   * This provides Finagle tracing interop by setting the Kamon Request Handler as Finagle's local TraceId.
+   * This works but any subsequent call to Trace.letId(Trace.nextId) will break this link.
+   */
+  private def letTracerAndSpan[R](span: Span, parent: Span, finagleTracer: Tracer)(f: => R): R =
+    Trace.letTracerAndId(finagleTracer, span.toTraceId(parent)) {
+      f
+    }
+}
+
+final class SpanInitializer[Req <: Request, Res]
+    extends Stack.Module1[
+      com.twitter.finagle.param.Tracer,
+      ServiceFactory[Req, Res]
+    ] {
+  import SpanInitializer._
+
+  val role: Stack.Role = SpanInitializer.role
+  val description: String =
+    "Create a new span as a child of the current span context and manages its start/finish lifecycle."
+
+  override def make(
+    finagleTracerParam: com.twitter.finagle.param.Tracer,
+    next: ServiceFactory[Req, Res]
+  ): ServiceFactory[Req, Res] = {
+    val finagleTracer = finagleTracerParam.tracer
+
+    val traceInitializer = Filter.mk[Req, Res, Req, Res] { (req, svc) =>
+      val parent = Kamon.currentSpan()
+      val handler = FinagleHttpInstrumentation.createHandler(req)
+      val span = handler.span
+
+      Tags.setHttpClientTags(span)
+
+      letTracerAndSpan(span, parent, finagleTracer) {
+        BroadcastRequestHandler.let(handler) {
+          // finish the span when the Future completes if it's not already finished by processResponse
+          svc(req).ensure(span.finish())
+        }
+      }
+    }
+    traceInitializer.andThen(next)
+  }
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/SpanInitializer.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/SpanInitializer.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.{Filter, ServiceFactory, Stack}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/Tags.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/Tags.scala
@@ -1,0 +1,63 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.finagle.http.Status
+import com.twitter.util.Time
+import kamon.trace.Span
+
+import java.net.InetSocketAddress
+
+/**
+ * Unique tags and value constants added to Kamon Finagle spans.
+ *
+ * As a general rule metric tags should only be for tags with low cardinality.
+ */
+private[finagle] object Tags {
+
+  object Keys {
+    val ResourceName = "resource.name"
+    val SpanKind = "span.kind"
+    val SpanType = "span.type"
+    val ErrorType = "error.type"
+    val PeerPort = "peer.port"
+    val PeerHostIPV4 = "peer.ipv4"
+    val PeerHostname = "peer.hostname"
+    val HttpStatusCategory = "http.status_category"
+  }
+
+  object Values {
+    val ClientSpanKind = "client"
+    val HttpSpanType = "http"
+  }
+
+  import Keys._
+  import Values._
+
+  def setHttpClientTags(span: Span): Unit = {
+    span.tag(SpanKind, ClientSpanKind)
+    span.tag(SpanType, HttpSpanType)
+  }
+
+  def setHttpResponseCategory(span: Span, status: Status): Unit =
+    span.tagMetrics(HttpStatusCategory, categorize(status))
+
+  private def categorize(status: Status): String =
+    if (status.code >= 100 && status.code < 200) "1xx"
+    else if (status.code >= 200 && status.code < 300) "2xx"
+    else if (status.code >= 300 && status.code < 400) "3xx"
+    else if (status.code >= 400 && status.code < 500) "4xx"
+    else if (status.code >= 500 && status.code < 600) "5xx"
+    else "unknown"
+
+  def mark(span: Span, event: String, time: Time): Unit = span.mark(event, time.toInstant)
+
+  def fail(span: Span, event: String, msg: String, time: Time): Unit = {
+    span.tag(Tags.Keys.ErrorType, event)
+    span.fail(msg)
+  }
+
+  def setPeer(span: Span, addr: InetSocketAddress): Unit = {
+    span.tag(Tags.Keys.PeerPort, addr.getPort)
+    span.tag(Tags.Keys.PeerHostIPV4, addr.getAddress.getHostAddress)
+    span.tag(Tags.Keys.PeerHostname, addr.getHostString)
+  }
+}

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/Tags.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/Tags.scala
@@ -16,7 +16,6 @@
 
 package kamon.instrumentation.finagle.client
 
-import com.twitter.finagle.http.Status
 import com.twitter.util.Time
 import kamon.trace.Span
 
@@ -24,50 +23,20 @@ import java.net.InetSocketAddress
 
 /**
  * Unique tags and value constants added to Kamon Finagle spans.
- *
- * As a general rule metric tags should only be for tags with low cardinality.
  */
 private[finagle] object Tags {
 
   object Keys {
     val ResourceName = "resource.name"
-    val SpanKind = "span.kind"
-    val SpanType = "span.type"
-    val ErrorType = "error.type"
     val PeerPort = "peer.port"
     val PeerHostIPV4 = "peer.ipv4"
     val PeerHostname = "peer.hostname"
-    val HttpStatusCategory = "http.status_category"
   }
-
-  object Values {
-    val ClientSpanKind = "client"
-    val HttpSpanType = "http"
-  }
-
-  import Keys._
-  import Values._
-
-  def setHttpClientTags(span: Span): Unit = {
-    span.tag(SpanKind, ClientSpanKind)
-    span.tag(SpanType, HttpSpanType)
-  }
-
-  def setHttpResponseCategory(span: Span, status: Status): Unit =
-    span.tagMetrics(HttpStatusCategory, categorize(status))
-
-  private def categorize(status: Status): String =
-    if (status.code >= 100 && status.code < 200) "1xx"
-    else if (status.code >= 200 && status.code < 300) "2xx"
-    else if (status.code >= 300 && status.code < 400) "3xx"
-    else if (status.code >= 400 && status.code < 500) "4xx"
-    else if (status.code >= 500 && status.code < 600) "5xx"
-    else "unknown"
 
   def mark(span: Span, event: String, time: Time): Unit = span.mark(event, time.toInstant)
 
   def fail(span: Span, event: String, msg: String, time: Time): Unit = {
-    span.tag(Tags.Keys.ErrorType, event)
+    mark(span, event, time)
     span.fail(msg)
   }
 

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/Tags.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/Tags.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle.client
 
 import com.twitter.finagle.http.Status

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/package.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/package.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package kamon.instrumentation.finagle
 
 import com.twitter.finagle.Http

--- a/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/package.scala
+++ b/instrumentation/kamon-finagle/src/main/scala/kamon/instrumentation/finagle/client/package.scala
@@ -1,0 +1,23 @@
+package kamon.instrumentation.finagle
+
+import com.twitter.finagle.Http
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.Response
+import com.twitter.finagle.http.filter.Export
+import com.twitter.finagle.tracing.TraceInitializerFilter
+
+package object client {
+  implicit final class HttpClientOps(private val client: Http.Client) extends AnyVal {
+    def withKamonTracing: Http.Client = {
+      client
+        .withTracer(new KamonFinagleTracer)
+        .withStack { stack =>
+          stack.replace(TraceInitializerFilter.role, new SpanInitializer[Request, Response])
+            .insertAfter(Export.httpTracingFilterRole, new ClientStatusTraceFilter[Request, Response]())
+            // HTTP request tags (http.method, url) are added by Kamon `HttpClientInstrumentation`
+            .remove(Export.httpTracingFilterRole)
+
+        }
+    }
+  }
+}

--- a/instrumentation/kamon-finagle/src/test/scala/kamon/instrumentation/finagle/client/HttpClientOpsSpec.scala
+++ b/instrumentation/kamon-finagle/src/test/scala/kamon/instrumentation/finagle/client/HttpClientOpsSpec.scala
@@ -1,0 +1,170 @@
+package kamon.instrumentation.finagle.client
+
+import com.twitter.bijection.Conversion.asMethod
+import com.twitter.bijection.twitter_util.UtilBijections.twitter2ScalaFuture
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.finagle.tracing.TraceInitializerFilter
+import com.twitter.finagle.{Filter, Http, ListeningServer, Service}
+import com.twitter.{util => twitterutil}
+import com.typesafe.config.Config
+import kamon.Kamon
+import kamon.instrumentation.http.HttpMessage
+import kamon.tag.Lookups
+import kamon.testkit.{InitAndStopKamonAfterAll, Reconfigure}
+import kamon.trace.Span
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.net.InetSocketAddress
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
+
+class HttpClientOpsSpec extends AnyWordSpecLike with Matchers with Reconfigure with InitAndStopKamonAfterAll with BeforeAndAfterAll {
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    applyConfig(HttpClientOpsSpec.Config)
+  }
+
+  "The Finagle Instrumentation" when {
+    "tracing a successful request" should {
+      lazy val (spans, request, serverRequest) = HttpClientOpsSpec.awaitRequest("/ok", 5.seconds)
+      lazy val span = spans.head
+
+      "initialize a span for each request" in {
+        spans should have size 1
+        span.operationName shouldBe "/ok" // defined by overridden name-generator
+        span.metricTags.get(Lookups.plainBoolean("error")) shouldBe false
+        span.metricTags.get(Lookups.plain("component")) shouldBe "finagle.http.client.request"
+        span.metricTags.get(Lookups.plain("span.kind")) shouldBe "client"
+        span.tags.get(Lookups.plain("span.type")) shouldBe "http"
+      }
+
+      "set request span tags" in {
+        span.metricTags.get(Lookups.plain("http.method")) shouldBe "GET"
+        span.tags.get(Lookups.plain("http.url")) shouldBe "/ok"
+      }
+
+      "set response span tags" in {
+        span.metricTags.get(Lookups.plainLong("http.status_code")) shouldBe 200
+        span.metricTags.get(Lookups.plain("http.status_category")) shouldBe "2xx"
+      }
+
+      "add trace propagation headers to the request" in {
+        val headers = request.headerMap
+        headers.get("X-B3-TraceId") should not be empty
+        headers.get("X-B3-SpanId") should not be empty
+        headers("X-B3-Sampled").toInt shouldBe 1
+      }
+
+      "receive trace propagation headers on server side" in {
+        request.headerMap("X-B3-TraceId") shouldBe serverRequest.headerMap("X-B3-TraceId")
+        request.headerMap("X-B3-SpanId") shouldBe serverRequest.headerMap("X-B3-SpanId")
+        request.headerMap("X-B3-Sampled") shouldBe serverRequest.headerMap("X-B3-Sampled")
+      }
+    }
+    "tracing a failed response" should {
+      lazy val (spans, _, _) = HttpClientOpsSpec.awaitRequest("/oops", 5.seconds)
+      lazy val span = spans.head
+
+      "set response span tags" in {
+        span.metricTags.get(Lookups.plainLong("http.status_code")) shouldBe 400
+        span.metricTags.get(Lookups.plain("http.status_category")) shouldBe "4xx"
+      }
+
+      "set error metric tags" in {
+        span.hasError shouldBe true
+        span.metricTags.get(Lookups.plainBoolean("error")) shouldBe true
+        span.tags.get(Lookups.plain("error.message")) shouldBe "Error HTTP response code '400'"
+      }
+    }
+  }
+}
+
+object HttpClientOpsSpec {
+  private val Config =
+    s"""
+       |kamon {
+       |  trace {
+       |    tick-interval = 1 millisecond
+       |    sampler = "always"
+       |  }
+       |  propagation.http.default.tags.entries.outgoing.span = "b3"
+       |  instrumentation.http-client.default.tracing.operations.name-generator = "${PathOperationNameGenerator.getClass.getName}"
+       |}""".stripMargin
+
+  private class MockSpanReporter extends kamon.module.SpanReporter {
+    val spansReported: Promise[Seq[Span.Finished]] = Promise[Seq[Span.Finished]]
+    override def stop(): Unit = {}
+    override def reconfigure(config: Config): Unit = {}
+    override def reportSpans(spans: Seq[Span.Finished]): Unit = if (spans.nonEmpty) spansReported.success(spans)
+  }
+
+  private object PathOperationNameGenerator extends kamon.instrumentation.http.HttpOperationNameGenerator {
+    override def name(request: HttpMessage.Request): Option[String] = Some(request.path)
+  }
+
+  private class MockFinagleServer {
+    val requestReceived: Promise[Request] = Promise[Request]
+    val server: ListeningServer = Http.server
+      // TraceInitializerFilter will clear b3 headers before we can check them in the test.
+      .withStack(_.remove(TraceInitializerFilter.role))
+      .serve(
+      ":*",
+      new Service[Request, Response] {
+        def apply(request: Request): twitterutil.Future[Response] = {
+          requestReceived.success(request)
+          request.path match {
+            case "/ok" => twitterutil.Future.value(Response())
+            case "/oops" => twitterutil.Future.value(Response().statusCode(400))
+          }
+        }
+      }
+    )
+    val port: Int = server.boundAddress.asInstanceOf[InetSocketAddress].getPort
+    def close(): Future[Unit] = server.close().as[Future[Unit]]
+  }
+
+  private class FinagleClient(localServicePort: Int) {
+    val requestHandled: Promise[Request] = Promise[Request]
+    val service: Service[Request, Response] = {
+      val testFilter = Filter.mk[Request, Response, Request, Response] { (req, svc) =>
+        requestHandled.success(req)
+        svc(req)
+      }
+
+      val svc = Http.client
+        .withKamonTracing // this is the thing from HttpClientOps under test
+        .newService("localhost:" + localServicePort, "test_client")
+
+      testFilter.andThen(svc)
+    }
+    def makeRequest(path: String): Future[Response] = service(Request(path)).as[Future[Response]]
+    def close(): Future[Unit] = service.close().as[Future[Unit]]
+  }
+
+  private def awaitRequest(path: String, timeout: FiniteDuration): (Seq[Span.Finished], Request, Request) = {
+    val reporter = new MockSpanReporter()
+    val registration = Kamon.addReporter("mock-span-reporter", reporter)
+    val server = new MockFinagleServer
+    val client = new FinagleClient(server.port)
+
+    import scala.concurrent.ExecutionContext.Implicits.global
+    try {
+      val f = for {
+        _ <- client.makeRequest(path)
+        request <- client.requestHandled.future
+        serverRequest <- server.requestReceived.future
+        span <- reporter.spansReported.future
+      } yield (span, request, serverRequest)
+      Await.result(f, timeout)
+    } finally {
+      registration.cancel()
+      val close = Future.sequence(Seq(client.close(), server.close()))
+      Await.result(close, timeout)
+    }
+  }
+}
+
+

--- a/instrumentation/kamon-finagle/src/test/scala/kamon/instrumentation/finagle/client/HttpClientOpsSpec.scala
+++ b/instrumentation/kamon-finagle/src/test/scala/kamon/instrumentation/finagle/client/HttpClientOpsSpec.scala
@@ -38,7 +38,6 @@ class HttpClientOpsSpec extends AnyWordSpecLike with Matchers with Reconfigure w
         span.metricTags.get(Lookups.plainBoolean("error")) shouldBe false
         span.metricTags.get(Lookups.plain("component")) shouldBe "finagle.http.client.request"
         span.metricTags.get(Lookups.plain("span.kind")) shouldBe "client"
-        span.tags.get(Lookups.plain("span.type")) shouldBe "http"
       }
 
       "set request span tags" in {
@@ -48,7 +47,10 @@ class HttpClientOpsSpec extends AnyWordSpecLike with Matchers with Reconfigure w
 
       "set response span tags" in {
         span.metricTags.get(Lookups.plainLong("http.status_code")) shouldBe 200
-        span.metricTags.get(Lookups.plain("http.status_category")) shouldBe "2xx"
+      }
+
+      "set marks for standard finagle annotations" in {
+        span.marks.map(_.key) should contain allOf("wire/recv", "wire/send", "client/send")
       }
 
       "add trace propagation headers to the request" in {
@@ -70,7 +72,6 @@ class HttpClientOpsSpec extends AnyWordSpecLike with Matchers with Reconfigure w
 
       "set response span tags" in {
         span.metricTags.get(Lookups.plainLong("http.status_code")) shouldBe 400
-        span.metricTags.get(Lookups.plain("http.status_category")) shouldBe "4xx"
       }
 
       "set error metric tags" in {

--- a/instrumentation/kamon-finagle/src/test/scala/kamon/instrumentation/finagle/client/IdConversionOpsSpec.scala
+++ b/instrumentation/kamon-finagle/src/test/scala/kamon/instrumentation/finagle/client/IdConversionOpsSpec.scala
@@ -1,0 +1,46 @@
+package kamon.instrumentation.finagle.client
+
+import kamon.trace.Identifier
+import kamon.trace.Span
+import kamon.trace.Trace
+import kamon.trace.Trace.SamplingDecision
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+import java.lang.{Long => JLong}
+
+class IdConversionOpsSpec extends AnyWordSpecLike with Matchers {
+  "IdConversion" should {
+    val traceId = "3708efcc740f856f"
+    val parentId = "a8cb127dad2883c8"
+    val childId = "7362a75ba1f53484"
+
+    "converts a base 16 id to base 10 unsigned long" in {
+      val id = kamon.trace.Identifier(traceId, traceId.getBytes)
+      IdConversionOps.KamonIdOps(id).toLongId shouldBe JLong.parseUnsignedLong("3965683133299262831")
+    }
+
+    "converts a Kamon Span to a Finagle TraceId" in {
+      val parent = Span.Remote(
+        id = Identifier(parentId, parentId.getBytes),
+        parentId = Identifier.Empty,
+        trace = Trace(
+          id = Identifier(traceId, traceId.getBytes),
+          samplingDecision = SamplingDecision.Sample
+        )
+      )
+
+      val child = Span.Remote(
+        id = Identifier(childId, childId.getBytes),
+        parentId = parent.id,
+        trace = parent.trace
+      )
+
+      val finagleTraceId = IdConversionOps.KamonSpanOps(child).toTraceId(parent)
+
+      BigInt(finagleTraceId.spanId.toLong) shouldBe JLong.parseUnsignedLong("8314391874080420996")
+      BigInt(finagleTraceId.parentId.toLong) shouldBe JLong.parseUnsignedLong("12162835549629481928")
+      BigInt(finagleTraceId.traceId.toLong) shouldBe JLong.parseUnsignedLong("3965683133299262831")
+    }
+  }
+}


### PR DESCRIPTION
Instrumentation to manage Kamon spans for finagle client request & response lifecycle.

Relates to #238