### PR TITLE
add error.type to traces. Includes feature flag (on by default)

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
@@ -270,24 +270,37 @@ class TracerSpec extends AnyWordSpec with Matchers with SpanInspection.Syntax wi
         .fail("byMessageAndException", new RuntimeException("byException"))
 
       Reconfigure.applyConfig("kamon.trace.include-error-stacktrace=false")
-      val byExceptionDisabled = Kamon.spanBuilder("o2").start()
-        .fail(new RuntimeException("byExceptionDisabled"))
+      val byExceptionStacktraceDisabled = Kamon.spanBuilder("o4").start()
+        .fail(new RuntimeException("byExceptionStacktraceDisabled"))
+
+      Reconfigure.applyConfig("kamon.trace.include-error-type=true")
+      val byExceptionTypeEnabled = Kamon.spanBuilder("o5").start()
+        .fail(new RuntimeException("byExceptionTypeEnabled"))
 
       byMessage.metricTags().get(plainBoolean("error")) shouldBe true
       byMessage.spanTags().get(plain("error.message")) shouldBe "byMessage"
       byMessage.spanTags().get(option("error.stacktrace")) shouldBe None
+      byMessage.spanTags().get(option("error.type")) shouldBe None
 
       byException.metricTags().get(plainBoolean("error")) shouldBe true
       byException.spanTags().get(plain("error.message")) shouldBe "byException"
       byException.spanTags().get(option("error.stacktrace")) shouldBe defined
+      byException.spanTags().get(option("error.type")) shouldBe None
 
       byMessageAndException.metricTags().get(plainBoolean("error")) shouldBe true
       byMessageAndException.spanTags().get(plain("error.message")) shouldBe "byMessageAndException"
-      byException.spanTags().get(option("error.stacktrace")) shouldBe defined
+      byMessageAndException.spanTags().get(option("error.stacktrace")) shouldBe defined
+      byMessageAndException.spanTags().get(option("error.type")) shouldBe None
 
-      byExceptionDisabled.metricTags().get(plainBoolean("error")) shouldBe true
-      byExceptionDisabled.spanTags().get(plain("error.message")) shouldBe "byExceptionDisabled"
-      byExceptionDisabled.spanTags().get(option("error.stacktrace")) shouldBe None
+      byExceptionStacktraceDisabled.metricTags().get(plainBoolean("error")) shouldBe true
+      byExceptionStacktraceDisabled.spanTags().get(plain("error.message")) shouldBe "byExceptionStacktraceDisabled"
+      byExceptionStacktraceDisabled.spanTags().get(option("error.stacktrace")) shouldBe None
+      byExceptionStacktraceDisabled.spanTags().get(option("error.type")) shouldBe None
+
+      byExceptionTypeEnabled.metricTags().get(plainBoolean("error")) shouldBe true
+      byExceptionTypeEnabled.spanTags().get(plain("error.message")) shouldBe "byExceptionTypeEnabled"
+      byExceptionTypeEnabled.spanTags().get(option("error.stacktrace")) shouldBe None
+      byExceptionTypeEnabled.spanTags().get(option("error.type")) shouldBe Some("java.lang.RuntimeException")
     }
   }
 

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
@@ -273,8 +273,8 @@ class TracerSpec extends AnyWordSpec with Matchers with SpanInspection.Syntax wi
       val byExceptionStacktraceDisabled = Kamon.spanBuilder("o4").start()
         .fail(new RuntimeException("byExceptionStacktraceDisabled"))
 
-      Reconfigure.applyConfig("kamon.trace.include-error-type=true")
-      val byExceptionTypeEnabled = Kamon.spanBuilder("o5").start()
+      Reconfigure.applyConfig("kamon.trace.include-error-type=false")
+      val byExceptionTypeDisabled = Kamon.spanBuilder("o5").start()
         .fail(new RuntimeException("byExceptionTypeEnabled"))
 
       byMessage.metricTags().get(plainBoolean("error")) shouldBe true
@@ -285,22 +285,22 @@ class TracerSpec extends AnyWordSpec with Matchers with SpanInspection.Syntax wi
       byException.metricTags().get(plainBoolean("error")) shouldBe true
       byException.spanTags().get(plain("error.message")) shouldBe "byException"
       byException.spanTags().get(option("error.stacktrace")) shouldBe defined
-      byException.spanTags().get(option("error.type")) shouldBe None
+      byException.spanTags().get(option("error.type")) shouldBe Some("java.lang.RuntimeException")
 
       byMessageAndException.metricTags().get(plainBoolean("error")) shouldBe true
       byMessageAndException.spanTags().get(plain("error.message")) shouldBe "byMessageAndException"
       byMessageAndException.spanTags().get(option("error.stacktrace")) shouldBe defined
-      byMessageAndException.spanTags().get(option("error.type")) shouldBe None
+      byMessageAndException.spanTags().get(option("error.type")) shouldBe Some("java.lang.RuntimeException")
 
       byExceptionStacktraceDisabled.metricTags().get(plainBoolean("error")) shouldBe true
       byExceptionStacktraceDisabled.spanTags().get(plain("error.message")) shouldBe "byExceptionStacktraceDisabled"
       byExceptionStacktraceDisabled.spanTags().get(option("error.stacktrace")) shouldBe None
-      byExceptionStacktraceDisabled.spanTags().get(option("error.type")) shouldBe None
+      byExceptionStacktraceDisabled.spanTags().get(option("error.type")) shouldBe Some("java.lang.RuntimeException")
 
-      byExceptionTypeEnabled.metricTags().get(plainBoolean("error")) shouldBe true
-      byExceptionTypeEnabled.spanTags().get(plain("error.message")) shouldBe "byExceptionTypeEnabled"
-      byExceptionTypeEnabled.spanTags().get(option("error.stacktrace")) shouldBe None
-      byExceptionTypeEnabled.spanTags().get(option("error.type")) shouldBe Some("java.lang.RuntimeException")
+      byExceptionTypeDisabled.metricTags().get(plainBoolean("error")) shouldBe true
+      byExceptionTypeDisabled.spanTags().get(plain("error.message")) shouldBe "byExceptionTypeEnabled"
+      byExceptionTypeDisabled.spanTags().get(option("error.stacktrace")) shouldBe None
+      byExceptionTypeDisabled.spanTags().get(option("error.type")) shouldBe None
     }
   }
 

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -178,7 +178,7 @@ kamon {
 
     # Decides whether to include the class name of a Throwable as the "error.type" Span tag when a Span is marked
     # as failed.
-    include-error-type = no
+    include-error-type = yes
 
     # Configures a sampler that decides which Spans should be sent to Span reporters. The possible values are:
     #   - always: report all traces.

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -176,6 +176,10 @@ kamon {
     # as failed.
     include-error-stacktrace = yes
 
+    # Decides whether to include the class name of a Throwable as the "error.type" Span tag when a Span is marked
+    # as failed.
+    include-error-type = no
+
     # Configures a sampler that decides which Spans should be sent to Span reporters. The possible values are:
     #   - always: report all traces.
     #   - never:  don't report any trace.

--- a/core/kamon-core/src/main/scala/kamon/trace/Span.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Span.scala
@@ -412,7 +412,7 @@ object Span {
       createdAt: Instant, initialMarks: List[Mark], initialLinks: List[Link], initialTrackMetrics: Boolean, tagWithParentOperation: Boolean,
       includeErrorStacktrace: Boolean, isDelayed: Boolean, clock: Clock, preFinishHooks: Array[Tracer.PreFinishHook],
       onFinish: Span.Finished => Unit, sampler: Sampler, scheduler: ScheduledExecutorService, reportingDelay: Duration,
-      localTailSamplerSettings: LocalTailSamplerSettings) extends Span.Delayed {
+      localTailSamplerSettings: LocalTailSamplerSettings, includeErrorType: Boolean) extends Span.Delayed {
 
     private val _metricTags = metricTags
     private val _spanTags = spanTags
@@ -526,6 +526,9 @@ object Span {
 
           if(includeErrorStacktrace)
             _spanTags.add(TagKeys.ErrorStacktrace, toStackTraceString(throwable))
+
+          if (includeErrorType)
+            _spanTags.add(TagKeys.ErrorType, throwable.getClass.getName)
         }
       }
       this
@@ -541,6 +544,9 @@ object Span {
 
           if(includeErrorStacktrace)
             _spanTags.add(TagKeys.ErrorStacktrace, toStackTraceString(throwable))
+
+          if (includeErrorType)
+            _spanTags.add(TagKeys.ErrorType, throwable.getClass.getName)
         }
       }
       this
@@ -809,6 +815,7 @@ object Span {
     val Error = "error"
     val ErrorMessage = "error.message"
     val ErrorStacktrace = "error.stacktrace"
+    val ErrorType = "error.type"
     val Component = "component"
     val OperationName = "operation"
     val ParentOperationName = "parentOperation"

--- a/core/kamon-core/src/main/scala/kamon/trace/Tracer.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Tracer.scala
@@ -54,6 +54,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
   @volatile private var _delayedSpanReportingDelay: Duration = Duration.ZERO
   @volatile private var _localTailSamplerSettings: LocalTailSamplerSettings = LocalTailSamplerSettings(false, Int.MaxValue, Long.MaxValue)
   @volatile private var _scheduler: Option[ScheduledExecutorService] = None
+  @volatile private var _includeErrorType: Boolean = false
   private val _onSpanFinish: Span.Finished => Unit = _spanBuffer.offer
 
   reconfigure(initialConfig)
@@ -363,7 +364,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
 
         new Span.Local(id, parentId, trace, position, _kind, localParent, _name, _spanTags, _metricTags, at, _marks, _links,
           _trackMetrics, _tagWithParentOperation, _includeErrorStacktrace, isDelayed, clock, _preFinishHooks, _onSpanFinish,
-          _sampler, _scheduler.get, _delayedSpanReportingDelay, _localTailSamplerSettings)
+          _sampler, _scheduler.get, _delayedSpanReportingDelay, _localTailSamplerSettings, _includeErrorType)
       }
     }
 
@@ -429,6 +430,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
       val tagWithUpstreamService = traceConfig.getBoolean("span-metric-tags.upstream-service")
       val tagWithParentOperation = traceConfig.getBoolean("span-metric-tags.parent-operation")
       val includeErrorStacktrace = traceConfig.getBoolean("include-error-stacktrace")
+      val includeErrorType = traceConfig.getBoolean("include-error-type")
       val delayedSpanReportingDelay = traceConfig.getDuration("span-reporting-delay")
       val localTailSamplerSettings = LocalTailSamplerSettings(
         enabled = traceConfig.getBoolean("local-tail-sampler.enabled"),
@@ -454,6 +456,7 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
       _identifierScheme = identifierScheme
       _joinRemoteParentsWithSameSpanID = joinRemoteParentsWithSameSpanID
       _includeErrorStacktrace = includeErrorStacktrace
+      _includeErrorType = includeErrorType
       _tagWithUpstreamService = tagWithUpstreamService
       _tagWithParentOperation = tagWithParentOperation
       _traceReporterQueueSize = traceReporterQueueSize


### PR DESCRIPTION
This is for some extra compatibility with opentelemetry libs. The tests fail locally with some OOMs, which is odd to me but I guess if the limits are tightly scoped, then adding an extra boolean field to the traces might explain it...