### PR TITLE
ensure trace actor excludes for rediscala are picked up, fixes #1072

### DIFF
--- a/instrumentation/kamon-akka/src/common/resources/reference.conf
+++ b/instrumentation/kamon-akka/src/common/resources/reference.conf
@@ -52,7 +52,7 @@ kamon.instrumentation.akka {
       #
       auto-grouping {
         includes = [ "*/user/**" ]
-        excludes = [ ]
+        excludes = ${?kamon.instrumentation.akka.filters.groups.auto-grouping.excludes} [ ]
       }
     }
 
@@ -72,7 +72,7 @@ kamon.instrumentation.akka {
       # track Actor groups instead of individual actors because wildly targetting actors can lead to cardinality issues.
       #
       track {
-        includes = [ ]
+        includes = ${?kamon.instrumentation.akka.filters.actors.track.includes} [ ]
         excludes = [ "*/system/**", "*/user/IO-**" ]
       }
 
@@ -81,7 +81,7 @@ kamon.instrumentation.akka {
       #
       trace {
         includes = [ "*/user/**", "*/system/sharding**" ]
-        excludes = [ ]
+        excludes = ${?kamon.instrumentation.akka.filters.actors.trace.excludes} [ ]
       }
 
       # Decides which actors generate Spans for the messages they process, even if that requires them to start a new
@@ -90,8 +90,8 @@ kamon.instrumentation.akka {
       # observability of the system and burry useful traces underneath the noise.
       #
       start-trace {
-        includes = [ ]
-        excludes = [ ]
+        includes = ${?kamon.instrumentation.akka.filters.actors.start-trace.includes} [ ]
+        excludes = ${?kamon.instrumentation.akka.filters.actors.start-trace.excludes} [ ]
       }
     }
 
@@ -99,14 +99,14 @@ kamon.instrumentation.akka {
     #
     routers {
       includes = [ "**" ]
-      excludes = [ ]
+      excludes = ${?kamon.instrumentation.akka.filters.routers.excludes} [ ]
     }
 
     # Decides which dispatchers should have metric tracking enabled.
     #
     dispatchers {
       includes = [ "**" ]
-      excludes = [ ]
+      excludes = ${?kamon.instrumentation.akka.filters.dispatchers.excludes} [ ]
     }
   }
 


### PR DESCRIPTION
Adds `${?____}` placeholders on all the Akka filter configurations with empty values so they can be merged without problems when we provide additional default values in other modules, like we do in `kamon-redis` to exclude tracing some Rediscala actors.