### PR TITLE
use coursier/setup-action Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
-      - uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v3
         with:
-          java-version: adopt@1.8.0-292
+          distribution: 'adopt'
+          java-version: '8'
       - name: Test
         run: sbt -v ";+core/test;+instrumentation/test;+reporters/test"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
-      - uses: actions/setup-java@v3
+      - uses: coursier/cache-action@v6
+      - uses: coursier/setup-action@v1
         with:
-          distribution: 'adopt'
-          java-version: '8'
+          jvm: adopt:8
+          apps: sbt
       - name: Test
         run: sbt -v ";+core/test;+instrumentation/test;+reporters/test"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
-      - uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '8'
       - name: Release
         run: sbt ";+instrumentation/publishLocal; release"
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: git fetch --depth=1 origin '+refs/tags/*:refs/tags/*'
-      - uses: actions/setup-java@v3
+      - uses: coursier/cache-action@v6
+      - uses: coursier/setup-action@v1
         with:
-          distribution: 'adopt'
-          java-version: '8'
-          cache: 'sbt'
+          jvm: adopt:8
+          apps: sbt
       - name: Release
         run: sbt ";+instrumentation/publishLocal; release"
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '8'
+          cache: 'sbt'
       - name: Release
         run: sbt ";+instrumentation/publishLocal; release"
         shell: bash


### PR DESCRIPTION
Migrating to `coursier/setup-action`, mostly because the `setup-scala` action started failing and I don't have the time/bandwidth to figure out why. Seemed related to Jabba but not sure :shrug: 