### PR TITLE
use Play Environment's classloader when creating Kamon-related objects

### DIFF
--- a/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/GuiceModule.scala
+++ b/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/GuiceModule.scala
@@ -36,6 +36,8 @@ object GuiceModule {
     Logger(classOf[KamonLoader]).info("Reconfiguring Kamon with Play's Config")
     Logger(classOf[KamonLoader]).info(configuration.underlying.getString("play.server.provider"))
     Logger(classOf[KamonLoader]).info(configuration.underlying.getString("kamon.trace.tick-interval"))
+
+    kamon.ClassLoading.changeClassLoader(environment.classLoader)
     Kamon.initWithoutAttaching(configuration.underlying)
 
     lifecycle.addStopHook { () =>


### PR DESCRIPTION
This solves `ClassNotFoundException`s thrown when a Play application is running on development mode and the application requires Kamon to dynamically create object instances for classes that belong to the Play project itself.

For example, creating a custom slow statement processor for the JDBC instrumentation within a Play project. This will always fail in development mode, but work fine on production.