### PR TITLE
implement basic tracing for the AWS Java SDK 2.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -597,6 +597,22 @@ lazy val `kamon-finagle` = (project in file("instrumentation/kamon-finagle"))
     )
   ).dependsOn(`kamon-core`, `kamon-instrumentation-common`, `kamon-testkit` % "test")
 
+lazy val `kamon-aws-sdk` = (project in file("instrumentation/kamon-aws-sdk"))
+  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(JavaAgent)
+  .settings(instrumentationSettings)
+  .settings(
+    libraryDependencies ++= Seq(
+      kanelaAgent % "provided",
+      "software.amazon.awssdk" % "dynamodb" % "2.17.191" % "provided",
+      "software.amazon.awssdk" % "sqs" % "2.17.191" % "provided",
+
+      scalatest % "test",
+      logbackClassic % "test",
+      "org.testcontainers" % "dynalite" % "1.17.1"
+    )
+  ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-testkit` % "test")
+
 /**
  * Reporters
  */

--- a/instrumentation/kamon-akka/build.sbt
+++ b/instrumentation/kamon-akka/build.sbt
@@ -3,7 +3,7 @@ import Def.Initialize
 
 val `Akka-2.4-version` = "2.4.20"
 val `Akka-2.5-version` = "2.5.32"
-val `Akka-2.6-version` = "2.6.11"
+val `Akka-2.6-version` = "2.6.14"
 
 /**
   * Compile Configurations

--- a/instrumentation/kamon-aws-sdk/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
+++ b/instrumentation/kamon-aws-sdk/src/main/resources/software/amazon/awssdk/global/handlers/execution.interceptors
@@ -1,0 +1,1 @@
+kamon.instrumentation.aws.sdk.AwsSdkClientExecutionInterceptor

--- a/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkClientExecutionInterceptor.scala
+++ b/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkClientExecutionInterceptor.scala
@@ -1,0 +1,57 @@
+/*
+ *  ==========================================================================================
+ *  Copyright © 2013-2022 The Kamon Project <https://kamon.io/>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ *  ==========================================================================================
+ */
+
+package kamon.instrumentation.aws.sdk
+
+import kamon.Kamon
+import kamon.trace.Span
+import software.amazon.awssdk.core.interceptor.{Context, ExecutionAttribute, ExecutionAttributes, ExecutionInterceptor, SdkExecutionAttribute}
+
+/**
+  * Bare-bones interceptor that creates Spans for all client requests made with the AWS SDK. There is no need to
+  * add this interceptor by hand anywhere, the AWS SDK will pick it up automatically from the classpath because it is
+  * included in the "software/amazon/awssdk/global/handlers/execution.interceptors" file shipped with this module.
+  *
+  */
+class AwsSdkClientExecutionInterceptor extends ExecutionInterceptor {
+  private val ClientSpanAttribute = new ExecutionAttribute[Span]("SdkClientSpan")
+
+  override def afterMarshalling(context: Context.AfterMarshalling, executionAttributes: ExecutionAttributes): Unit = {
+    val operationName = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME)
+    val serviceName = executionAttributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME)
+    val clientType = executionAttributes.getAttribute(SdkExecutionAttribute.CLIENT_TYPE)
+
+    val clientSpan = Kamon.clientSpanBuilder(operationName, serviceName)
+      .tag("aws.sdk.client_type", clientType.name())
+      .start()
+
+    executionAttributes.putAttribute(ClientSpanAttribute, clientSpan)
+  }
+
+  override def afterExecution(context: Context.AfterExecution, executionAttributes: ExecutionAttributes): Unit = {
+    val kamonSpan = executionAttributes.getAttribute(ClientSpanAttribute)
+    if(kamonSpan != null) {
+      kamonSpan.finish()
+    }
+  }
+
+  override def onExecutionFailure(context: Context.FailedExecution, executionAttributes: ExecutionAttributes): Unit = {
+    val kamonSpan = executionAttributes.getAttribute(ClientSpanAttribute)
+    if(kamonSpan != null) {
+      kamonSpan.fail(context.exception()).finish()
+    }
+  }
+}

--- a/instrumentation/kamon-aws-sdk/src/test/resources/logback.xml
+++ b/instrumentation/kamon-aws-sdk/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="kamon.log.LogbackFilter"/>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/instrumentation/kamon-aws-sdk/src/test/scala/kamon/instrumentation/aws/sdk/DynamoDBTracingSpec.scala
+++ b/instrumentation/kamon-aws-sdk/src/test/scala/kamon/instrumentation/aws/sdk/DynamoDBTracingSpec.scala
@@ -1,0 +1,68 @@
+/*
+ *  ==========================================================================================
+ *  Copyright © 2013-2022 The Kamon Project <https://kamon.io/>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ *  except in compliance with the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the
+ *  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  either express or implied. See the License for the specific language governing permissions
+ *  and limitations under the License.
+ *  ==========================================================================================
+ */
+
+package kamon.instrumentation.aws.sdk
+
+import kamon.tag.Lookups.plain
+import kamon.testkit.{InitAndStopKamonAfterAll, TestSpanReporter}
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.containers.GenericContainer
+import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.{AttributeDefinition, CreateTableRequest, KeySchemaElement, KeyType, ProvisionedThroughput}
+
+import scala.concurrent.duration._
+import java.net.URI
+
+class DynamoDBTracingSpec extends AnyWordSpec with Matchers with OptionValues with InitAndStopKamonAfterAll with Eventually with TestSpanReporter {
+  val dynamoPort = 8000
+  val dynamoContainer: GenericContainer[_] = new GenericContainer("amazon/dynamodb-local:latest")
+    .withExposedPorts(dynamoPort)
+
+  lazy val client = DynamoDbClient.builder()
+    .endpointOverride(URI.create(s"http://${dynamoContainer.getHost}:${dynamoContainer.getMappedPort(dynamoPort)}"))
+    .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("dummy", "dummy")))
+    .region(Region.US_EAST_1)
+    .build()
+
+
+  "the DynamoDB instrumentation on the SDK" should {
+    "create a Span for simple calls" in {
+      client.createTable(CreateTableRequest.builder()
+        .tableName("people")
+        .attributeDefinitions(AttributeDefinition.builder().attributeName("customerId").attributeType("S").build())
+        .keySchema(KeySchemaElement.builder().attributeName("customerId").keyType(KeyType.HASH).build())
+        .provisionedThroughput(ProvisionedThroughput.builder().readCapacityUnits(5l).writeCapacityUnits(5l).build())
+        .build())
+
+
+      eventually(timeout(5 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName shouldBe "CreateTable"
+        span.metricTags.get(plain("component")) shouldBe "DynamoDb"
+      }
+    }
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    dynamoContainer.start()
+  }
+}


### PR DESCRIPTION
This PR traces client calls executed with the AWS SDK for Java 2.x. A very similar approach is necessary for 1.x but that will be addressed in a separate PR.

Right now I'm focusing specifically on getting DynamoDB calls to show on traces, but a lot more should show up after this. SQS comes next.