### PR TITLE
Http protobuf for otel take 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,6 +723,7 @@ lazy val `kamon-opentelemetry` = (project in file("reporters/kamon-opentelemetry
     libraryDependencies ++= Seq(
       "io.opentelemetry" % "opentelemetry-proto" % "0.17.1",
       "io.grpc" % "grpc-netty" % "1.36.0",
+      okHttp,
 
       scalatest % "test",
       logbackClassic % "test"

--- a/reporters/kamon-opentelemetry/src/main/resources/reference.conf
+++ b/reporters/kamon-opentelemetry/src/main/resources/reference.conf
@@ -2,7 +2,7 @@
 # kamon-otlp reference configuration       #
 # ======================================== #
 
-kamon.otel.trace {
+kamon.otel {
   # Hostname and port where the OTLP Server is running
   host = "localhost"
   port = 4317
@@ -14,24 +14,60 @@ kamon.otel.trace {
   # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
   endpoint = ${kamon.otel.trace.protocol}"://"${kamon.otel.trace.host}":"${kamon.otel.trace.port}
   endpoint = ${?OTEL_EXPORTER_OTLP_ENDPOINT}
-  endpoint = ${?OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
 
-  # Enable or disable including tags from kamon.environment.tags as resource labels in the exported trace
-  # Any keys containing a hyphen (-) will be converted to a dot (.) as that is the standard.
-  # e.g. service-version becomes service.version
-  # reference: https://github.com/kamon-io/Kamon/blob/master/core/kamon-core/src/main/resources/reference.conf#L23
+  # Supports empty string or gzip
+  compression = ""
+  compression = ${?OTEL_EXPORTER_OTLP_COMPRESSION}
+
+  # Supports comma-separated pairs (i.e "api-key=supersecret,data-type=application-traces")
+  headers = ""
+  headers = ${?OTEL_EXPORTER_OTLP_HEADERS}
+
+  timeout = 10s
+  timeout = ${?OTEL_EXPORTER_OTLP_TIMEOUT}
+
+  # Supports grpc and http/protobuf
+  otelProtocol = "grpc"
+  otelProtocol = ${?OTEL_EXPORTER_OTLP_PROTOCOL}
+
   include-environment-tags = no
+  trace {
+      host = ${kamon.otel.host}
+      port = ${kamon.otel.port}
+      protocol = ${kamon.otel.protocol}
 
-  # Arbitrary key-value pairs that further identify the environment where this service instance is running.
-  # These are added as KeyValue labels to the Resource part of the exported traces
-  # Requires 'include-environment-tags' to be set to 'yes'
-  #
-  # kamon.environment.tags {
-  #   service-version = "x.x.x"
-  #   service-namespace = "ns"
-  #   service-instance.id = "xxx-yyy"
-  # }
+      endpoint = ${kamon.otel.endpoint}"/v1/trace"
+      endpoint = ${?OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
+
+      compression = ${kamon.otel.compression}
+      compression = ${?OTEL_EXPORTER_OTLP_TRACES_COMPRESSION}
+
+      headers = ${kamon.otel.headers}
+      headers = ${?OTEL_EXPORTER_OTLP_TRACES_HEADERS}
+
+      timeout = ${kamon.otel.timeout}
+      timeout = ${?OTEL_EXPORTER_OTLP_TRACES_TIMEOUT}
+
+      otelProtocol = ${kamon.otel.otelProtocol}
+      otelProtocol = ${?OTEL_EXPORTER_OTLP_TRACES_PROTOCOL}
+
+      # Enable or disable including tags from kamon.environment.tags as resource labels in the exported trace
+      # Any keys containing a hyphen (-) will be converted to a dot (.) as that is the standard.
+      # e.g. service-version becomes service.version
+      # reference: https://github.com/kamon-io/Kamon/blob/master/core/kamon-core/src/main/resources/reference.conf#L23
+      include-environment-tags = ${kamon.otel.include-environment-tags}
+  }
 }
+
+# Arbitrary key-value pairs that further identify the environment where this service instance is running.
+# These are added as KeyValue labels to the Resource part of the exported traces
+# Requires 'include-environment-tags' to be set to 'yes'
+#
+# kamon.environment.tags {
+#   service-version = "x.x.x"
+#   service-namespace = "ns"
+#   service-instance.id = "xxx-yyy"
+# }
 
 kamon.modules {
   otel-trace-reporter {

--- a/reporters/kamon-opentelemetry/src/main/resources/reference.conf
+++ b/reporters/kamon-opentelemetry/src/main/resources/reference.conf
@@ -36,8 +36,8 @@ kamon.otel {
       port = ${kamon.otel.port}
       protocol = ${kamon.otel.protocol}
 
-      endpoint = ${kamon.otel.endpoint}"/v1/trace"
-      endpoint = ${?OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
+      endpoint = ${kamon.otel.endpoint}
+      fullEndpoint = ${?OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
 
       compression = ${kamon.otel.compression}
       compression = ${?OTEL_EXPORTER_OTLP_TRACES_COMPRESSION}

--- a/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/TraceService.scala
+++ b/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/TraceService.scala
@@ -16,16 +16,24 @@
 package kamon.otel
 
 import com.google.common.util.concurrent.{FutureCallback, Futures}
+import com.google.protobuf.CodedInputStream
 import com.typesafe.config.Config
-import io.grpc.{ManagedChannel, ManagedChannelBuilder}
+import io.grpc.{ManagedChannel, ManagedChannelBuilder, Metadata}
+import io.grpc.stub.MetadataUtils
 import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc.TraceServiceFutureStub
 import io.opentelemetry.proto.collector.trace.v1.{ExportTraceServiceRequest, ExportTraceServiceResponse, TraceServiceGrpc}
+import okhttp3.{Call, Callback, Dispatcher, MediaType, OkHttpClient, Request, RequestBody, Response, ResponseBody}
+import okio.{BufferedSink, GzipSink, Okio}
 import org.slf4j.LoggerFactory
 
-import java.io.Closeable
+import java.io.{Closeable, IOException}
 import java.net.URL
-import java.util.concurrent.{Executors, ThreadFactory, TimeUnit}
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Executors, SynchronousQueue, ThreadFactory, ThreadPoolExecutor, TimeUnit}
+
 import scala.concurrent.{Future, Promise}
+import scala.util.control.NonFatal
 
 /**
  * Service for exporting OpenTelemetry traces
@@ -48,27 +56,50 @@ private[otel] object GrpcTraceService {
    * @param config
    * @return
    */
-  def apply(config: Config): GrpcTraceService = {
+  def apply(config: Config): TraceService = {
     val otelExporterConfig = config.getConfig("kamon.otel.trace")
-    val protocol = otelExporterConfig.getString("protocol")
+    val schema = otelExporterConfig.getString("protocol")
     val endpoint = otelExporterConfig.getString("endpoint")
+    val compression = otelExporterConfig.getString("compression") match {
+      case "gzip" => true
+      case x =>
+        if (x != "") logger.warn(s"unrecognised compression $x. Defaulting to no compression")
+        false
+    }
+    val protocol = otelExporterConfig.getString("otelProtocol")
+    val headers = otelExporterConfig.getString("headers").split(',').filter(_.nonEmpty).map(_.split("=", 2)).map {
+      case Array(k) => k -> ""
+      case Array(k, v) => k -> v
+    }.toSeq
+    val timeoutNanos = otelExporterConfig.getDuration("timeout").toNanos
     val url = new URL(endpoint)
 
     //inspiration from https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
 
     logger.info(s"Configured endpoint for OpenTelemetry trace reporting [${url.getHost}:${url.getPort}]")
-    //TODO : possibly add support for trustedCertificates in case TLS is to be enabled
-    val builder = ManagedChannelBuilder.forAddress(url.getHost, url.getPort)
-    if (protocol.equals("https"))
-      builder.useTransportSecurity()
-    else
-      builder.usePlaintext()
 
-    val channel = builder.build()
-    new GrpcTraceService(
-      channel,
-      TraceServiceGrpc.newFutureStub(channel)
-    )
+    protocol match {
+      case "http/protobuf" => new HTTPTraceService(url, compression, headers, timeoutNanos)
+      case x =>
+        if (x != "grpc") logger.warn(s"Unrecognised opentelemetry schema type $x. Defaulting to grpc")
+        //TODO : possibly add support for trustedCertificates in case TLS is to be enabled
+        val builder = ManagedChannelBuilder.forAddress(url.getHost, url.getPort)
+        val metadata: Option[Metadata] = if (headers.isEmpty) None else {
+          val m = new Metadata()
+          headers.foreach{ case (k, v) => m.put(Metadata.Key.of(k, Metadata.ASCII_STRING_MARSHALLER), v) }
+          Some(m)
+        }
+        metadata.foreach(m => builder.intercept(MetadataUtils.newAttachHeadersInterceptor(m)))
+        if (schema.equals("https"))
+          builder.useTransportSecurity()
+        else
+          builder.usePlaintext()
+
+        val channel = builder.build()
+        val stub = TraceServiceGrpc.newFutureStub(channel)
+        val stubWithCodec = if (compression) stub.withCompression("gzip") else stub
+        new GrpcTraceService(channel, stubWithCodec)
+    }
   }
 }
 
@@ -109,4 +140,93 @@ private[otel] class GrpcTraceService(channel:ManagedChannel, traceService:TraceS
       override def onFailure(t: Throwable): Unit = promise.failure(t)
     }
 
+}
+
+private[otel] class HTTPTraceService(url: URL, compressionEnabled: Boolean, headers: Seq[(String, String)], timeoutNanos: Long) extends TraceService {
+  // Private utils copied from the opentelemetry-exporter-otlp-http-trace implementation
+  private val daemonThreadFactory: ThreadFactory = new ThreadFactory {
+    private val counter = new AtomicInteger
+    private val delegate = Executors.defaultThreadFactory
+    override def newThread(r: Runnable): Thread = {
+      val t: Thread = delegate.newThread(r)
+      try {
+        t.setDaemon(true)
+        t.setName("okhttp-dispatch-" + counter.incrementAndGet)
+      } catch { case _: SecurityException => }
+      t
+    }
+  }
+  private val dispatcher: Dispatcher = new Dispatcher(new ThreadPoolExecutor(
+    0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS, new SynchronousQueue[Runnable], daemonThreadFactory
+  ))
+  private val protoMediaType: MediaType = MediaType.parse("application/x-protobuf")
+  private def gzipRequestBody(requestBody: RequestBody): RequestBody = new RequestBody {
+    override def contentType: MediaType = requestBody.contentType
+    override def contentLength: Long = -1
+
+    override def writeTo(bufferedSink: BufferedSink): Unit = {
+      val gzipSink = Okio.buffer(new GzipSink(bufferedSink))
+      requestBody.writeTo(gzipSink)
+      gzipSink.close()
+    }
+  }
+  def getStatusMessage(serializedStatus: Array[Byte]): String = {
+    val input = CodedInputStream.newInstance(serializedStatus)
+    while (true) {
+      val tag = input.readTag
+      input.readTag match {
+        // Serialized Status proto had no message, proto always defaults to empty string when not found.
+        case 0 => return ""
+        case 18 => return input.readStringRequireUtf8
+        case _ => input.skipField(tag)
+      }
+    }
+    throw new Error("Unreachable")
+  }
+  private def extractErrorStatus(response: Response, responseBody: Option[ResponseBody]): String = responseBody match {
+    case None => "Response body missing, HTTP status message: " + response.message
+    case Some(responseBody) =>
+    try getStatusMessage(responseBody.bytes())
+    catch {
+      case _: IOException =>
+        "Unable to parse response body, HTTP status message: " + response.message
+    }
+  }
+
+  // build delegate
+  val clientBuilder: OkHttpClient.Builder =
+    new OkHttpClient.Builder().dispatcher(dispatcher).callTimeout(Duration ofNanos timeoutNanos)
+  val delegate: OkHttpClient = clientBuilder.build()
+
+  // export method
+  override def exportSpans(request: ExportTraceServiceRequest): Future[ExportTraceServiceResponse] = {
+    val requestBuilder = new Request.Builder().url(url)
+    headers.foreach{ case (k, v) => requestBuilder.addHeader(k, v) }
+    val requestBody = RequestBody.create(protoMediaType, request.toByteArray)
+    if (compressionEnabled) {
+      requestBuilder.addHeader("Content-Encoding", "gzip")
+      requestBuilder.post(gzipRequestBody(requestBody))
+    }
+    else requestBuilder.post(requestBody)
+    val httpRequest: Request = requestBuilder.build()
+    val responsePromise = Promise[ExportTraceServiceResponse]
+    val callback: Callback = new Callback {
+      override def onFailure(call: Call, e: IOException): Unit = responsePromise.failure(e)
+      override def onResponse(call: Call, response: Response): Unit = {
+        if (response.isSuccessful) responsePromise.success(ExportTraceServiceResponse.getDefaultInstance)
+        else {
+          val errMsg = extractErrorStatus(response, Option(response.body()))
+          responsePromise.failure(new RuntimeException(errMsg))
+        }
+      }
+    }
+    delegate.newCall(httpRequest).enqueue(callback)
+    responsePromise.future
+  }
+
+  override def close(): Unit = {
+    delegate.dispatcher().executorService().shutdown()
+    delegate.connectionPool().evictAll()
+    try Option(delegate.cache()).foreach(_.close()) catch { case NonFatal(_) => }
+  }
 }

--- a/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/TraceService.scala
+++ b/reporters/kamon-opentelemetry/src/main/scala/kamon/otel/TraceService.scala
@@ -76,7 +76,7 @@ private[otel] object GrpcTraceService {
 
     //inspiration from https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/otlp/trace/src/main/java/io/opentelemetry/exporter/otlp/trace/OtlpGrpcSpanExporterBuilder.java
 
-    logger.info(s"Configured endpoint for OpenTelemetry trace reporting [${url.getHost}:${url.getPort}]")
+    logger.info(s"Configured endpoint for OpenTelemetry trace reporting [${url.getHost}:${url.getPort}] using $protocol protocol")
 
     protocol match {
       case "http/protobuf" => new HTTPTraceService(url, compression, headers, timeoutNanos)


### PR DESCRIPTION
Alternative implementation of opentelemetry http/protobuf reporting; includes more of the standard configuration options from https://opentelemetry.io/docs/reference/specification/protocol/exporter/#specifying-headers-via-environment-variables than were previously supported
