### PR TITLE
make cluster sharding instrumentation work with Akka 2.7, fixes #1242

### DIFF
--- a/instrumentation/kamon-akka/build.sbt
+++ b/instrumentation/kamon-akka/build.sbt
@@ -3,7 +3,7 @@ import Def.Initialize
 
 val `Akka-2.4-version` = "2.4.20"
 val `Akka-2.5-version` = "2.5.32"
-val `Akka-2.6-version` = "2.6.11"
+val `Akka-2.6-version` = "2.6.20"
 
 /**
   * Compile Configurations
@@ -31,7 +31,7 @@ configs(
 // The Common configuration should always depend on the latest version of Akka. All code in the Common configuration
 // should be source compatible with all Akka versions.
 inConfig(Common)(Defaults.compileSettings ++ Seq(
-  crossScalaVersions := Seq("2.12.11", "2.13.1")
+  crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`)
 ))
 
 libraryDependencies ++= { if(scalaBinaryVersion.value == "2.11") Seq.empty else Seq(
@@ -50,7 +50,7 @@ libraryDependencies ++= { if(scalaBinaryVersion.value == "2.11") Seq.empty else 
 
 
 inConfig(`Compile-Akka-2.6`)(Defaults.compileSettings ++ Seq(
-  crossScalaVersions := Seq("2.12.11", "2.13.1"),
+  crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`),
   sources := joinSources(Common, `Compile-Akka-2.6`).value
 ))
 
@@ -141,11 +141,11 @@ lazy val baseTestSettings = Seq(
   fork := true,
   parallelExecution := false,
   javaOptions := (Test / javaOptions).value,
-  dependencyClasspath += (Compile / packageBin).value,
+  dependencyClasspath += (Compile / packageBin).value
 )
 
 inConfig(TestCommon)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
-  crossScalaVersions := Seq("2.12.11", "2.13.1")
+  crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`)
 ))
 
 inConfig(`Test-Akka-2.5`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
@@ -155,7 +155,7 @@ inConfig(`Test-Akka-2.5`)(Defaults.testSettings ++ instrumentationSettings ++ ba
 ))
 
 inConfig(`Test-Akka-2.6`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
-  crossScalaVersions := Seq("2.12.11", "2.13.1"),
+  crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`),
   sources := joinSources(TestCommon, `Test-Akka-2.6`).value,
   unmanagedResourceDirectories ++= (Common / unmanagedResourceDirectories).value,
   unmanagedResourceDirectories ++= (TestCommon / unmanagedResourceDirectories).value

--- a/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/ActorMonitorInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/ActorMonitorInstrumentation.scala
@@ -12,7 +12,7 @@ import scala.util.control.NonFatal
 
 class ActorMonitorInstrumentation extends InstrumentationBuilder with VersionFiltering {
 
-  onAkka("2.6") {
+  onAkka("2.6", "2.7") {
     /*
      * Changes implementation of extractMessageClass for our ActorMonitor.
      * In akka 2.6, all typed messages are converted to AdaptMessage,

--- a/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/DispatcherInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/DispatcherInstrumentation.scala
@@ -31,7 +31,7 @@ import kanela.agent.libs.net.bytebuddy.implementation.bind.annotation.{Argument,
 
 class DispatcherInstrumentation extends InstrumentationBuilder with VersionFiltering  {
 
-  onAkka("2.6") {
+  onAkka("2.6", "2.7") {
 
     /**
       * This is where the actual ExecutorService instances are being created, but at this point we don't have access to

--- a/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/remote/RemotingInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/remote/RemotingInstrumentation.scala
@@ -17,7 +17,7 @@ import kanela.agent.libs.net.bytebuddy.asm.Advice
 
 class RemotingInstrumentation extends InstrumentationBuilder with VersionFiltering {
 
-  onAkka("2.6") {
+  onAkka("2.6", "2.7") {
 
     /**
       * Send messages might be buffered if they reach the EndpointWriter before it has been initialized and the current

--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/remote/ShardingInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/remote/ShardingInstrumentation.scala
@@ -11,7 +11,7 @@ import kanela.agent.libs.net.bytebuddy.asm.Advice
 
 class ShardingInstrumentation extends InstrumentationBuilder with VersionFiltering {
 
-  onAkka("2.5", "2.6") {
+  onAkka("2.5", "2.6", "2.7") {
 
     /**
       * The ShardRegion instrumentation just takes care of counting the Region messages and, when stopped, cleans up the
@@ -50,6 +50,11 @@ class ShardingInstrumentation extends InstrumentationBuilder with VersionFilteri
   }
 
   afterAkkaVersion("2.6", 11) {
+    onType("akka.cluster.sharding.Shard")
+      .advise(method("shardInitialized"), ShardInitializedAdvice)
+  }
+
+  afterAkkaVersion("2.7", 0) {
     onType("akka.cluster.sharding.Shard")
       .advise(method("shardInitialized"), ShardInitializedAdvice)
   }

--- a/instrumentation/kamon-akka/src/test-common/scala/kamon/instrumentation/akka/DispatcherMetricsSpec.scala
+++ b/instrumentation/kamon-akka/src/test-common/scala/kamon/instrumentation/akka/DispatcherMetricsSpec.scala
@@ -43,12 +43,14 @@ class DispatcherMetricsSpec extends TestKit(ActorSystem("DispatcherMetricsSpec")
       "tracked-pinned-dispatcher",
       "tracked-fjp",
       "tracked-tpe"
-    ) ++ (if(Version.current.startsWith("2.6")) Seq("akka.actor.internal-dispatcher") else Seq.empty)
+    ) ++ (if(Version.current.startsWith("2.6") || Version.current.startsWith("2.7"))
+      Seq("akka.actor.internal-dispatcher") else Seq.empty)
 
     val excluded = "explicitly-excluded"
     val allDispatchers = trackedDispatchers :+ excluded
     val builtInDispatchers = Seq("akka.actor.default-dispatcher") ++ {
-      if(Version.current.startsWith("2.6")) Seq("akka.actor.internal-dispatcher") else Seq.empty
+      if(Version.current.startsWith("2.6") || Version.current.startsWith("2.7"))
+        Seq("akka.actor.internal-dispatcher") else Seq.empty
     }
 
 

--- a/instrumentation/kamon-akka/src/test-common/scala/kamon/instrumentation/akka/RouterMetricsSpec.scala
+++ b/instrumentation/kamon-akka/src/test-common/scala/kamon/instrumentation/akka/RouterMetricsSpec.scala
@@ -89,6 +89,9 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with A
 
     "record the time-in-mailbox for pool routers" in new RouterMetricsFixtures {
       val timingsListener = TestProbe()
+      // If we don't initialize the listener upfront the timings might be wrong.
+      timingsListener.testActor.tell("hello", timingsListener.ref)
+      timingsListener.expectMsg("hello")
       val router = createTestPoolRouter("measuring-time-in-mailbox-in-pool-router", true)
 
       router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)
@@ -104,6 +107,9 @@ class RouterMetricsSpec extends TestKit(ActorSystem("RouterMetricsSpec")) with A
 
     "record the time-in-mailbox for balancing pool routers" in new RouterMetricsFixtures {
       val timingsListener = TestProbe()
+      // If we don't initialize the listener upfront the timings might be wrong.
+      timingsListener.testActor.tell("hello", timingsListener.ref)
+      timingsListener.expectMsg("hello")
       val router = createTestBalancingPoolRouter("measuring-time-in-mailbox-in-balancing-pool-router", true)
 
       router.tell(RouterTrackTimings(sleep = Some(1 second)), timingsListener.ref)


### PR DESCRIPTION
Tested with Akka 2.6.20 and 2.7.0. All tests passing.