### PR TITLE
escape backslashes in prometheus label values, fixes #958

### DIFF
--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/ScrapeDataBuilder.scala
@@ -268,8 +268,15 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
 
     while(tagIterator.hasNext) {
       val pair = tagIterator.next()
-      if(tagCount > 0) buffer.append(",")
-      buffer.append(normalizeLabelName(pair.key)).append("=\"").append(pair.value).append('"')
+      if(tagCount > 0)
+        buffer.append(",")
+
+      buffer
+        .append(normalizeLabelName(pair.key))
+        .append("=\"")
+        .append(normalizeLabelValue(pair.value))
+        .append('"')
+
       tagCount += 1
     }
 
@@ -306,6 +313,10 @@ class ScrapeDataBuilder(prometheusConfig: PrometheusSettings.Generic, environmen
 
   private def validNameChar(char: Char): Char =
     if(char.isLetterOrDigit || char == '_' || char == ':') char else '_'
+
+  private def normalizeLabelValue(value: String): String = {
+    if(value.contains("\\")) value.replace("\\", "\\\\") else value
+  }
 
   private def format(value: Double): String =
     _numberFormat.format(value)

--- a/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
+++ b/reporters/kamon-prometheus/src/test/scala/kamon/prometheus/ScrapeDataBuilderSpec.scala
@@ -63,6 +63,22 @@ class ScrapeDataBuilderSpec extends AnyWordSpec with Matchers {
         """.stripMargin.trim()
       }
     }
+
+    "escape backslash in tag values" in {
+      val counter = MetricSnapshotBuilder.counter("counter.with.backslash", "", TagSet.of("path", "c:\\users\\temp"), time.seconds, 10)
+
+      builder()
+        .appendCounters(Seq(counter))
+        .build() should include {
+
+        """
+          |# TYPE counter_with_backslash_seconds_total counter
+          |counter_with_backslash_seconds_total{path="c:\\users\\temp"} 10.0
+        """.stripMargin.trim()
+      }
+    }
+
+
     "not add extra '_total' postfix if metric name already ends with it when using units" in {
       val counterOne = MetricSnapshotBuilder.counter("app:counter-one-seconds-total", "", TagSet.of("tag.with.dots", "value"), time.seconds, 10)
       val gaugeOne = MetricSnapshotBuilder.gauge("gauge-one-seconds", "", TagSet.of("tag-with-dashes", "value"), time.seconds, 20)
@@ -327,7 +343,7 @@ class ScrapeDataBuilderSpec extends AnyWordSpec with Matchers {
       val result = builder(withGauges = Seq("first*"))
         .appendDistributionMetricsAsGauges(Seq(histogramWithHundredEntries, histogramWithHundredEntriesTwo))
         .build()
-      println(result)
+
       result should include {
         """|# TYPE firstMetric_min gauge
            |firstMetric_min 1.0


### PR DESCRIPTION
Backslashes are the only character we are having problems with so far, as reported in #958. This PR escapes them with a double backslash. 