### PR TITLE
tweak cats-effect-3 instrumentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -270,7 +270,7 @@ lazy val `kamon-cats-io-3` = (project in file("instrumentation/kamon-cats-io-3")
       logbackClassic % "test"
     ),
 
-  ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-testkit` % "test")
+  ).dependsOn(`kamon-core`, `kamon-executors`, `kamon-scala-future` % "test", `kamon-testkit` % "test")
 
 
 lazy val `kamon-logback` = (project in file("instrumentation/kamon-logback"))

--- a/instrumentation/kamon-cats-io-3/src/main/scala/kamon/instrumentation/cats3/IOFiberInstrumentation.scala
+++ b/instrumentation/kamon-cats-io-3/src/main/scala/kamon/instrumentation/cats3/IOFiberInstrumentation.scala
@@ -12,8 +12,6 @@ class IOFiberInstrumentation extends InstrumentationBuilder {
 
   onType("cats.effect.IOFiber")
     .mixin(classOf[HasContext.Mixin])
-    .advise(isConstructor.and(takesArguments(9)), AfterFiberInit)
-    .advise(method("suspend"), SaveCurrentContextOnExit)
     .advise(method("run"), RunLoopWithContext)
 
 
@@ -43,15 +41,6 @@ class IOFiberInstrumentation extends InstrumentationBuilder {
     .advise(method("sleep"), classOf[CleanSchedulerContextAdvice])
 }
 
-class AfterFiberInit
-object AfterFiberInit {
-
-  @Advice.OnMethodExit
-  @static def exit(@Advice.This fiber: Any): Unit ={
-    fiber.asInstanceOf[HasContext].setContext(Kamon.currentContext())
-  }
-}
-
 class RunLoopWithContext
 object RunLoopWithContext {
 
@@ -69,16 +58,6 @@ object RunLoopWithContext {
     fiber.asInstanceOf[HasContext].setContext(leftContext)
   }
 }
-
-class SaveCurrentContextOnExit
-object SaveCurrentContextOnExit {
-
-  @Advice.OnMethodExit()
-  @static def exit(@Advice.This fiber: Any): Unit = {
-    fiber.asInstanceOf[HasContext].setContext(Kamon.currentContext())
-  }
-}
-
 class SetContextOnNewFiber
 object SetContextOnNewFiber {
 

--- a/instrumentation/kamon-cats-io-3/src/main/scala/kamon/instrumentation/cats3/IOFiberInstrumentation.scala
+++ b/instrumentation/kamon-cats-io-3/src/main/scala/kamon/instrumentation/cats3/IOFiberInstrumentation.scala
@@ -14,7 +14,6 @@ class IOFiberInstrumentation extends InstrumentationBuilder {
     .mixin(classOf[HasContext.Mixin])
     .advise(isConstructor.and(takesArguments(9)), AfterFiberInit)
     .advise(method("suspend"), SaveCurrentContextOnExit)
-    .advise(method("resume"), RestoreContextOnSuccessfulResume)
     .advise(method("run"), RunLoopWithContext)
 
 
@@ -68,18 +67,6 @@ object RunLoopWithContext {
     scope.close()
 
     fiber.asInstanceOf[HasContext].setContext(leftContext)
-  }
-}
-
-class RestoreContextOnSuccessfulResume
-object RestoreContextOnSuccessfulResume {
-
-  @Advice.OnMethodExit()
-  @static def exit(@Advice.This fiber: Any, @Advice.Return wasSuspended: Boolean): Unit = {
-    if(wasSuspended) {
-      val ctxFiber = fiber.asInstanceOf[HasContext].context
-      Kamon.storeContext(ctxFiber)
-    }
   }
 }
 


### PR DESCRIPTION
- add new test case for cats-io-3 instrumentation
- rm 'RestoreContextOnSuccessfulResume' advice

I've been running into some funny behaviour when executing code using dispatchers and was able to minimise it in the tests. It seems like the 'resume' advice actually pollutes context under some circumstances, and it's not obvious that it ever actually does the right thing.

Some of the other instrumentation seemed redundant in light of this, so I removed that too. Tests still pass, as does the new one which was consistently failing before - however I'm conscious that I may be missing something here.

I'll think about this a bit more, and add new tests if inspiration strikes as to why we thought we needed those advice points in the first place, but thought it sensible to open up a pr for further discussion in the meantime 