### PR TITLE
close the APM client response body regardless of the response

### DIFF
--- a/reporters/kamon-apm-reporter/src/main/scala/kamon/apm/ApiClient.scala
+++ b/reporters/kamon-apm-reporter/src/main/scala/kamon/apm/ApiClient.scala
@@ -73,6 +73,10 @@ class ApiClient(settings: Settings) {
 
     tryPosting match {
       case Success(response) =>
+        // The response body must be closed (even if there is no body in the response),
+        // otherwise OkHttp leaks connections.
+        response.body().close()
+
         response.code() match {
           case 200 =>
             _logger.trace("Request to the Kamon APM [{}] endpoint succeeded", endpointName)


### PR DESCRIPTION
On 2.5.10 we moved to use the APM v2 ingestion API which doesn't return a response body, but OkHttp requires response bodies to be closed regardless of whether there is a body. Without this fix, applications end up logging this warning:

```
WARNING: A connection to https://ingestion.apm.kamon.io/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```