### PR TITLE
consider ignored-operations when taking deferred sampling decisions

### DIFF
--- a/core/kamon-core/src/main/scala/kamon/trace/Tracer.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/Tracer.scala
@@ -366,7 +366,8 @@ class Tracer(initialConfig: Config, clock: Clock, contextStorage: ContextStorage
 
         new Span.Local(id, parentId, trace, position, _kind, localParent, _name, _spanTags, _metricTags, at, _marks, _links,
           _trackMetrics, _tagWithParentOperation, _includeErrorStacktrace, isDelayed, clock, _preFinishHooks, _onSpanFinish,
-          _sampler, _scheduler.get, _delayedSpanReportingDelay, _localTailSamplerSettings, _includeErrorType)
+          _sampler, _scheduler.get, _delayedSpanReportingDelay, _localTailSamplerSettings, _includeErrorType,
+          _ignoredOperations, _trackMetricsOnIgnoredOperations)
       }
     }
 


### PR DESCRIPTION
This fix ensures that ignored operations will be taken into account when using deferred sampling decisions (which we do in pretty much every HTTP framework instrumentation!)