### PR TITLE
do not start start traces in the producer instrumentation, related to #1115

### DIFF
--- a/instrumentation/kamon-kafka/src/main/resources/reference.conf
+++ b/instrumentation/kamon-kafka/src/main/resources/reference.conf
@@ -6,6 +6,11 @@ kamon.instrumentation.kafka {
   client {
     tracing {
 
+      # Decides whether the Producer instrumentation should start a new trace when sending records to Kafka and no
+      # trace is currently running on the application. You almost never will the Producer to start new traces, but
+      # we have this setting for backwards compatibility reasons.
+      start-trace-on-producer = no
+
       # Decides whether the Spans created by the Kafka Consumer instrumentation should continue the same trace created
       # on the Kafka Producer side or not. When this setting is set to "no" the instrumentation will start a new trace
       # on the consumer side and add a link to the corresponding parent trace.

--- a/instrumentation/kamon-kafka/src/main/resources/reference.conf
+++ b/instrumentation/kamon-kafka/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ kamon.instrumentation.kafka {
     tracing {
 
       # Decides whether the Producer instrumentation should start a new trace when sending records to Kafka and no
-      # trace is currently running on the application. You almost never will the Producer to start new traces, but
+      # trace is currently running on the application. You almost never want the Producer to start new traces, but
       # we have this setting for backwards compatibility reasons.
       start-trace-on-producer = no
 

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/KafkaInstrumentation.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/KafkaInstrumentation.scala
@@ -36,6 +36,7 @@ object KafkaInstrumentation {
     val kafkaConfig = config.getConfig("kamon.instrumentation.kafka.client")
 
     Settings(
+      startTraceOnProducer = kafkaConfig.getBoolean("tracing.start-trace-on-producer"),
       continueTraceOnConsumer = kafkaConfig.getBoolean("tracing.continue-trace-on-consumer"),
       useDelayedSpans = kafkaConfig.getBoolean("tracing.use-delayed-spans")
     )
@@ -197,6 +198,7 @@ object KafkaInstrumentation {
   }
 
   case class Settings (
+    startTraceOnProducer: Boolean,
     continueTraceOnConsumer: Boolean,
     useDelayedSpans: Boolean
   )

--- a/instrumentation/kamon-kafka/src/test/resources/application.conf
+++ b/instrumentation/kamon-kafka/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+kamon.instrumentation.kafka.client.tracing {
+  start-trace-on-producer = yes
+}


### PR DESCRIPTION
Introduces a new setting `start-trace-on-producer` that determines whether the producer instrumentation should start a new Span (and trace) when producing a message without any current trace on the producing application. In most cases you don't want that, so we are defaulting it to `no`. 

This will prevent apps from creating unnecessary spans on the producer side that can in turn generate A LOT of spans on the consumer side.