### PR TITLE
Adds metrics-excludes configuration to summary setttings

### DIFF
--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -67,6 +67,13 @@ kamon.prometheus {
       # "*akka*"
     ]
 
+    # Names of the histograms, timer and range sampler metrics that shouldn't be exported as summaries,
+    # even when they are included in the "metrics" configuration. All patterns are treated as Glob patterns.
+    metrics-excludes = [
+      # example:
+      # "request-size*"
+    ]
+
     # Quantiles that should be reported (will be translated to the according percentiles)
     quantiles = [
       0.5,

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
@@ -37,7 +37,8 @@ object PrometheusSettings {
 
   case class SummarySettings(
     quantiles: Seq[java.lang.Double],
-    metricMatchers: Seq[Glob]
+    metricMatchers: Seq[Glob],
+    metricExcludes: Seq[Glob]
   )
 
   case class GaugeSettings(metricMatchers: Seq[Glob])
@@ -51,7 +52,8 @@ object PrometheusSettings {
       includeEnvironmentTags = prometheusConfig.getBoolean("include-environment-tags"),
       summarySettings = SummarySettings(
         quantiles = prometheusConfig.getDoubleList("summaries.quantiles").asScala.toSeq,
-        metricMatchers = prometheusConfig.getStringList("summaries.metrics").asScala.map(Glob).toSeq
+        metricMatchers = prometheusConfig.getStringList("summaries.metrics").asScala.map(Glob).toSeq,
+        metricExcludes = prometheusConfig.getStringList("summaries.metrics-excludes").asScala.map(Glob).toSeq
       ),
       gaugeSettings = GaugeSettings(
         metricMatchers = prometheusConfig.getStringList("gauges.metrics").asScala.map(Glob).toSeq

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -119,7 +119,9 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
   }
 
   private def appendDistributionMetric(metric: MetricSnapshot.Distributions): Unit = {
-    val reportAsSummary = prometheusConfig.summarySettings.metricMatchers.exists(_.accept(metric.name))
+    val reportAsSummary = prometheusConfig.summarySettings.metricMatchers.exists(_.accept(metric.name)) &&
+      !prometheusConfig.summarySettings.metricExcludes.exists(_.accept(metric.name))
+
     if (reportAsSummary) {
         appendDistributionMetricAsSummary(metric)
     } else {

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -321,6 +321,47 @@ class ScrapeDataBuilderSpec extends AnyWordSpec with Matchers {
 
     }
 
+    "append summary only for matching metrics, but filter out excluded summaries" in {
+      val histogramWithHundredEntries = constantDistribution("firstMetric", none, 1, 100)
+      val histogramWithHundredEntriesTwo = constantDistribution("secondMetric", none, 1, 100)
+      val result = builder(withSummary = Seq("*Metric*"), withSummaryExcludes = Seq("secondMetric*"))
+        .appendHistograms(Seq(histogramWithHundredEntries, histogramWithHundredEntriesTwo))
+        .build()
+      result should include {
+        """|# TYPE firstMetric summary
+           |firstMetric{quantile="0.5"} 50.0
+           |firstMetric{quantile="0.75"} 75.0
+           |firstMetric{quantile="0.95"} 95.0
+           |firstMetric{quantile="0.99"} 99.0
+           |firstMetric_count 100.0
+           |firstMetric_sum 5050.0
+           |""".stripMargin
+      }
+      result should not include {
+        """|# TYPE secondMetric summary
+           |firstMetric{quantile="0.5"} 50.0
+           |firstMetric{quantile="0.75"} 75.0
+           |firstMetric{quantile="0.95"} 95.0
+           |firstMetric{quantile="0.99"} 99.0
+           |firstMetric_count 100.0
+           |firstMetric_sum 5050.0
+           |""".stripMargin
+      }
+      result should include {
+        """|# TYPE secondMetric histogram
+           |secondMetric_bucket{le="5.0"} 5.0
+           |secondMetric_bucket{le="7.0"} 7.0
+           |secondMetric_bucket{le="8.0"} 8.0
+           |secondMetric_bucket{le="9.0"} 9.0
+           |secondMetric_bucket{le="10.0"} 10.0
+           |secondMetric_bucket{le="11.0"} 11.0
+           |secondMetric_bucket{le="12.0"} 12.0
+           |secondMetric_bucket{le="+Inf"} 100.0
+           |""".stripMargin
+      }
+    }
+
+
     "append gauges only for matching metrics" in {
       val histogramWithHundredEntries = constantDistribution("firstMetric", none, 1, 100)
       val histogramWithHundredEntriesTwo = constantDistribution("secondMetric", none, 1, 100)
@@ -397,6 +438,7 @@ class ScrapeDataBuilderSpec extends AnyWordSpec with Matchers {
                       customBuckets: Map[String, Seq[java.lang.Double]] = Map("histogram.custom-buckets" -> Seq(1D, 3D)),
                       environmentTags: TagSet = TagSet.Empty,
                       withSummary: Seq[String] = Seq.empty,
+                      withSummaryExcludes: Seq[String] = Seq.empty,
                       withGauges: Seq[String] = Seq.empty) = {
     new ScrapeDataBuilder(
       PrometheusSettings.Generic(
@@ -405,7 +447,7 @@ class ScrapeDataBuilderSpec extends AnyWordSpec with Matchers {
         buckets,
         customBuckets,
         false,
-        SummarySettings(Seq(0.5, 0.75, 0.95, 0.99), withSummary.map(Glob)),
+        SummarySettings(Seq(0.5, 0.75, 0.95, 0.99), withSummary.map(Glob), withSummaryExcludes.map(Glob)),
         GaugeSettings(withGauges.map(Glob))),
       environmentTags
     )


### PR DESCRIPTION
Allows to exclude certain metrics from being reported as summaries. This is especially helpful when using "**" to report all metrics as summaries.