### PR TITLE
bump sbt-sonatype version to 3.9.13

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.13")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.5.0")
 


### PR DESCRIPTION
Every now and then we have the release Github Action [failing](https://github.com/kamon-io/Kamon/runs/7996957462?check_suite_focus=true) due to timeouts, even though the release actually goes through successfully. I went through sbt-sonatype's release notes and saw a something about retries and increased timeouts so maybe this upgrade is all we need :crossed_fingers: 