### PR TITLE
implement a kamon.enabled setting

### DIFF
--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -15,6 +15,12 @@ kamon {
   # what it does, but the basics of not attaching the instrumentation, reporters, and modules is functional.
   enabled = yes
 
+  init {
+
+    # Hides the Kamon banner shown during Kamon's init process
+    hide-banner = no
+  }
+
   environment {
 
     # Identifier for this service.

--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -4,6 +4,17 @@
 
 kamon {
 
+  # !!! EXPERIMENTAL !!!
+  #
+  # Sets whether Kamon should initialize instrumentation, modules, and reporters when calling Kamon.init() (and its
+  # variants) or not. This setting is not meant to be changed during application runtime, as it might not be able to
+  # completely add or remove instrumentation from already-loaded classes. If you need to enable/disable Kamon, restart
+  # your application with a new value for this setting.
+  #
+  # Marked as experimental because its behavior might change as we find corner cases and change the exact scope of
+  # what it does, but the basics of not attaching the instrumentation, reporters, and modules is functional.
+  enabled = yes
+
   environment {
 
     # Identifier for this service.

--- a/core/kamon-core/src/main/scala/kamon/Init.scala
+++ b/core/kamon-core/src/main/scala/kamon/Init.scala
@@ -37,10 +37,15 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     * Attempts to attach the instrumentation agent and start all registered modules.
     */
   def init(): Unit = {
-    self.attachInstrumentation()
-    self.initScheduler()
-    self.loadModules()
-    self.moduleRegistry().init()
+    if(enabled()) {
+      self.attachInstrumentation()
+      self.initScheduler()
+      self.loadModules()
+      self.moduleRegistry().init()
+    } else {
+      self.disableInstrumentation()
+      self.disabledWarning()
+    }
   }
 
   /**
@@ -48,11 +53,17 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     * start all registered modules.
     */
   def init(config: Config): Unit = {
-    self.attachInstrumentation()
-    self.initScheduler()
     self.reconfigure(config)
-    self.loadModules()
-    self.moduleRegistry().init()
+
+    if(enabled()) {
+      self.attachInstrumentation()
+      self.initScheduler()
+      self.loadModules()
+      self.moduleRegistry().init()
+    } else {
+      self.disableInstrumentation()
+      self.disabledWarning()
+    }
 
   }
 
@@ -60,9 +71,14 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     * Initializes Kamon without trying to attach the instrumentation agent from the Kamon Bundle.
     */
   def initWithoutAttaching(): Unit = {
-    self.initScheduler()
-    self.loadModules()
-    self.moduleRegistry().init()
+    if(enabled()) {
+      self.initScheduler()
+      self.loadModules()
+      self.moduleRegistry().init()
+    } else {
+      self.disableInstrumentation()
+      self.disabledWarning()
+    }
   }
 
   /**
@@ -70,7 +86,13 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     */
   def initWithoutAttaching(config: Config): Unit = {
     self.reconfigure(config)
-    self.initWithoutAttaching()
+
+    if(enabled()) {
+      self.initWithoutAttaching()
+    } else {
+      self.disableInstrumentation()
+      self.disabledWarning()
+    }
   }
 
 
@@ -79,7 +101,6 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     self.stopScheduler()
     self.moduleRegistry().shutdown()
     self.stopModules()
-
   }
 
   /**
@@ -103,6 +124,35 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
         case t: Throwable =>
           _logger.error("Failed to attach the Kanela agent included in the kamon-bundle", t)
       }
+    }
+  }
+
+  private def disabledWarning(): Unit = {
+    _logger.warn("Kamon is DISABLED. No instrumentation, reporters, or context propagation will be applied on this " +
+                 "process. Restart the process with kamon.enabled=yes to restore Kamon's functionality")
+  }
+
+  /**
+    * Tries to disable the Kanela agent, in case it was attached via the -javaagent:... option. The agent is always
+    * attached to the System Classloader so we try to find it there and call "disable" on it.
+    */
+  private def disableInstrumentation(): Unit = {
+    try {
+      Class.forName("kanela.agent.Kanela", true, ClassLoader.getSystemClassLoader)
+        .getDeclaredMethod("disable")
+        .invoke(null)
+
+      _logger.info("Disabled the Kanela instrumentation agent. Classes will not be instrumented in this process")
+
+    } catch {
+      case _: ClassNotFoundException =>
+        // Do nothing. This means that Kanela wasn't loaded so there was no need to do anything.
+
+      case _: NoSuchMethodException =>
+        _logger.error("Failed to disable the Kanela instrumentation agent. Please ensure you are using Kanela >=1.0.17")
+
+      case t: Throwable =>
+        _logger.error("Failed to disable the Kanela instrumentation agent", t)
     }
   }
 

--- a/core/kamon-core/src/main/scala/kamon/status/InstrumentationStatus.scala
+++ b/core/kamon-core/src/main/scala/kamon/status/InstrumentationStatus.scala
@@ -53,6 +53,11 @@ object InstrumentationStatus {
       // then Kanela must be present.
       val present = (registryClass != null) && kanelaLoaded
 
+      val kanelaVersion = Class.forName("kanela.agent.util.BuildInfo", false, ClassLoader.getSystemClassLoader)
+        .getMethod("version")
+        .invoke(null)
+        .asInstanceOf[String]
+
       val modules = registryClass.getMethod("shareModules")
         .invoke(null)
         .asInstanceOf[JavaList[JavaMap[String, String]]]
@@ -66,7 +71,7 @@ object InstrumentationStatus {
         .map(toTypeError)
         .toSeq
 
-      Status.Instrumentation(present, modules.toSeq, errors)
+      Status.Instrumentation(present, Option(kanelaVersion), modules.toSeq, errors)
     } catch {
       case t: Throwable =>
 
@@ -80,7 +85,7 @@ object InstrumentationStatus {
           }
         }
 
-        Status.Instrumentation(false, Seq.empty, Seq.empty)
+        Status.Instrumentation(false, None, Seq.empty, Seq.empty)
     }
   }
 

--- a/core/kamon-core/src/main/scala/kamon/status/Status.scala
+++ b/core/kamon-core/src/main/scala/kamon/status/Status.scala
@@ -113,6 +113,7 @@ object Status {
     */
   case class Instrumentation (
     present: Boolean,
+    kanelaVersion: Option[String],
     modules: Seq[Status.Instrumentation.ModuleInfo],
     errors: Seq[Status.Instrumentation.TypeError]
   )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,7 +26,7 @@ object BaseProject extends AutoPlugin {
     /** Marker configuration for dependencies that will be shaded into their module's jar.  */
     lazy val Shaded = config("shaded").hide
 
-    val kanelaAgent       = "io.kamon"              %  "kanela-agent"    % "1.0.16"
+    val kanelaAgent       = "io.kamon"              %  "kanela-agent"    % "1.0.17"
     val slf4jApi          = "org.slf4j"             %  "slf4j-api"       % "1.7.25"
     val slf4jnop          = "org.slf4j"             %  "slf4j-nop"       % "1.7.24"
     val logbackClassic    = "ch.qos.logback"        %  "logback-classic" % "1.2.3"


### PR DESCRIPTION
This PR brings the minimal required to have a functional `kamon.enabled` setting. Some notes:
- It requires a few changes in Kanela for it to be really disabled, I'll have a separate PR for that
- The `kamon.enabled` setting can only be set during initialization. You either start the application with Kamon enabled or you don't. Changing the setting requires to restart the application for things to work properly. Certain things **might** work under the hood if you reconfigure Kamon at runtime and change this setting, but that is not path we will support for now