### PR TITLE
propagate context when handling unary Akka gRPC server requests

### DIFF
--- a/instrumentation/kamon-akka-grpc/src/main/java/kamon/instrumentation/akka/grpc/AkkaGRPCUnmarshallingContextPropagation.java
+++ b/instrumentation/kamon-akka-grpc/src/main/java/kamon/instrumentation/akka/grpc/AkkaGRPCUnmarshallingContextPropagation.java
@@ -1,0 +1,49 @@
+package kamon.instrumentation.akka.grpc;
+
+import akka.http.javadsl.model.HttpEntity;
+import kamon.Kamon;
+import kamon.context.Context;
+import kanela.agent.libs.net.bytebuddy.asm.Advice;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public class AkkaGRPCUnmarshallingContextPropagation {
+
+  @Advice.OnMethodExit()
+  public static void onExit(
+      @Advice.Return(readOnly = false) CompletionStage<?> returnValue,
+      @Advice.Argument(0) Object firstArgument) {
+
+    if(firstArgument instanceof HttpEntity && returnValue instanceof CompletableFuture) {
+      final Context currentContext = Kamon.currentContext();
+
+      // NOTES: The wrapper is only overriding thenCompose because it is the only function that gets called
+      //        after GrpcMarshalling.unmarshall in the auto-generated HandlerFactory for gRPC services. In
+      //        the future this might be removed if we instrument CompletionStage directly.
+      returnValue = new ContextPropagatingCompletionStage<>((CompletableFuture) returnValue, currentContext);
+    }
+  }
+
+
+  public static class ContextPropagatingCompletionStage<T> extends CompletableFuture<T> {
+    private final CompletableFuture<T> wrapped;
+    private final Context context;
+
+    public ContextPropagatingCompletionStage(CompletableFuture<T> wrapped, Context context) {
+      this.wrapped = wrapped;
+      this.context = context;
+    }
+
+    @Override
+    public <U> CompletableFuture<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
+      Function<? super T, ? extends CompletionStage<U>> wrapperFunction = (t) -> {
+        return Kamon.runWithContext(context, () -> fn.apply(t));
+      };
+
+      return wrapped.thenCompose(wrapperFunction);
+    }
+  }
+
+}

--- a/instrumentation/kamon-akka-grpc/src/main/resources/reference.conf
+++ b/instrumentation/kamon-akka-grpc/src/main/resources/reference.conf
@@ -13,7 +13,8 @@ kanela.modules {
     ]
 
     within = [
-      "^akka.grpc.internal..*"
+      "^akka.grpc.internal..*",
+      "^akka.grpc.javadsl.GrpcMarshalling$"
     ]
   }
 }

--- a/instrumentation/kamon-akka-grpc/src/main/scala/kamon/instrumentation/akka/grpc/AkkaGrpcServerInstrumentation.scala
+++ b/instrumentation/kamon-akka-grpc/src/main/scala/kamon/instrumentation/akka/grpc/AkkaGrpcServerInstrumentation.scala
@@ -35,6 +35,10 @@ class AkkaGrpcServerInstrumentation extends InstrumentationBuilder {
     */
   onType("akka.grpc.internal.NoOpTelemetry$")
     .advise(method("onRequest"), AkkaGRPCServerRequestHandler)
+
+
+  onType("akka.grpc.javadsl.GrpcMarshalling")
+    .advise(method("unmarshal"), classOf[AkkaGRPCUnmarshallingContextPropagation])
 }
 
 object AkkaGRPCServerRequestHandler {


### PR DESCRIPTION
This PR ensures that context (including the HTTP Server Span) that we create automatically on the Akka HTTP instrumentation will get propagated to the service implementation calls. 

Notes:
  - It only works with unary requests. Stream-based requests will still require manual handling by users.
  - The culprit of this issue is that `CompletionStage` is not instrumented at all and the Java-based version of Akka gRPC uses completable futures in a few places. Writing instrumentation for `CompletionStage` might be enough to remove this instrumentation in the future.