### PR TITLE
Fix reporting of network activity on Linux

### DIFF
--- a/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/host/HostMetricsCollector.scala
+++ b/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/host/HostMetricsCollector.scala
@@ -221,6 +221,7 @@ class HostMetricsCollector(ec: ExecutionContext) extends ScheduledAction {
 
       interfaces.asScala.foreach(interface => {
         if (_settings.trackedInterfaces.accept(interface.getName)) {
+          interface.updateAttributes()
           val interfaceInstruments = _networkActivityInstruments.interfaceInstruments(interface.getName)
           interfaceInstruments.receivedBytes.diff(interface.getBytesRecv)
           interfaceInstruments.sentBytes.diff(interface.getBytesSent)


### PR DESCRIPTION
The current Kamon release doesn't seem to report network activity on
Linux, in docker or outside. This may be related with the
"updateAttributes()" method in OSHI not being invoked.

A local experiment confirmed that OSHI will indeed report an unchanging
value for e.g. `getBytesRecv()`, unless `updateAttributes()` is invoked
first.

Hence, this should probably get things working again.