### PR TITLE
build system-metrics for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -419,6 +419,7 @@ lazy val `kamon-annotation` = (project in file("instrumentation/kamon-annotation
 lazy val `kamon-system-metrics` = (project in file("instrumentation/kamon-system-metrics"))
   .disablePlugins(AssemblyPlugin)
   .settings(
+    crossScalaVersions += `scala_3_version`,
     libraryDependencies ++= Seq(
       oshiCore,
       scalatest % "test",


### PR DESCRIPTION
And hopefully publish it.

Fixes missing dependency in scala 3 projects:
```scala
libraryDependencies += "io.kamon"                   %% "kamon-system-metrics" % kamonVersion
```