### PR TITLE
DataDog Trace HTTP Propagation

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
@@ -1,0 +1,157 @@
+package kamon.trace
+
+import kamon.context.{Context, HttpPropagation}
+import kamon.trace.Trace.SamplingDecision
+import org.scalatest.OptionValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable
+
+class DataDogSpanPropagationSpec extends AnyWordSpec with Matchers with OptionValues {
+  val dataDogPropagation = SpanPropagation.DataDog()
+
+  "The DataDog Span propagation for HTTP" should {
+    "write the Span data into headers" in {
+      val headersMap = mutable.Map.empty[String, String]
+      dataDogPropagation.write(testContext(), headerWriterFromMap(headersMap))
+
+      headersMap.get("x-datadog-trace-id").value shouldBe unsignedLongString("1234")
+      // not a typo, span id should be set as `x-datadog-parent-id`
+      headersMap.get("x-datadog-parent-id").value shouldBe unsignedLongString("4321")
+      headersMap.get("x-datadog-sampling-priority").value shouldBe "1"
+    }
+
+    "not inject anything if there is no Span in the Context" in {
+      val headersMap = mutable.Map.empty[String, String]
+      dataDogPropagation.write(Context.Empty, headerWriterFromMap(headersMap))
+      headersMap.values shouldBe empty
+    }
+
+    "extract a RemoteSpan from incoming headers when all fields are set" in {
+      val headersMap = Map(
+        "x-datadog-trace-id" -> unsignedLongString("1234"),
+        "x-datadog-parent-id" -> unsignedLongString("4321"),
+        "x-datadog-sampling-priority" -> "1"
+      )
+
+      val spanContext = dataDogPropagation.read(headerReaderFromMap(headersMap), Context.Empty).get(Span.Key)
+      spanContext.id.string shouldBe "4321"
+      spanContext.trace.id.string shouldBe "1234"
+      spanContext.trace.samplingDecision shouldBe SamplingDecision.Sample
+      spanContext.parentId shouldBe Identifier.Empty
+    }
+
+    "decode the sampling decision based on the x-datadog-sampling-priority header" in {
+      val sampledHeaders = Map(
+        "x-datadog-trace-id" -> unsignedLongString("1234"),
+        "x-datadog-parent-id" -> unsignedLongString("4321"),
+        "x-datadog-sampling-priority" -> "1"
+      )
+
+      val notSampledHeaders = Map(
+        "x-datadog-trace-id" -> unsignedLongString("1234"),
+        "x-datadog-parent-id" -> unsignedLongString("4321"),
+        "x-datadog-sampling-priority" -> "0"
+      )
+
+      val noSamplingHeaders = Map(
+        "x-datadog-trace-id" -> unsignedLongString("1234"),
+        "x-datadog-parent-id" -> unsignedLongString("4321")
+      )
+
+      dataDogPropagation.read(headerReaderFromMap(sampledHeaders), Context.Empty)
+        .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.Sample
+
+      dataDogPropagation.read(headerReaderFromMap(notSampledHeaders), Context.Empty)
+        .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.DoNotSample
+
+      dataDogPropagation.read(headerReaderFromMap(noSamplingHeaders), Context.Empty)
+        .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.Unknown
+    }
+
+    "not include the x-datadog-sampling-priorit header if the sampling decision is unknown" in {
+      val context = testContext()
+      val sampledSpan = context.get(Span.Key)
+      val notSampledSpanContext = Context.Empty.withEntry(Span.Key,
+        new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.DoNotSample)))
+      val unknownSamplingSpanContext = Context.Empty.withEntry(Span.Key,
+        new Span.Remote(sampledSpan.id, sampledSpan.parentId, Trace(sampledSpan.trace.id, SamplingDecision.Unknown)))
+      val headersMap = mutable.Map.empty[String, String]
+
+      dataDogPropagation.write(context, headerWriterFromMap(headersMap))
+      headersMap.get("x-datadog-sampling-priority").value shouldBe("1")
+      headersMap.clear()
+
+      dataDogPropagation.write(notSampledSpanContext, headerWriterFromMap(headersMap))
+      headersMap.get("x-datadog-sampling-priority").value shouldBe("0")
+      headersMap.clear()
+
+      dataDogPropagation.write(unknownSamplingSpanContext, headerWriterFromMap(headersMap))
+      headersMap.get("x-datadog-sampling-priority") shouldBe empty
+    }
+
+    "extract a minimal SpanContext from a TextMap containing only the Trace ID and Span ID" in {
+      val headers = Map(
+        "x-datadog-trace-id" -> unsignedLongString("1234"),
+        "x-datadog-parent-id" -> unsignedLongString("4321")
+      )
+
+      val span = dataDogPropagation.read(headerReaderFromMap(headers), Context.Empty).get(Span.Key)
+      span.id.string shouldBe "4321"
+      span.parentId shouldBe Identifier.Empty
+      span.trace.id.string shouldBe "1234"
+      span.trace.samplingDecision shouldBe SamplingDecision.Unknown
+    }
+
+    "round trip a Span from TextMap -> Context -> TextMap" in {
+      val headers = Map(
+        "x-datadog-trace-id" -> unsignedLongString("1234"),
+        "x-datadog-parent-id" -> unsignedLongString("4321"),
+        "x-datadog-sampling-priority" -> "1"
+      )
+
+      val writenHeaders = mutable.Map.empty[String, String]
+      val context = dataDogPropagation.read(headerReaderFromMap(headers), Context.Empty)
+      dataDogPropagation.write(context, headerWriterFromMap(writenHeaders))
+      writenHeaders should contain theSameElementsAs(headers)
+    }
+  }
+
+  def unsignedLongString(id: String): String = BigInt(id, 16).toString
+
+  def headerReaderFromMap(map: Map[String, String]): HttpPropagation.HeaderReader = new HttpPropagation.HeaderReader {
+    override def read(header: String): Option[String] = {
+      if(map.get("fail").nonEmpty)
+        sys.error("failing on purpose")
+
+      map.get(header)
+    }
+
+    override def readAll(): Map[String, String] = map
+  }
+
+  def headerWriterFromMap(map: mutable.Map[String, String]): HttpPropagation.HeaderWriter = new HttpPropagation.HeaderWriter {
+    override def write(header: String, value: String): Unit = map.put(header, value)
+  }
+
+  def testContext(): Context =
+    Context.of(Span.Key, new Span.Remote(
+      id = Identifier("4321", Array[Byte](4, 3, 2, 1)),
+      parentId = Identifier("2222", Array[Byte](2, 2, 2, 2)),
+      trace = Trace(
+        id = Identifier("1234", Array[Byte](1, 2, 3, 4)),
+        samplingDecision = SamplingDecision.Sample
+      )
+    ))
+
+  def testContextWithoutParent(): Context =
+    Context.of(Span.Key, new Span.Remote(
+      id = Identifier("4321", Array[Byte](4, 3, 2, 1)),
+      parentId = Identifier.Empty,
+      trace = Trace(
+        id = Identifier("1234", Array[Byte](1, 2, 3, 4)),
+        samplingDecision = SamplingDecision.Sample
+      )
+    ))
+}

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
@@ -70,7 +70,7 @@ class DataDogSpanPropagationSpec extends AnyWordSpec with Matchers with OptionVa
         .get(Span.Key).trace.samplingDecision shouldBe SamplingDecision.Unknown
     }
 
-    "not include the x-datadog-sampling-priorit header if the sampling decision is unknown" in {
+    "not include the x-datadog-sampling-priority header if the sampling decision is unknown" in {
       val context = testContext()
       val sampledSpan = context.get(Span.Key)
       val notSampledSpanContext = Context.Empty.withEntry(Span.Key,

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -362,6 +362,7 @@ kamon {
             #   - b3-single for the Zipkin B3 single header format (see https://github.com/openzipkin/b3-propagation#single-header)
             #   - uber for the Uber/Jaeger format (see https://www.jaegertracing.io/docs/1.16/client-libraries/#propagation-format)
             #   - w3c for the W3C Trace Context format (see https://www.w3.org/TR/trace-context-1/) - requires identifier-scheme = double
+            #   - datadog for the DataDog HTTP trace format (see https://github.com/DataDog/dd-trace-java/blob/76e41d3d51314ed2814d0c8deac78c17bb87638e/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java#L24..L27)
             #
             span = "b3"
           }
@@ -376,6 +377,7 @@ kamon {
             #   - b3-single for the Zipkin B3 single header format (see https://github.com/openzipkin/b3-propagation#single-header)
             #   - uber for the Uber/Jaeger format (see https://www.jaegertracing.io/docs/1.16/client-libraries/#propagation-format)
             #   - w3c for the W3C Trace Context format (see https://www.w3.org/TR/trace-context-1/) - requires identifier-scheme = double
+            #   - datadog for the DataDog HTTP trace format (see https://github.com/DataDog/dd-trace-java/blob/76e41d3d51314ed2814d0c8deac78c17bb87638e/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java#L24..L27)
             #
             span = "b3"
           }

--- a/core/kamon-core/src/main/scala/kamon/context/HttpPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/context/HttpPropagation.scala
@@ -238,7 +238,8 @@ object HttpPropagation {
       "span/b3" -> SpanPropagation.B3(),
       "span/uber" -> SpanPropagation.Uber(),
       "span/b3-single" -> SpanPropagation.B3Single(),
-      "span/w3c" -> SpanPropagation.W3CTraceContext()
+      "span/w3c" -> SpanPropagation.W3CTraceContext(),
+      "span/datadog" -> SpanPropagation.DataDog()
     )
 
     def from(config: Config, identifierScheme: String): Settings = {

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -473,8 +473,8 @@ object W3CTraceContext {
 
         val samplingDecision =
           reader.read(Headers.SamplingPriority) match {
-            case Some(sampled) if sampled == SamplingPriority.Sample => SamplingDecision.Sample
-            case Some(sampled) if sampled == SamplingPriority.DoNotSample => SamplingDecision.DoNotSample
+            case Some(SamplingPriority.Sample) => SamplingDecision.Sample
+            case Some(SamplingPriority.DoNotSample) => SamplingDecision.DoNotSample
             case _ => SamplingDecision.Unknown
           }
 

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -417,4 +417,85 @@ object W3CTraceContext {
       override def initialValue(): Array[Byte] = Array.ofDim[Byte](256)
     }
   }
+
+  /**
+    * DataDog HTTP propagation. Based on `dd-trace-java` implementation and observations from services instrumented
+    * with the DataDog Java Agent. List of all available HTTP headers used in trace propagation.
+    *
+    * https://github.com/DataDog/dd-trace-java/blob/76e41d3d51314ed2814d0c8deac78c17bb87638e/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java#L24..L27
+    *
+    * Only a subset of possible DataDog headers are handled.
+    */
+  object DataDog {
+    def apply(): DataDog = new DataDog
+
+    object Headers {
+      val ParentSpanId = "x-datadog-parent-id"
+      val TraceId = "x-datadog-trace-id"
+      val SamplingPriority = "x-datadog-sampling-priority"
+    }
+
+    object SamplingPriority {
+      val Sample = "1"
+      val DoNotSample = "0"
+    }
+
+    final implicit class KamonIdOps(private val id: kamon.trace.Identifier) extends AnyVal {
+      def toLongId: Long = BigInt(id.string, 16).toLong
+      def toUnsignedLongString: String = BigInt(id.string, 16).toString
+    }
+
+    /**
+      * DataDog tracing ids will be 64 bit unsigned integers.
+      * https://docs.datadoghq.com/tracing/guide/send_traces_to_agent_by_api/
+      */
+    def decodeUnsignedLongToHex(id: String): String =
+      urlDecode(id).toLong.toHexString
+  }
+
+  class DataDog extends Propagation.EntryReader[HeaderReader] with Propagation.EntryWriter[HeaderWriter] {
+    import DataDog._
+
+    override def read(reader: HeaderReader, context: Context): Context = {
+      val identifierScheme = Kamon.identifierScheme
+      val traceId = reader.read(Headers.TraceId)
+        .map(id => identifierScheme.traceIdFactory.from(decodeUnsignedLongToHex(id)))
+        .getOrElse(Identifier.Empty)
+
+      // To preserve the parent/child relationship of spans in DataDog the `x-parent-parent-id` is used as the span id
+      // of the new span. See `DatadogHttpCodec` implementation in `dd-trace-java` for details.
+      val spanId = reader.read(Headers.ParentSpanId)
+        .map(id => identifierScheme.spanIdFactory.from(decodeUnsignedLongToHex(id)))
+        .getOrElse(Identifier.Empty)
+
+      if (traceId != Identifier.Empty) {
+        val parentId = Identifier.Empty
+
+        val samplingDecision =
+          reader.read(Headers.SamplingPriority) match {
+            case Some(sampled) if sampled == SamplingPriority.Sample => SamplingDecision.Sample
+            case Some(sampled) if sampled == SamplingPriority.DoNotSample => SamplingDecision.DoNotSample
+            case _ => SamplingDecision.Unknown
+          }
+
+        context.withEntry(Span.Key, Span.Remote(spanId, parentId, Trace(traceId, samplingDecision)))
+      } else context
+    }
+
+    override def write(context: Context, writer: HeaderWriter): Unit = {
+      val span = context.get(Span.Key)
+
+      if (span != Span.Empty) {
+        writer.write(Headers.ParentSpanId, span.id.toUnsignedLongString)
+        writer.write(Headers.TraceId, span.trace.id.toUnsignedLongString)
+        if (span.trace.samplingDecision != SamplingDecision.Unknown) {
+          val decision = if (span.trace.samplingDecision == SamplingDecision.Sample)
+            SamplingPriority.Sample
+          else
+            SamplingPriority.DoNotSample
+          writer.write(Headers.SamplingPriority,decision)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
ref: https://github.com/kamon-io/Kamon/discussions/1031

Basic DataDog HTTP Propagation. This does not include support for [other headers the `dd-trace-java` library supports](https://github.com/DataDog/dd-trace-java/blob/76e41d3d51314ed2814d0c8deac78c17bb87638e/dd-trace-core/src/main/java/datadog/trace/core/propagation/DatadogHttpCodec.java#L24..L27) including `ot-baggage-` prefixed headers and `x-datadog-origin`. I think it could be added simply, but we don't use either header in our solutions ATM.

I also want to give credit to my colleague for his contributions @linkleonard
