### PR TITLE
remove misleading notation from the adaptive sampler reference config

### DIFF
--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -209,7 +209,7 @@ kamon {
       # decisions.
       throughput = 600
 
-      # Groups allow to override the default balacing behavior for a particular subset of operations in this
+      # Groups allow to override the default balancing behavior for a particular subset of operations in this
       # application. With groups, users can guarantee that certain operations will always be sampled, never sampled, or
       # provide minimum and/or maximum sampled traces throughput goals.
       #
@@ -232,7 +232,7 @@ kamon {
       # For example, if you wanted to ensure that health check operations are never sampled you could include
       #
       #   health-checks {
-      #     operations = ["GET \/status"]
+      #     operations = ["/status", "/health"]
       #
       #     rules {
       #       sample = never


### PR DESCRIPTION
It happened quite a few times that folks write the rules wrong because of the example code in the reference.conf file suggesting that you should add the HTTP method and escape the forward slash, but that is not necessary at all!