### PR TITLE
make kamon-scala-future and kamon-kafka modules pass tests for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -228,6 +228,7 @@ lazy val `kamon-scala-future` = (project in file("instrumentation/kamon-scala-fu
   .disablePlugins(AssemblyPlugin)
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
+  .settings(crossScalaVersions += `scala_3_version`)
   .settings(
     libraryDependencies ++=Seq(
       kanelaAgent % "provided",
@@ -312,6 +313,7 @@ lazy val `kamon-kafka` = (project in file("instrumentation/kamon-kafka"))
   .disablePlugins(AssemblyPlugin)
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
+  .settings(crossScalaVersions += `scala_3_version`)
   .settings(
     libraryDependencies ++= Seq(
       kanelaAgent                 % "provided",
@@ -319,8 +321,7 @@ lazy val `kamon-kafka` = (project in file("instrumentation/kamon-kafka"))
 
       scalatest                   % "test",
       logbackClassic              % "test",
-      "io.github.embeddedkafka"   %% "embedded-kafka"   % "2.4.1.1" % "test"
-    )
+      "io.github.embeddedkafka"   %% "embedded-kafka"   % "2.4.1.1" % "test" cross CrossVersion.for3Use2_13)
   ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-testkit` % "test")
 
 

--- a/instrumentation/kamon-kafka/src/test/scala/kamon/instrumentation/kafka/testutil/TestSpanReporting.scala
+++ b/instrumentation/kamon-kafka/src/test/scala/kamon/instrumentation/kafka/testutil/TestSpanReporting.scala
@@ -17,9 +17,9 @@ package kamon.instrumentation.kafka.testutil
 import kamon.Kamon
 import kamon.module.Module.Registration
 import kamon.testkit.{Reconfigure, TestSpanReporter}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.{BeforeAndAfter, Suite}
 
-trait TestSpanReporting extends Reconfigure { _: BeforeAndAfter =>
+trait TestSpanReporting extends Reconfigure { this: BeforeAndAfter with Suite =>
   var registration: Registration = _
   val reporter = new TestSpanReporter.BufferingSpanReporter
 

--- a/instrumentation/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
+++ b/instrumentation/kamon-scala-future/src/test/scala/kamon/instrumentation/futures/scala/FutureInstrumentationSpec.scala
@@ -33,7 +33,7 @@ class FutureInstrumentationSpec extends AnyWordSpec with Matchers with ScalaFutu
   //       is no need to have explicit Runnable/Callable instrumentation because the instrumentation brought by the
   //       kamon-executors module should take care of all non-JDK Runnable/Callable implementations.
 
-  implicit val execContext = ExecutionContext.Implicits.global
+  implicit val execContext: ExecutionContext = ExecutionContext.Implicits.global
 
   "a Scala Future created when instrumentation is active" should {
     "capture the Context available when created" which {


### PR DESCRIPTION
Enables scala 3 for a couple more instrumentation modules