### PR TITLE
fix dynalite dependency scope, fixes #1171

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -612,7 +612,7 @@ lazy val `kamon-aws-sdk` = (project in file("instrumentation/kamon-aws-sdk"))
 
       scalatest % "test",
       logbackClassic % "test",
-      "org.testcontainers" % "dynalite" % "1.17.1"
+      "org.testcontainers" % "dynalite" % "1.17.1" % "test"
     )
   ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-testkit` % "test")
 


### PR DESCRIPTION
The dynalite dependency wasn't on the `Test` scope and ended up bringing a bunch of stuff that got packaged in the bundle jar :cry: 

This fixes it.