### PR TITLE
Cross compile kamon-instrumentation-common with scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,6 +160,8 @@ lazy val `kamon-instrumentation-common` = (project in file("instrumentation/kamo
   .settings(instrumentationSettings)
   .settings(
         crossScalaVersions += `scala_3_version`,
+  ).settings(
+    scalacOptions ++= { if(scalaBinaryVersion.value.startsWith("3.")) Seq("-Xtarget:8") else Seq.empty }
   )
   .settings(
     resolvers += Resolver.mavenLocal,

--- a/build.sbt
+++ b/build.sbt
@@ -160,8 +160,6 @@ lazy val `kamon-instrumentation-common` = (project in file("instrumentation/kamo
   .settings(instrumentationSettings)
   .settings(
         crossScalaVersions += `scala_3_version`,
-  ).settings(
-    scalacOptions ++= { if(scalaBinaryVersion.value.startsWith("3.")) Seq("-Xtarget:8") else Seq.empty }
   )
   .settings(
     resolvers += Resolver.mavenLocal,
@@ -826,7 +824,6 @@ lazy val bundle = (project in file("bundle"))
 
 import com.lightbend.sbt.javaagent.Modules
 import BundleKeys._
-import sbt.Keys.scalacOptions
 
 lazy val commonBundleSettings = Seq(
   moduleName := "kamon-bundle",

--- a/build.sbt
+++ b/build.sbt
@@ -159,6 +159,9 @@ lazy val `kamon-instrumentation-common` = (project in file("instrumentation/kamo
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
   .settings(
+        crossScalaVersions += `scala_3_version`,
+  )
+  .settings(
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       slf4jApi % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -824,6 +824,7 @@ lazy val bundle = (project in file("bundle"))
 
 import com.lightbend.sbt.javaagent.Modules
 import BundleKeys._
+import sbt.Keys.scalacOptions
 
 lazy val commonBundleSettings = Seq(
   moduleName := "kamon-bundle",

--- a/instrumentation/kamon-instrumentation-common/src/main/scala-2.11/scala/annotation/static.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala-2.11/scala/annotation/static.scala
@@ -1,0 +1,4 @@
+package scala.annotation
+
+import scala.annotation.meta._
+final class static extends StaticAnnotation

--- a/instrumentation/kamon-instrumentation-common/src/main/scala-2.12/scala/annotation/static.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala-2.12/scala/annotation/static.scala
@@ -1,0 +1,4 @@
+package scala.annotation
+
+import scala.annotation.meta._
+final class static extends StaticAnnotation

--- a/instrumentation/kamon-instrumentation-common/src/main/scala-2.13/scala/annotation/static.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala-2.13/scala/annotation/static.scala
@@ -1,0 +1,4 @@
+package scala.annotation
+
+import scala.annotation.meta._
+final class static extends StaticAnnotation

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentContext.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentContext.scala
@@ -24,7 +24,7 @@ import kanela.agent.libs.net.bytebuddy.asm.Advice
   * Advise that copies the current Context from Kamon into a HasContext instance when the advised method starts
   * executing.
   */
-class CaptureCurrentContextOnEnter
+class CaptureCurrentContextOnEnter private()
 object CaptureCurrentContextOnEnter {
 
   @Advice.OnMethodEnter

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentContext.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentContext.scala
@@ -17,13 +17,14 @@
 package kamon
 package instrumentation
 package context
-
+import scala.annotation.static
 import kanela.agent.libs.net.bytebuddy.asm.Advice
 
 /**
   * Advise that copies the current Context from Kamon into a HasContext instance when the advised method starts
   * executing.
   */
+class CaptureCurrentContextOnEnter
 object CaptureCurrentContextOnEnter {
 
   @Advice.OnMethodEnter
@@ -36,10 +37,11 @@ object CaptureCurrentContextOnEnter {
   * Advise that copies the current Context from Kamon into a HasContext instance when the advised method finishes
   * executing.
   */
+class CaptureCurrentContextOnExit
 object CaptureCurrentContextOnExit {
 
   @Advice.OnMethodExit
-  def exit(@Advice.This hasContext: HasContext): Unit =
+  @static def exit(@Advice.This hasContext: HasContext): Unit =
     hasContext.setContext(Kamon.currentContext())
 
 }

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentContext.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentContext.scala
@@ -28,7 +28,7 @@ class CaptureCurrentContextOnEnter
 object CaptureCurrentContextOnEnter {
 
   @Advice.OnMethodEnter
-  def enter(@Advice.This hasContext: HasContext): Unit =
+  @static def enter(@Advice.This hasContext: HasContext): Unit =
     hasContext.setContext(Kamon.currentContext())
 
 }

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentTimestamp.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentTimestamp.scala
@@ -18,14 +18,16 @@ package kamon.instrumentation.context
 
 import kanela.agent.libs.net.bytebuddy.asm.Advice
 
+import scala.annotation.static
 /**
   * Advise that copies the current System.nanoTime into a HasTimestamp instance when the advised method starts
   * executing.
   */
+class CaptureCurrentTimestampOnEnter
 object CaptureCurrentTimestampOnEnter {
 
   @Advice.OnMethodEnter
-  def enter(@Advice.This hasTimestamp: HasTimestamp): Unit =
+  @static def enter(@Advice.This hasTimestamp: HasTimestamp): Unit =
     hasTimestamp.setTimestamp(System.nanoTime())
 
 }

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentTimestamp.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/CaptureCurrentTimestamp.scala
@@ -23,7 +23,7 @@ import scala.annotation.static
   * Advise that copies the current System.nanoTime into a HasTimestamp instance when the advised method starts
   * executing.
   */
-class CaptureCurrentTimestampOnEnter
+class CaptureCurrentTimestampOnEnter private()
 object CaptureCurrentTimestampOnEnter {
 
   @Advice.OnMethodEnter

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/InvokeWithCapturedContext.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/InvokeWithCapturedContext.scala
@@ -21,17 +21,19 @@ package context
 
 import kamon.context.Storage
 import kanela.agent.libs.net.bytebuddy.asm.Advice
-
+import scala.annotation.meta.param
+import scala.annotation.static
 /**
   * Advice that sets the Context from a HasContext instance as the current Context while the advised method is invoked.
   */
+class InvokeWithCapturedContext
 object InvokeWithCapturedContext {
 
   @Advice.OnMethodEnter
-  def enter(@Advice.This hasContext: HasContext): Storage.Scope =
+  @static def enter(@(Advice.This@param) hasContext: HasContext): Storage.Scope =
     Kamon.storeContext(hasContext.context)
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable])
-  def exit(@Advice.Enter scope: Storage.Scope): Unit =
+  @static def exit(@(Advice.Enter@param) scope: Storage.Scope): Unit =
     scope.close()
 }

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/InvokeWithCapturedContext.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/InvokeWithCapturedContext.scala
@@ -21,7 +21,6 @@ package context
 
 import kamon.context.Storage
 import kanela.agent.libs.net.bytebuddy.asm.Advice
-import scala.annotation.meta.param
 import scala.annotation.static
 /**
   * Advice that sets the Context from a HasContext instance as the current Context while the advised method is invoked.
@@ -30,10 +29,10 @@ class InvokeWithCapturedContext private()
 object InvokeWithCapturedContext {
 
   @Advice.OnMethodEnter
-  @static def enter(@(Advice.This@param) hasContext: HasContext): Storage.Scope =
+  @static def enter(@Advice.This hasContext: HasContext): Storage.Scope =
     Kamon.storeContext(hasContext.context)
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable])
-  @static def exit(@(Advice.Enter@param) scope: Storage.Scope): Unit =
+  @static def exit(@Advice.Enter scope: Storage.Scope): Unit =
     scope.close()
 }

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/InvokeWithCapturedContext.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/context/InvokeWithCapturedContext.scala
@@ -26,7 +26,7 @@ import scala.annotation.static
 /**
   * Advice that sets the Context from a HasContext instance as the current Context while the advised method is invoked.
   */
-class InvokeWithCapturedContext
+class InvokeWithCapturedContext private()
 object InvokeWithCapturedContext {
 
   @Advice.OnMethodEnter

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/package.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/package.scala
@@ -33,7 +33,7 @@ package object instrumentation {
     def advise[A](method: Junction[MethodDescription], advice: A)(implicit singletonEvidence: A <:< Singleton): InstrumentationBuilder.Target
   }
 
-  implicit def adviseWithCompanionObject(target: InstrumentationBuilder.Target) = new AdviseWithCompanionObject {
+  implicit def adviseWithCompanionObject(target: InstrumentationBuilder.Target): AdviseWithCompanionObject = new AdviseWithCompanionObject {
 
     override def advise[A](method: Junction[MethodDescription], advice: A)(implicit singletonEvidence: A <:< Singleton): InstrumentationBuilder.Target = {
       // Companion object instances always have the '$' sign at the end of their class name, we must remove it to get

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -164,7 +164,7 @@ object BaseProject extends AutoPlugin {
       case Some((2,11)) => Seq("-Xfuture", "-Ybackend:GenASM")
       case Some((2,12)) => Seq("-Xfuture", "-opt:l:method,-closure-invocations")
       case Some((2,13)) => Seq.empty
-      case Some((3, _)) => Seq("-source:3.0-migration")
+      case Some((3, _)) => Seq("-source:3.0-migration", "-Xtarget:8")
       case _ => Seq.empty
     })
   )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -59,7 +59,7 @@ object BaseProject extends AutoPlugin {
     val `scala_2.11_version` = "2.11.12"
     val `scala_2.12_version` = "2.12.15"
     val `scala_2.13_version` = "2.13.8"
-    val scala_3_version = "3.0.2"
+    val scala_3_version = "3.1.3"
 
     // This installs the GPG signing key from the
     setupGpg()


### PR DESCRIPTION
Hello,
Thank you for your work on Kamon.

We are recently looking to upgrade to scala 3 and stumbled upon some kamon modules not having scala 3 builds. One in particular is kamon-http4s which depends on kamon-core and kamon-instrumentation-common .

~~It seems easy enough to add scala 3 to the latter. I have already done the work for kamon-http4s , just need an official release if you can and send you a PR on that project too.~~

Please let me know what you think.

Kind regards


EDIT:
just saw this https://github.com/kamon-io/Kamon/issues/1064

I'll have a deeper look