### PR TITLE
do not generate spans for Akka Streams-related actors, fixes #1116

### DIFF
--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorCellInfo.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorCellInfo.scala
@@ -16,12 +16,16 @@ case class ActorCellInfo (
   isRouter: Boolean,
   isRoutee: Boolean,
   isRootSupervisor: Boolean,
+  isStreamImplementationActor: Boolean,
   isTemporary: Boolean,
   actorOrRouterClass: Class[_],
   routeeClass: Option[Class[_]]
 )
 
 object ActorCellInfo {
+
+  private val StreamsSupervisorActorClassName = "akka.stream.impl.StreamSupervisor"
+  private val StreamsInterpreterActorClassName = "akka.stream.impl.fusing.ActorGraphInterpreter"
 
   /**
     * Reads information from an ActorCell.
@@ -63,8 +67,12 @@ object ActorCellInfo {
       }
     } else props.dispatcher
 
-    ActorCellInfo(fullPath, actorName, system.name, dispatcherName, isRouter, isRoutee, isRootSupervisor, isTemporary,
-      actorOrRouterClass, routeeClass)
+    val actorClassName = actorOrRouterClass.getName
+    val isStreamImplementationActor =
+      actorClassName == StreamsSupervisorActorClassName || actorClassName == StreamsInterpreterActorClassName
+
+    ActorCellInfo(fullPath, actorName, system.name, dispatcherName, isRouter, isRoutee, isRootSupervisor,
+      isStreamImplementationActor, isTemporary, actorOrRouterClass, routeeClass)
   }
 
   /**

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorMonitor.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/instrumentations/ActorMonitor.scala
@@ -75,7 +75,7 @@ object ActorMonitor {
     val settings = AkkaInstrumentation.settings()
     val isTraced = Kamon.filter(TraceActorFilterName).accept(cell.path)
     val startsTrace = settings.safeActorStartTraceFilter.accept(cell.path)
-    val participatesInTracing = isTraced || startsTrace
+    val participatesInTracing = (isTraced || startsTrace) && !cell.isStreamImplementationActor
     val autoGroupingPath = resolveAutoGroupingPath(cell.actorOrRouterClass, ref, parent, system.name)
 
     def traceWrap(monitor: ActorMonitor): ActorMonitor =


### PR DESCRIPTION
All streams materialized with the system-wide materializer are excluded from tracing by the default filters, but that cannot catch any streams-related actors created by actor scoped materializer. This PR ensures we will not generate Spans for `akka.stream.impl.StreamSupervisor` and `akka.stream.impl.fusing.ActorGraphInterpreter` actors.
