### PR TITLE
make adding the db.statement tag configurable in jdbc calls

### DIFF
--- a/instrumentation/kamon-jdbc/src/main/resources/reference.conf
+++ b/instrumentation/kamon-jdbc/src/main/resources/reference.conf
@@ -6,7 +6,13 @@ kamon.instrumentation.jdbc {
 
   # Parses sql to generate nicer operation name
   # Might have a negative performance impact
-  parse-sql-for-operation-name = false
+  parse-sql-for-operation-name = no
+
+  # Decides when to include the db.statement tag in Spans. The possible values are:
+  #   - always: always adds the db.statement tag, regardless of the statement type
+  #   - prepared: adds the db.statement tag on prepared statements only
+  #   - never: completely disables adding the db.statement tag to JDBC spans
+  add-db-statement-as-span-tag = always
 
   # Defines additional instrumentation actions to be taken when Slow or Failed JDBC statements are detected.
   #

--- a/instrumentation/kamon-jdbc/src/test/scala/kamon/instrumentation/jdbc/SlickInstrumentationSpec.scala
+++ b/instrumentation/kamon-jdbc/src/test/scala/kamon/instrumentation/jdbc/SlickInstrumentationSpec.scala
@@ -37,6 +37,8 @@ class SlickInstrumentationSpec extends AnyWordSpec with Matchers with Eventually
 
   "the Slick instrumentation" should {
     "propagate the current Context to the AsyncExecutor on Slick" in {
+      applyConfig("kamon.instrumentation.jdbc.add-db-statement-as-span-tag=always")
+      
       val db = setup(Database.forConfig("slick-h2"))
       val parent = Kamon.spanBuilder("parent").start()
 


### PR DESCRIPTION
This PR makes it possible to decide whether the db.statement tag is going to be added to spans created by the JDBC instrumentation. There are three possible settings:
  - **always**: (default) will always add the `db.statement` tag to spans
  - **prepared**: will only add the the `db.statement` tag when the traced execution was made with a PreparedStatement, which should ensure no placeholder values are leaked to the tracing backend
  - **never**: completely disables adding the `db.statement` tag to spans
