### PR TITLE
include a simpler way to ignore operations on Kamon's tracer

### DIFF
--- a/core/kamon-core-tests/src/test/resources/reference.conf
+++ b/core/kamon-core-tests/src/test/resources/reference.conf
@@ -11,6 +11,8 @@ kamon {
   trace {
     sampler = always
 
+    ignored-operations = ["/status", "/ready"]
+
     adaptive-sampler {
       throughput = 600
 

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/TracerSpec.scala
@@ -119,6 +119,16 @@ class TracerSpec extends AnyWordSpec with Matchers with SpanInspection.Syntax wi
       Reconfigure.reset()
     }
 
+    "never sample ignored operations" in {
+      Reconfigure.sampleAlways()
+
+      Kamon.spanBuilder("/ready").start().trace.samplingDecision shouldBe(SamplingDecision.DoNotSample)
+      Kamon.spanBuilder("/status").start().trace.samplingDecision shouldBe(SamplingDecision.DoNotSample)
+      Kamon.spanBuilder("/other").start().trace.samplingDecision shouldBe(SamplingDecision.Sample)
+
+      Reconfigure.reset()
+    }
+
     "figure out the position of a Span in its trace" in {
       Kamon.spanBuilder("root").start().position shouldBe Position.Root
       Kamon.spanBuilder("localRoot").asChildOf(remoteSpan()).start().position shouldBe Position.LocalRoot

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -180,6 +180,17 @@ kamon {
     # as failed.
     include-error-type = yes
 
+    # List of operation names that should not be sampled, regardless of the configured sampler. This is useful when you
+    # need to prevent gathering metrics from operations like status checks and readiness endpoints that skew your
+    # overall throughput and latency metrics.
+    #
+    # Beware that these operations are only ignored when the sampling decision is taken by the current process. If a
+    # sampling decision was already taken by a previous service then this setting will have no effect.
+    ignored-operations = []
+
+    # Decides wether whether ignored operations should generate metrics or not.
+    track-metrics-on-ignored-operations = no
+
     # Configures a sampler that decides which Spans should be sent to Span reporters. The possible values are:
     #   - always: report all traces.
     #   - never:  don't report any trace.

--- a/core/kamon-core/src/main/scala/kamon/trace/Tracer.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Tracer.scala
@@ -55,6 +55,8 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
   @volatile private var _localTailSamplerSettings: LocalTailSamplerSettings = LocalTailSamplerSettings(false, Int.MaxValue, Long.MaxValue)
   @volatile private var _scheduler: Option[ScheduledExecutorService] = None
   @volatile private var _includeErrorType: Boolean = false
+  @volatile private var _ignoredOperations: Set[String] = Set.empty
+  @volatile private var _trackMetricsOnIgnoredOperations: Boolean = false
   private val _onSpanFinish: Span.Finished => Unit = _spanBuffer.offer
 
   reconfigure(initialConfig)
@@ -368,8 +370,15 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
       }
     }
 
-    private def suggestedOrSamplerDecision(): SamplingDecision =
-      _suggestedSamplingDecision.getOrElse(_sampler.decide(this))
+    private def suggestedOrSamplerDecision(): SamplingDecision = {
+      if(_ignoredOperations.contains(_name)) {
+        if(!_trackMetricsOnIgnoredOperations)
+          doNotTrackMetrics()
+
+        SamplingDecision.DoNotSample
+      } else
+        _suggestedSamplingDecision.getOrElse(_sampler.decide(this))
+    }
 
     private def suggestedOrGeneratedTraceId(): Identifier =
       if(_suggestedTraceId.isEmpty) identifierScheme.traceIdFactory.generate() else _suggestedTraceId
@@ -430,6 +439,8 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
       val tagWithUpstreamService = traceConfig.getBoolean("span-metric-tags.upstream-service")
       val tagWithParentOperation = traceConfig.getBoolean("span-metric-tags.parent-operation")
       val includeErrorStacktrace = traceConfig.getBoolean("include-error-stacktrace")
+      val ignoredOperations = traceConfig.getStringList("ignored-operations").asScala.toSet
+      val trackMetricsOnIgnoredOperations = traceConfig.getBoolean("track-metrics-on-ignored-operations")
       val includeErrorType = traceConfig.getBoolean("include-error-type")
       val delayedSpanReportingDelay = traceConfig.getDuration("span-reporting-delay")
       val localTailSamplerSettings = LocalTailSamplerSettings(
@@ -457,6 +468,8 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
       _joinRemoteParentsWithSameSpanID = joinRemoteParentsWithSameSpanID
       _includeErrorStacktrace = includeErrorStacktrace
       _includeErrorType = includeErrorType
+      _ignoredOperations = ignoredOperations
+      _trackMetricsOnIgnoredOperations = trackMetricsOnIgnoredOperations
       _tagWithUpstreamService = tagWithUpstreamService
       _tagWithParentOperation = tagWithParentOperation
       _traceReporterQueueSize = traceReporterQueueSize


### PR DESCRIPTION
These PR adds two settings to solve one of the most common questions we get asked about sampling: how do we disable sampling for health checks and status endpoints? Now there is one specific setting for that:

```
kamon.trace.ignored-operations = ["/status", "/health", "/ready"]
```
This has a few advantages over the groups configuration on the adaptive sampler:
- It works with all samplers, including `always` and `random`.
- It comes with a `track-metrics-on-ignored-operations` setting, which allows to disable metrics for these operations too (the adaptive sampler would only disable sampling but still track metrics for all operations).



