### PR TITLE
increase the default range of http.server.connection.lifetime metric, fixes #1201

### DIFF
--- a/instrumentation/kamon-instrumentation-common/src/main/resources/reference.conf
+++ b/instrumentation/kamon-instrumentation-common/src/main/resources/reference.conf
@@ -251,4 +251,15 @@ kamon {
       }
     }
   }
+
+  metric.factory.custom-settings {
+
+    # Increases the range of this metric to cover up to ~7 days while still saving 30% of space in
+    # allocated histograms. Should prevent the most common warnings about out-of-range updates.
+    #
+    "http.server.connection.lifetime" {
+      lowest-discernible-value = 1000000
+      highest-trackable-value = 6E14
+    }
+  }
 }


### PR DESCRIPTION
Details in #1201.