### PR TITLE
add memory utilization metrics and support for ZGC/Shenandoah

### DIFF
--- a/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
+++ b/instrumentation/kamon-system-metrics/src/main/scala/kamon/instrumentation/system/jvm/JvmMetrics.scala
@@ -45,6 +45,12 @@ object JvmMetrics {
     unit = MeasurementUnit.information.bytes
   )
 
+  val MemoryUtilization = Kamon.histogram(
+    name = "jvm.memory.utilization",
+    description = "Tracks the percentage of heap used across old/tenured/single memory regions after GC events",
+    unit = MeasurementUnit.percentage
+  )
+
   val MemoryFree = Kamon.histogram(
     name = "jvm.memory.free",
     description = "Samples the free space in a memory region",
@@ -148,7 +154,7 @@ object JvmMetrics {
   class GarbageCollectionInstruments(tags: TagSet) extends InstrumentGroup(tags) {
     private val _collectorCache = mutable.Map.empty[String, Histogram]
 
-    val allocation = register(MemoryAllocation)
+    val memoryUtilization = register(MemoryUtilization)
     val promotionToOld = register(GcPromotion, "space", "old")
 
     def garbageCollectionTime(collector: Collector): Histogram =
@@ -163,6 +169,8 @@ object JvmMetrics {
   }
 
   class MemoryUsageInstruments(tags: TagSet) extends InstrumentGroup(tags) {
+    val allocation = register(MemoryAllocation)
+
     private val _memoryRegionsCache = mutable.Map.empty[String, MemoryRegionInstruments]
     private val _memoryPoolsCache = mutable.Map.empty[String, MemoryRegionInstruments]
     private val _memoryBuffersCache = mutable.Map.empty[String, BufferPoolInstruments]


### PR DESCRIPTION
The PR includes three improvements to our GC-related metrics:
- It categorizes correctly the memory usage regions and gc times for the ZGC and Shenandoah collectors
- Add a new `jvm.memory.utilization` metric that tracks the percentage of memory used across old/tenured/single regions. This metric simplifies GC monitoring and alerting because there is no need to do math on the monitoring backend to come up with the usage based on max vs used memory
- Use `ThreadMXBean.getThreadAllocatedBytes(...)` to measure allocated bytes instead of trying to infer the allocated bytes from the Eden sizes. This is a more reliable approach, although we might miss some allocation data when threads disappear (which is not typical in common application behavior where a set number of thread pools are allocated and stay constant through the app's lifetime)