### PR TITLE
Allow W3C TraceContext propagation in kamon-kafka

### DIFF
--- a/instrumentation/kamon-kafka/src/main/java/kamon/instrumentation/kafka/client/advisor/SendMethodAdvisor.java
+++ b/instrumentation/kamon-kafka/src/main/java/kamon/instrumentation/kafka/client/advisor/SendMethodAdvisor.java
@@ -50,8 +50,8 @@ public class SendMethodAdvisor {
                     .start();
 
             Context ctx = recordContext.withEntry(Span.Key(), span);
-            record.headers().add(KafkaInstrumentation.Keys$.MODULE$.ContextHeader(), ContextSerializationHelper.toByteArray(ctx));
-
+            KafkaInstrumentation.settings().propagator().write(ctx, record.headers());
+            
             callback = new ProducerCallback(callback, span, ctx);
         }
     }

--- a/instrumentation/kamon-kafka/src/main/resources/reference.conf
+++ b/instrumentation/kamon-kafka/src/main/resources/reference.conf
@@ -20,6 +20,13 @@ kamon.instrumentation.kafka {
       # set to the timestamp returned by Kafka's record, the start time is set to the time when the consumer started
       # the poll operation and the end time is set to the instant when the message poll was completed.
       use-delayed-spans = no
+
+      # Decides which specification to use for context propagation. By default, uses the `kctx` header for
+      # compatibility with older versions.
+      # Possible values:
+      #   - w3c - requires kamon.trace.identifier-scheme = double
+      #   - kctx
+      propagator = "kctx"
     }
   }
 }

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/KafkaInstrumentation.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/KafkaInstrumentation.scala
@@ -213,7 +213,7 @@ object KafkaInstrumentation {
     startTraceOnProducer: Boolean,
     continueTraceOnConsumer: Boolean,
     useDelayedSpans: Boolean,
-    propagator: KafkaPropagator,
+    propagator: KafkaPropagator
   )
 
 }

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/RecordProcessor.scala
@@ -40,11 +40,7 @@ private[kafka] object RecordProcessor {
       val consumerInfo = ConsumerInfo(resolve(groupId), clientId)
 
       records.iterator().asScala.foreach(record => {
-        val header = Option(record.headers.lastHeader(KafkaInstrumentation.Keys.ContextHeader))
-
-        val incomingContext = header.map { h =>
-          ContextSerializationHelper.fromByteArray(h.value())
-        }.getOrElse(Context.Empty)
+        val incomingContext = KafkaInstrumentation.settings.propagator.read(record.headers(), Context.Empty)
 
         record.asInstanceOf[ConsumedRecordData].set(
           incomingContext,

--- a/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/SpanPropagation.scala
+++ b/instrumentation/kamon-kafka/src/main/scala/kamon/instrumentation/kafka/client/SpanPropagation.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2013-2021 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kamon.instrumentation.kafka.client
+
+import kamon.context.{Context, _}
+import kamon.trace.Span
+import org.apache.kafka.common.header.{Headers => KafkaHeaders}
+
+import java.nio.charset.StandardCharsets
+
+trait KafkaPropagator extends Propagation.EntryReader[KafkaHeaders] with Propagation.EntryWriter[KafkaHeaders] {}
+
+/**
+  * Propagation mechanisms for Kamon's Span data to and from HTTP and Binary mediums.
+  */
+object SpanPropagation {
+
+  class W3CTraceContext extends KafkaPropagator {
+
+    import kamon.trace.SpanPropagation.W3CTraceContext._
+
+    override def read(medium: KafkaHeaders, context: Context): Context = {
+
+      val contextWithParent = for {
+        traceParent <- Option(medium.lastHeader(Headers.TraceParent))
+        span <- decodeTraceParent(new String(traceParent.value(), StandardCharsets.UTF_8))
+      } yield {
+        val spanContext = context.withEntry(Span.Key, span)
+        val traceState = Option(medium.lastHeader(Headers.TraceState))
+        traceState.map { state =>
+          spanContext.withEntry(TraceStateKey, new String(state.value(), StandardCharsets.UTF_8))
+        }.getOrElse(spanContext)
+      }
+
+      contextWithParent.getOrElse(context)
+    }
+
+    override def write(context: Context, medium: KafkaHeaders): Unit = {
+      val span = context.get(Span.Key)
+
+      if (span != Span.Empty) {
+        medium.add(Headers.TraceParent, encodeTraceParent(span).getBytes(StandardCharsets.UTF_8))
+        medium.add(Headers.TraceState, context.get(TraceStateKey).getBytes(StandardCharsets.UTF_8))
+      }
+    }
+  }
+
+  object W3CTraceContext {
+    def apply(): W3CTraceContext = new W3CTraceContext()
+  }
+
+  /**
+    * Reads and Writes a Span instance using the W3C Trace Context propagation format.
+    * The specification can be found here: https://www.w3.org/TR/trace-context-1/
+    */
+  class KCtxHeader extends KafkaPropagator {
+
+    import KCtxHeader._
+
+    override def read(medium: KafkaHeaders, context: Context): Context = {
+      val header = Option(medium.lastHeader(Headers.Kctx))
+
+      header.map { h =>
+        ContextSerializationHelper.fromByteArray(h.value())
+      }.getOrElse(context)
+    }
+
+    override def write(context: Context, medium: KafkaHeaders): Unit = {
+
+      medium.add(Headers.Kctx, ContextSerializationHelper.toByteArray(context))
+    }
+  }
+
+  object KCtxHeader {
+
+    object Headers {
+      val Kctx = "kctx"
+    }
+
+    def apply(): KCtxHeader =
+      new KCtxHeader()
+  }
+
+}


### PR DESCRIPTION
Fixes #1235 by adding a new configuration key `kamon.instrumentation.kafka.client.tracing.propagator` that can take the value `w3c` to propagate the trace context using the W3C TraceContext specification.

Please excuse any bad scala code, I'm still a newb in this ecosystem.