### PR TITLE
reorganize the logback instrumentation to avoid stack overflows, fixes #1212

### DIFF
--- a/instrumentation/kamon-logback/src/main/java/kamon/instrumentation/logback/MdcPropertyMapAdvice.java
+++ b/instrumentation/kamon-logback/src/main/java/kamon/instrumentation/logback/MdcPropertyMapAdvice.java
@@ -1,0 +1,13 @@
+package kamon.instrumentation.logback;
+
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+
+import java.util.Map;
+
+public class MdcPropertyMapAdvice {
+
+  @Advice.OnMethodExit()
+  public static void onExit(@Advice.Return(readOnly = false) java.util.Map<String, String> propertyMap) {
+    propertyMap = ContextToMdcPropertyMapAppender.appendContext(propertyMap);
+  }
+}

--- a/instrumentation/kamon-logback/src/main/scala/kamon/instrumentation/logback/LogbackInstrumentation.scala
+++ b/instrumentation/kamon-logback/src/main/scala/kamon/instrumentation/logback/LogbackInstrumentation.scala
@@ -25,10 +25,8 @@ import kamon.tag.Tag
 import kamon.trace.{Identifier, Span}
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.asm.Advice
-import kanela.agent.libs.net.bytebuddy.implementation.bind.annotation.{RuntimeType, SuperCall}
-import org.slf4j.MDC
 
-import java.util.concurrent.Callable
+import java.util
 import scala.collection.JavaConverters._
 
 
@@ -41,7 +39,7 @@ class LogbackInstrumentation extends InstrumentationBuilder {
     .advise(method("appendLoopOnAppenders"), AppendLoopOnAppendersAdvice)
 
   onType("ch.qos.logback.classic.util.LogbackMDCAdapter")
-    .intercept(method("getPropertyMap"), GetPropertyMapMethodInterceptor)
+    .advise(method("getPropertyMap"), classOf[MdcPropertyMapAdvice])
 }
 
 object LogbackInstrumentation {
@@ -86,46 +84,40 @@ object AppendLoopOnAppendersAdvice {
     scope.close()
 }
 
-object GetPropertyMapMethodInterceptor {
+object ContextToMdcPropertyMapAppender {
 
-  @RuntimeType
-  def aroundGetMDCPropertyMap(@SuperCall callable: Callable[_]): Any = {
+  def appendContext(mdc: java.util.Map[String, String]): java.util.Map[String, String] = {
     val settings = LogbackInstrumentation.settings()
 
-    if (settings.propagateContextToMDC) {
-      val mdcContextMapBeforePropagation = MDC.getCopyOfContextMap
+    if (settings.propagateContextToMDC && mdc != null) {
       val currentContext = Kamon.currentContext()
       val span = currentContext.get(Span.Key)
+      val mdcWithKamonContext = new util.HashMap[String, String](mdc)
 
       if (span.trace.id != Identifier.Empty) {
-        MDC.put(settings.mdcTraceIdKey, span.trace.id.string)
-        MDC.put(settings.mdcSpanIdKey, span.id.string)
-        MDC.put(settings.mdcSpanOperationNameKey, span.operationName())
+        mdcWithKamonContext.put(settings.mdcTraceIdKey, span.trace.id.string)
+        mdcWithKamonContext.put(settings.mdcSpanIdKey, span.id.string)
+        mdcWithKamonContext.put(settings.mdcSpanOperationNameKey, span.operationName())
       }
 
       if (settings.mdcCopyTags) {
         currentContext.tags.iterator().foreach(t => {
-          MDC.put(t.key, Tag.unwrapValue(t).toString)
+          mdcWithKamonContext.put(t.key, Tag.unwrapValue(t).toString)
         })
       }
 
       settings.mdcCopyKeys.foreach { key =>
         currentContext.get(Context.key[Any](key, "")) match {
-          case Some(value) if value.toString.nonEmpty => MDC.put(key, value.toString)
-          case keyValue if keyValue != null && keyValue.toString.nonEmpty => MDC.put(key, keyValue.toString)
+          case Some(value) if value.toString.nonEmpty => mdcWithKamonContext.put(key, value.toString)
+          case keyValue if keyValue != null && keyValue.toString.nonEmpty => mdcWithKamonContext.put(key, keyValue.toString)
           case _ => // Just ignore the nulls and empty strings
         }
       }
 
-      try callable.call() finally {
-        if (mdcContextMapBeforePropagation != null) {
-          MDC.setContextMap(mdcContextMapBeforePropagation)
-        } else { // a null contextMap is possible and means 'empty'
-          MDC.clear()
-        }
-      }
+      // Returning an immutable map to reproduce what Logback does since 1.3.2
+      mdcWithKamonContext
     } else {
-      callable.call()
+      mdc
     }
   }
 }

--- a/instrumentation/kamon-logback/src/main/scala/kamon/instrumentation/logback/LogbackInstrumentation.scala
+++ b/instrumentation/kamon-logback/src/main/scala/kamon/instrumentation/logback/LogbackInstrumentation.scala
@@ -114,7 +114,6 @@ object ContextToMdcPropertyMapAppender {
         }
       }
 
-      // Returning an immutable map to reproduce what Logback does since 1.3.2
       mdcWithKamonContext
     } else {
       mdc


### PR DESCRIPTION
Instead of using an interceptor where we end up with calls to the super class, we are using an advice that overrides map returned by `ch.qos.logback.classic.util.LogbackMDCAdapter#getPropertyMap`. 

This makes the same instrumentation work with logback 1.2.x, 1.3.x, and 1.4.x.