### PR TITLE
kamon-redis bump + scala 3 compatibility 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -569,17 +569,18 @@ lazy val `kamon-redis` = (project in file("instrumentation/kamon-redis"))
   .enablePlugins(JavaAgent)
   .settings(instrumentationSettings)
   .settings(
+    crossScalaVersions += `scala_3_version`,
     libraryDependencies ++= Seq(
       kanelaAgent % "provided",
       "redis.clients" % "jedis"  % "3.6.0" % "provided",
       "io.lettuce" % "lettuce-core"  % "6.1.2.RELEASE" % "provided",
-      "com.github.etaty" %% "rediscala" % "1.9.0" % "provided",
 
       scalatest % "test",
       logbackClassic % "test",
       "org.testcontainers" % "testcontainers" % "1.15.3" % "test",
-    )
-  ).dependsOn(`kamon-core`, `kamon-testkit` % "test")
+    ) :+ (if (scalaVersion.value.startsWith("2.11")) "com.github.etaty" %% "rediscala" % "1.9.0" % "provided"
+          else "io.github.rediscala" %% "rediscala" % "1.13.0" % "provided")
+  ).dependsOn(`kamon-core`, `kamon-instrumentation-common`, `kamon-testkit` % "test")
 
 lazy val `kamon-caffeine` = (project in file("instrumentation/kamon-caffeine"))
   .disablePlugins(AssemblyPlugin)

--- a/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
+++ b/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/jedis/JedisInstrumentation.scala
@@ -26,6 +26,8 @@ import kanela.agent.libs.net.bytebuddy.asm.Advice
 import kanela.agent.libs.net.bytebuddy.description.method.MethodDescription
 import kanela.agent.libs.net.bytebuddy.matcher.ElementMatchers.{isMethod, isPublic, isStatic, namedOneOf, not}
 
+import scala.annotation.static
+
 class JedisInstrumentation extends InstrumentationBuilder {
 
   /**
@@ -87,7 +89,7 @@ object ClientOperationsAdvice {
   private val currentRedisOperationKey = "redis.current"
 
   @Advice.OnMethodEnter(suppress = classOf[Throwable])
-  def enter(@Advice.Origin("#m") methodName: String): Scope = {
+  @static def enter(@Advice.Origin("#m") methodName: String): Scope = {
     val currentContext = Kamon.currentContext()
 
     if(currentContext.getTag(plain(currentRedisOperationKey)) == null) {
@@ -106,7 +108,7 @@ object ClientOperationsAdvice {
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable], suppress = classOf[Throwable])
-  def exit(@Advice.Enter scope: Scope, @Advice.Thrown t: Throwable): Unit = {
+  @static def exit(@Advice.Enter scope: Scope, @Advice.Thrown t: Throwable): Unit = {
     if(scope != Scope.Empty) {
       val span = scope.context.get(Span.Key)
       if (t != null) {
@@ -123,7 +125,7 @@ class SendCommandAdvice
 object SendCommandAdvice {
 
   @Advice.OnMethodEnter
-  def sendCommand(@Advice.Argument(1) command: Any): Unit = {
+  @static def sendCommand(@Advice.Argument(1) command: Any): Unit = {
     // The command object should actually be an Enum and its toString() produces
     // the actual command name sent to Redis
     Kamon.currentSpan()
@@ -136,7 +138,7 @@ class SendCommandAdviceForJedis4
 object SendCommandAdviceForJedis4 {
 
   @Advice.OnMethodEnter
-  def sendCommand(@Advice.Argument(1) commandArguments: Any): Unit = {
+  @static def sendCommand(@Advice.Argument(1) commandArguments: Any): Unit = {
     val firstArgument = commandArguments.asInstanceOf[java.lang.Iterable[Any]].iterator().next()
 
     // The command object should actually be an Enum and its toString() produces

--- a/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/lettuce/LettuceInstrumentation.scala
+++ b/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/lettuce/LettuceInstrumentation.scala
@@ -6,6 +6,8 @@ import kamon.trace.Span
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.asm.Advice
 
+import scala.annotation.static
+
 class LettuceInstrumentation extends InstrumentationBuilder {
   onType("io.lettuce.core.AbstractRedisAsyncCommands")
     .advise(method("dispatch")
@@ -15,14 +17,14 @@ class LettuceInstrumentation extends InstrumentationBuilder {
 class AsyncCommandAdvice
 object AsyncCommandAdvice {
   @Advice.OnMethodEnter()
-  def enter(@Advice.Argument(0) command: RedisCommand[_, _, _]): Span = {
+  @static def enter(@Advice.Argument(0) command: RedisCommand[_, _, _]): Span = {
     val spanName = s"redis.command.${command.getType}"
     Kamon.clientSpanBuilder(spanName, "redis.client.lettuce")
       .start();
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable],suppress = classOf[Throwable])
-  def exit(@Advice.Enter span: Span,
+  @static def exit(@Advice.Enter span: Span,
            @Advice.Thrown t: Throwable,
            @Advice.Return asyncCommand: AsyncCommand[_, _, _]) = {
     if (t != null) {

--- a/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/rediscala/RediscalaInstrumentation.scala
+++ b/instrumentation/kamon-redis/src/main/scala/kamon/instrumentation/rediscala/RediscalaInstrumentation.scala
@@ -6,6 +6,7 @@ import kamon.util.CallingThreadExecutionContext
 import kanela.agent.api.instrumentation.InstrumentationBuilder
 import kanela.agent.libs.net.bytebuddy.asm.Advice
 
+import scala.annotation.static
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -22,7 +23,7 @@ class RediscalaInstrumentation extends InstrumentationBuilder {
 class RequestInstrumentation
 object RequestInstrumentation {
   @Advice.OnMethodEnter()
-  def enter(@Advice.Argument(0) command: Any): Span = {
+  @static def enter(@Advice.Argument(0) command: Any): Span = {
     val spanName = s"redis.command.${command.getClass.getSimpleName}"
 
     Kamon.clientSpanBuilder(spanName, "redis.client.rediscala")
@@ -30,7 +31,7 @@ object RequestInstrumentation {
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable], suppress = classOf[Throwable])
-  def exit(@Advice.Enter span: Span,
+  @static def exit(@Advice.Enter span: Span,
            @Advice.Thrown t: Throwable,
            @Advice.Return future: Future[_]) = {
     if (t != null) {
@@ -53,7 +54,7 @@ class RoundRobinRequestInstrumentation
 
 object RoundRobinRequestInstrumentation {
   @Advice.OnMethodEnter()
-  def enter(@Advice.Argument(1) command: Any): Span = {
+  @static def enter(@Advice.Argument(1) command: Any): Span = {
     println("Entering round robin")
     val spanName = s"redis.command.${command.getClass.getSimpleName}"
     Kamon.clientSpanBuilder(spanName, "redis.client.rediscala")
@@ -61,7 +62,7 @@ object RoundRobinRequestInstrumentation {
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable], suppress = classOf[Throwable])
-  def exit(@Advice.Enter span: Span,
+  @static def exit(@Advice.Enter span: Span,
            @Advice.Thrown t: Throwable,
            @Advice.Return future: Future[_]) = {
     println("Exiting round robin")
@@ -84,14 +85,14 @@ object RoundRobinRequestInstrumentation {
 class ActorRequestAdvice
 object ActorRequestAdvice {
   @Advice.OnMethodEnter()
-  def enter(@Advice.Argument(1) command: Any): Span = {
+  @static def enter(@Advice.Argument(1) command: Any): Span = {
     val spanName = s"redis.command.${command.getClass.getSimpleName}"
     Kamon.clientSpanBuilder(spanName, "redis.client.rediscala")
       .start()
   }
 
   @Advice.OnMethodExit(onThrowable = classOf[Throwable], suppress = classOf[Throwable])
-  def exit(@Advice.Enter span: Span,
+  @static def exit(@Advice.Enter span: Span,
            @Advice.Thrown t: Throwable,
            @Advice.Return future: Future[_]) = {
     if (t != null) {


### PR DESCRIPTION
Makes kamon-redis module work for scala 3. Bumps rediscala to new organization name for all scala versions except for scala 2.11 to enable this