### PR TITLE
Fix twitter future context propagation

### DIFF
--- a/instrumentation/kamon-twitter-future/src/main/java/kamon/instrumentation/futures/twitter/InterruptiblePromiseConstructorAdvice.java
+++ b/instrumentation/kamon-twitter-future/src/main/java/kamon/instrumentation/futures/twitter/InterruptiblePromiseConstructorAdvice.java
@@ -1,0 +1,33 @@
+/*
+ *  ==========================================================================================
+ *  Copyright © 2013-2022 The Kamon Project <https://kamon.io/>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ *  ==========================================================================================
+ */
+
+package kamon.instrumentation.futures.twitter;
+
+import kamon.Kamon;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+import scala.PartialFunction;
+import scala.runtime.BoxedUnit;
+
+public class InterruptiblePromiseConstructorAdvice {
+
+  @Advice.OnMethodExit
+  public static void onConstructorExit(@Advice.FieldValue(value = "handler", readOnly = false) PartialFunction<Throwable, BoxedUnit> handler) {
+    if(!(handler instanceof InterruptibleHandlerWithContext)) {
+      handler = new InterruptibleHandlerWithContext(Kamon.currentContext(), handler);
+    }
+  }
+
+}

--- a/instrumentation/kamon-twitter-future/src/main/resources/reference.conf
+++ b/instrumentation/kamon-twitter-future/src/main/resources/reference.conf
@@ -3,8 +3,21 @@
 ####################################################
 
 kanela.modules {
+  twitter-future {
+    name="Twitter Future Instrumentation"
+    description="Brings context propagation across asynchronous actions for Twitter Futures"
+
+    instrumentations = [
+      "kamon.instrumentation.futures.twitter.TwitterFutureInstrumentation"
+    ]
+
+    within = [
+      "com.twitter.util.Promise.*"
+    ]
+  }
+
   executor-service {
-    within += "com.twitter.util.*"
-    exclude += "com.twitter.util.ConstFuture.*"
+    within += "^com.twitter.util.ExecutorServiceFuturePool.*"
+    within += "^com.twitter.bijection.twitter_util.ScalaFuturePool.*"
   }
 }

--- a/instrumentation/kamon-twitter-future/src/main/resources/reference.conf
+++ b/instrumentation/kamon-twitter-future/src/main/resources/reference.conf
@@ -17,6 +17,7 @@ kanela.modules {
   }
 
   executor-service {
+    within += "^com.twitter.util.ConstFuture.*"
     within += "^com.twitter.util.ExecutorServiceFuturePool.*"
     within += "^com.twitter.bijection.twitter_util.ScalaFuturePool.*"
   }

--- a/instrumentation/kamon-twitter-future/src/main/scala/kamon/instrumentation/futures/twitter/TwitterFutureInstrumentation.scala
+++ b/instrumentation/kamon-twitter-future/src/main/scala/kamon/instrumentation/futures/twitter/TwitterFutureInstrumentation.scala
@@ -1,3 +1,19 @@
+/*
+ *  ==========================================================================================
+ *  Copyright © 2013-2022 The Kamon Project <https://kamon.io/>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ *  ==========================================================================================
+ */
+
 package kamon
 package instrumentation
 package futures

--- a/instrumentation/kamon-twitter-future/src/main/scala/kamon/instrumentation/futures/twitter/TwitterFutureInstrumentation.scala
+++ b/instrumentation/kamon-twitter-future/src/main/scala/kamon/instrumentation/futures/twitter/TwitterFutureInstrumentation.scala
@@ -1,0 +1,15 @@
+package kamon
+package instrumentation
+package futures
+package twitter
+
+import kamon.instrumentation.context.{CaptureCurrentContextOnExit, HasContext, InvokeWithCapturedContext}
+import kanela.agent.api.instrumentation.InstrumentationBuilder
+
+class TwitterFutureInstrumentation extends InstrumentationBuilder {
+
+  onType("com.twitter.util.Promise$WaitQueue")
+    .mixin(classOf[HasContext.Mixin])
+    .advise(isConstructor, CaptureCurrentContextOnExit)
+    .advise(method("runInScheduler"), InvokeWithCapturedContext)
+}

--- a/instrumentation/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
+++ b/instrumentation/kamon-twitter-future/src/test/scala/kamon/instrumentation/futures/twitter/FutureInstrumentationSpec.scala
@@ -1,18 +1,19 @@
-/* ===================================================
- * Copyright © 2016 the kamon project <http://kamon.io/>
+/*
+ *  ==========================================================================================
+ *  Copyright © 2013-2022 The Kamon Project <https://kamon.io/>
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * ========================================================== */
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ *  ==========================================================================================
+ */
+
 package kamon.instrumentation.futures.twitter
 
 import com.twitter.util.{Await, FuturePool}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -127,7 +127,6 @@ object BaseProject extends AutoPlugin {
     Global / concurrentRestrictions += Tags.limit(Tags.Test, 1),
     licenses += (("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
     resolvers += Resolver.mavenLocal,
-    headerLicense := Some(HeaderLicense.ALv2("2013-2021","The Kamon Project <https://kamon.io>")),
     Keys.commands += Command.command("testUntilFailed") { state: State =>
       "test" :: "testUntilFailed" :: state
     }


### PR DESCRIPTION
This PR changes the way we instrument Twitter Futures to ensure we always do context propagation. It was motivated by this discussion: https://github.com/kamon-io/Kamon/discussions/1005