### PR TITLE
measure the entire Jedis roundtrip time, fixes #1082

### DIFF
--- a/core/kamon-core/src/main/scala/kamon/context/Storage.scala
+++ b/core/kamon-core/src/main/scala/kamon/context/Storage.scala
@@ -57,6 +57,18 @@ object Storage {
     def close(): Unit
   }
 
+  object Scope {
+
+    /**
+      * A Scope instance that doesn't carry any context and does nothing on close.
+      */
+    val Empty: Scope = new Scope {
+      override def context: Context = Context.Empty
+      override def close(): Unit = {}
+    }
+  }
+
+
   /**
     * A ThreadLocal context storage that allows the scope to be closed in a different
     * thread than the thread where store(..) was called.

--- a/instrumentation/kamon-redis/src/main/resources/reference.conf
+++ b/instrumentation/kamon-redis/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ kanela.modules {
     ]
 
     within = [
-      "redis.clients.jedis.Protocol",
+      "redis.clients.jedis..*",
       "io.lettuce.core..*",
       "redis..*",
     ]

--- a/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
+++ b/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
@@ -18,43 +18,93 @@ package kamon
 package instrumentation
 package jedis
 
-import kamon.Kamon
+import kamon.context.Storage.Scope
+import kamon.tag.Lookups.plain
 import kamon.trace.Span
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.asm.Advice
 import kanela.agent.libs.net.bytebuddy.description.method.MethodDescription
-import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.{isMethod, isPublic, namedOneOf, not, whereAny}
-import redis.clients.jedis.Protocol
+import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.{isMethod, isPublic, isStatic, namedOneOf, not}
 
 class JedisInstrumentation extends InstrumentationBuilder {
-  onType("redis.clients.jedis.Jedis")
+  onTypes("redis.clients.jedis.Jedis", "redis.clients.jedis.BinaryJedis")
     .advise(
-      isMethod[MethodDescription]().and(not(namedOneOf[MethodDescription](
-        "close",
-        "toString",
-        "hashCode"
-      ))), classOf[SendCommandAdvice])
+      isMethod[MethodDescription]()
+        .and(isPublic[MethodDescription])
+        .and(not(isStatic[MethodDescription]))
+        .and(not(namedOneOf[MethodDescription](
+          "setDataSource",
+          "getDB",
+          "isConnected",
+          "connect",
+          "disconnect",
+          "resetState",
+          "getClient",
+          "getConnection",
+          "isConnected",
+          "isBroken",
+          "close",
+          "toString",
+          "hashCode"
+        ))),
+      classOf[ClientOperationsAdvice])
+
+
+  onType("redis.clients.jedis.Protocol")
+    .advise(
+      method("sendCommand")
+        .and(isPublic[MethodDescription])
+        .and(isStatic[MethodDescription])
+        .and(takesArguments(3)),
+      classOf[SendCommandAdvice])
 }
 
-class SendCommandAdvice
-
-object SendCommandAdvice {
+class ClientOperationsAdvice
+object ClientOperationsAdvice {
+  private val currentRedisOperationKey = "redis.current-op"
 
   @Advice.OnMethodEnter(suppress = classOf[Throwable])
-  def enter(@Advice.Origin("#m") methodName: String): Span = {
-    val spanName = s"redis.command.${methodName}"
+  def enter(@Advice.Origin("#m") methodName: String): Scope = {
+    val currentContext = Kamon.currentContext()
 
-    Kamon
-      .clientSpanBuilder(spanName, "redis.client.jedis")
-      .start()
+    if(currentContext.getTag(plain(currentRedisOperationKey)) == null) {
+
+      // The actual span name is going to be set in the SendCommand advice
+      val clientSpan = Kamon
+        .clientSpanBuilder("jedis", "redis.client.jedis")
+        .tagMetrics("db.system", "redis")
+        .start()
+
+      Kamon.storeContext(currentContext
+        .withEntry(Span.Key, clientSpan)
+        .withTag(currentRedisOperationKey, methodName)
+      )
+    } else Scope.Empty
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable], suppress = classOf[Throwable])
-  def exit(@Advice.Enter span: Span, @Advice.Thrown t: Throwable): Unit = {
-    if (t != null) {
-      span.fail(t)
-    }
+  def exit(@Advice.Enter scope: Scope, @Advice.Thrown t: Throwable): Unit = {
+    if(scope != Scope.Empty) {
+      val span = scope.context.get(Span.Key)
+      if (t != null) {
+        span.fail(t)
+      }
 
-    span.finish()
+      span.finish()
+      scope.close()
+    }
+  }
+}
+
+class SendCommandAdvice
+object SendCommandAdvice {
+
+  @Advice.OnMethodEnter
+  def sendCommand(@Advice.Argument(1) command: Any): Unit = {
+    // The command object should actually be an Enum and its toString() produces
+    // the actual command name sent to Redis
+    Kamon.currentSpan()
+      .name(command.toString())
+      .tag("db.operation", command.toString())
   }
 }

--- a/instrumentation/kamon-redis/src/test/scala/kamon/instrumentation/combined/RedisInstrumentationsSpec.scala
+++ b/instrumentation/kamon-redis/src/test/scala/kamon/instrumentation/combined/RedisInstrumentationsSpec.scala
@@ -2,6 +2,8 @@ package kamon.instrumentation.combined
 
 
 import io.lettuce.core.{RedisClient => LettuceClient}
+import kamon.tag.Lookups
+import kamon.tag.Lookups._
 import kamon.testkit.{InitAndStopKamonAfterAll, MetricInspection, TestSpanReporter}
 import kamon.trace.Span.Kind
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
@@ -51,8 +53,10 @@ class RedisInstrumentationsSpec extends AnyWordSpec
 
       eventually(timeout(2.seconds)) {
         val span = testSpanReporter().nextSpan().get
-        span.operationName shouldBe "redis.command.set"
         span.kind shouldBe Kind.Client
+        span.operationName shouldBe "SET"
+        span.metricTags.get(plain("db.system")) shouldBe "redis"
+        span.tags.get(plain("db.operation")) shouldBe "SET"
         testSpanReporter().spans() shouldBe empty
       }
 
@@ -61,8 +65,10 @@ class RedisInstrumentationsSpec extends AnyWordSpec
       jedis.get("foo")
       eventually(timeout(2.seconds)) {
         val span = testSpanReporter().nextSpan().get
-        span.operationName shouldBe "redis.command.get"
         span.kind shouldBe Kind.Client
+        span.operationName shouldBe "GET"
+        span.metricTags.get(plain("db.system")) shouldBe "redis"
+        span.tags.get(plain("db.operation")) shouldBe "GET"
         testSpanReporter().spans() shouldBe empty
       }
     }

--- a/instrumentation/kamon-redis/src/test/scala/kamon/instrumentation/combined/RedisInstrumentationsSpec.scala
+++ b/instrumentation/kamon-redis/src/test/scala/kamon/instrumentation/combined/RedisInstrumentationsSpec.scala
@@ -51,7 +51,7 @@ class RedisInstrumentationsSpec extends AnyWordSpec
 
       eventually(timeout(2.seconds)) {
         val span = testSpanReporter().nextSpan().get
-        span.operationName shouldBe "redis.command.SET"
+        span.operationName shouldBe "redis.command.set"
         span.kind shouldBe Kind.Client
         testSpanReporter().spans() shouldBe empty
       }
@@ -61,7 +61,7 @@ class RedisInstrumentationsSpec extends AnyWordSpec
       jedis.get("foo")
       eventually(timeout(2.seconds)) {
         val span = testSpanReporter().nextSpan().get
-        span.operationName shouldBe "redis.command.GET"
+        span.operationName shouldBe "redis.command.get"
         span.kind shouldBe Kind.Client
         testSpanReporter().spans() shouldBe empty
       }


### PR DESCRIPTION
Turns out that our current Jedis instrumentation is only measuring the time it takes to send a command to Redis, without taking into account how long will it take to get an answer back. This PR fixes that. Thanks to @jtjeferreira for bringing this up!

TODO:
  - [x] Check if we should change the span names and tags to something that matches the otel spec
  - [x] Try it out with Jedis 4.x
  - [x] Ignore other possibly unwanted methods from generating spans in the Jedis class (currently only `toString`, `hashCode`, and `close` are ignored)