### PR TITLE
move the AWS SDK context key/attribute initialization to a companion object, fixes #1173

### DIFF
--- a/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkClientExecutionInterceptor.scala
+++ b/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkClientExecutionInterceptor.scala
@@ -28,7 +28,7 @@ import software.amazon.awssdk.core.interceptor.{Context, ExecutionAttribute, Exe
   * included in the "software/amazon/awssdk/global/handlers/execution.interceptors" file shipped with this module.
   */
 class AwsSdkClientExecutionInterceptor extends ExecutionInterceptor {
-  private val ClientSpanAttribute = new ExecutionAttribute[Span]("SdkClientSpan")
+  import AwsSdkClientExecutionInterceptor.ClientSpanAttribute
 
   override def afterMarshalling(context: Context.AfterMarshalling, executionAttributes: ExecutionAttributes): Unit = {
     val operationName = executionAttributes.getAttribute(SdkExecutionAttribute.OPERATION_NAME)
@@ -55,4 +55,8 @@ class AwsSdkClientExecutionInterceptor extends ExecutionInterceptor {
       kamonSpan.fail(context.exception()).finish()
     }
   }
+}
+
+object AwsSdkClientExecutionInterceptor {
+  private val ClientSpanAttribute = new ExecutionAttribute[Span]("SdkClientSpan")
 }

--- a/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkRequestHandler.scala
+++ b/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkRequestHandler.scala
@@ -29,7 +29,7 @@ import kamon.trace.Span
   * included in the "software/amazon/awssdk/global/handlers/execution.interceptors" file shipped with this module.
   */
 class AwsSdkRequestHandler extends RequestHandler2 {
-  val SpanContextKey = new HandlerContextKey[Span](classOf[Span].getName)
+  import AwsSdkRequestHandler.SpanContextKey
 
   override def beforeRequest(request: Request[_]): Unit = {
     val serviceName = request.getServiceName
@@ -66,4 +66,8 @@ class AwsSdkRequestHandler extends RequestHandler2 {
         .finish()
     }
   }
+}
+
+object AwsSdkRequestHandler {
+  private val SpanContextKey = new HandlerContextKey[Span](classOf[Span].getName)
 }


### PR DESCRIPTION
The change is only really necessary on the request interceptor (for the 2.x AWS SDK) but it didn't hurt to make that initialization only once for the 1.x version as well. This should fix #1173.