### PR TITLE
add token authentication to the InfluxDB reporter, fixes #1107

### DIFF
--- a/reporters/kamon-influxdb/src/main/resources/reference.conf
+++ b/reporters/kamon-influxdb/src/main/resources/reference.conf
@@ -24,13 +24,19 @@ kamon {
     # [ns,u,µ,ms,s]
     precision = "s"
 
-  # Client authentication credentials for connection to the InfluxDB server. There is no authentication by default,
-  # if you wish to enable it, add an authentication section to your configuration file. E.g.:
-  #
-  #   authentication {
-  #     user = "user"
-  #     password = "password"
-  #   }
+    # Client authentication credentials for connection to the InfluxDB server. There is no authentication by default.
+    # You can enable authentication by adding an authentication section to your configuration file with either token or
+    # user/password settings in it. If you specify both, token authentication will be used.
+    #
+    #   authentication {
+    #     token = "your_api_token"
+    #
+    #     // OR
+    #
+    #     user = "user"
+    #     password = "password"
+    #
+    #   }
 
     # Allow including environment information as tags on all reported metrics.
     environment-tags {


### PR DESCRIPTION
Allows using [API token authentication](https://docs.influxdata.com/influxdb/v2.1/api-guide/api_intro/#authentication) when connecting to the InfluxDB server.