### PR TITLE
additional CE3 context propagation tests + compat with CE 3.4.0-RC2

### DIFF
--- a/instrumentation/kamon-cats-io-3/src/main/scala/kamon/instrumentation/cats3/IOFiberInstrumentation.scala
+++ b/instrumentation/kamon-cats-io-3/src/main/scala/kamon/instrumentation/cats3/IOFiberInstrumentation.scala
@@ -12,7 +12,7 @@ class IOFiberInstrumentation extends InstrumentationBuilder {
 
   onType("cats.effect.IOFiber")
     .mixin(classOf[HasContext.Mixin])
-    .advise(isConstructor.and(takesArguments(9)), AfterFiberInit)
+    .advise(isConstructor.and(takesArguments(5).or(takesArguments(3))), AfterFiberInit)
     .advise(method("suspend"), SaveCurrentContextOnExit)
     .advise(method("resume"), RestoreContextOnSuccessfulResume)
     .advise(method("run"), RunLoopWithContext)


### PR DESCRIPTION
I'm adding an extra context propagation test and changing the instrumentation a little bit to match CE 3.4.0-RC2. The tests passed with 3.3.14, 3.4.0-RC1, and 3.4.0-RC2