### PR TITLE
#1248 add a support for New Relic's licence key

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -799,8 +799,8 @@ lazy val `kamon-newrelic` = (project in file("reporters/kamon-newrelic"))
   .settings(
     crossScalaVersions += `scala_3_version`,
     libraryDependencies ++= Seq(
-      "com.newrelic.telemetry" % "telemetry-core" % "0.12.0",
-      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.12.0",
+      "com.newrelic.telemetry" % "telemetry-core" % "0.15.0",
+      "com.newrelic.telemetry" % "telemetry-http-okhttp" % "0.15.0",
       scalatest % "test",
       "org.mockito" % "mockito-core" % "3.12.4" % "test"
     )

--- a/reporters/kamon-newrelic/src/main/resources/reference.conf
+++ b/reporters/kamon-newrelic/src/main/resources/reference.conf
@@ -3,8 +3,17 @@
 # ======================================= #
 
 kamon.newrelic {
-    # A New Relic Insights API Insert Key is required to send trace data to New Relic
-    # https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys#insert-key-create
+    # An API key is required to send data to New Relic. In this reporter you can select to
+    # use either license key or insights insert key. If both key types are configured or both
+    # are default, then insights insert key is preferred. Otherwise, the key, which value is
+    # not "none" is chosen.
+
+    # A license key, which is recommended by the New Relic documentation.
+    # https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#license-key
+    license-key = "none"
+
+    # A insights insert key, which is not recommended by the New Relic documentation.
+    # https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#insights-insert-key
     nr-insights-insert-key = "none"
 
     # Enable audit logging for data sent to New Relic. This will be logged at DEBUG, so you

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicConfig.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicConfig.scala
@@ -57,9 +57,14 @@ private object NewRelicConfig {
   }
 
   sealed trait NewRelicApiKey {
-    def apiKeyAndUseLicenseKey: (String, Boolean) = this match {
-      case LicenseKey(licenceKey) => (licenceKey, true)
-      case InsightsInsertKey(insightsInsertKey) => (insightsInsertKey, false)
+    def value: String = this match {
+      case LicenseKey(licenseKey) => licenseKey
+      case InsightsInsertKey(insightsInsertKey) => insightsInsertKey
+    }
+
+    def isLicenseKey: Boolean = this match {
+      case LicenseKey(_) => true
+      case _ => false
     }
   }
 

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicConfig.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicConfig.scala
@@ -39,11 +39,11 @@ private object NewRelicConfig {
     val nrConfig = config.getConfig("kamon.newrelic")
 
     // TODO maybe some validation around these values?
-    val apiKey = if (nrConfig.hasPath("license-key")) {
-      LicenseKey(nrConfig.getString("license-key"))
-    } else {
-      InsightsInsertKey(nrConfig.getString("nr-insights-insert-key"))
+    val apiKey = (nrConfig.getString("license-key"), nrConfig.getString("nr-insights-insert-key")) match {
+      case (licenseKey, "none") if licenseKey != "none" => LicenseKey(licenseKey)
+      case (_, insightsInsertKey) => InsightsInsertKey(insightsInsertKey)
     }
+
     val enableAuditLogging = nrConfig.getBoolean("enable-audit-logging")
     val userAgent = s"newrelic-kamon-reporter/${LibraryVersion.version}"
     val callTimeout = Duration.ofSeconds(5)

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicConfig.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/NewRelicConfig.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013-2020 The Kamon Project <https://kamon.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kamon.newrelic
+
+import com.typesafe.config.Config
+import kamon.newrelic.NewRelicConfig.NewRelicApiKey
+import kamon.newrelic.NewRelicConfig.NewRelicApiKey.{InsightsInsertKey, LicenseKey}
+
+import java.net.URL
+import java.time.Duration
+
+
+private case class NewRelicConfig(
+                                   apiKey: NewRelicApiKey,
+                                   enableAuditLogging: Boolean,
+                                   userAgent: String,
+                                   callTimeout: Duration,
+                                   spanIngestUri: Option[URL],
+                                   metricIngestUri: Option[URL]
+                                 )
+
+private object NewRelicConfig {
+
+  def fromConfig(config: Config): NewRelicConfig = {
+    val nrConfig = config.getConfig("kamon.newrelic")
+
+    // TODO maybe some validation around these values?
+    val apiKey = if (nrConfig.hasPath("license-key")) {
+      LicenseKey(nrConfig.getString("license-key"))
+    } else {
+      InsightsInsertKey(nrConfig.getString("nr-insights-insert-key"))
+    }
+    val enableAuditLogging = nrConfig.getBoolean("enable-audit-logging")
+    val userAgent = s"newrelic-kamon-reporter/${LibraryVersion.version}"
+    val callTimeout = Duration.ofSeconds(5)
+    val spanIngestUri = getUrlOption(nrConfig, "span-ingest-uri")
+    val metricIngestUri = getUrlOption(nrConfig, "metric-ingest-uri")
+    NewRelicConfig(apiKey, enableAuditLogging, userAgent, callTimeout, spanIngestUri, metricIngestUri)
+  }
+
+  private def getUrlOption(config: Config, path: String): Option[URL] = {
+    if (config.hasPath(path)) Some(new URL(config.getString(path))) else None
+  }
+
+  sealed trait NewRelicApiKey {
+    def apiKeyAndUseLicenseKey: (String, Boolean) = this match {
+      case LicenseKey(licenceKey) => (licenceKey, true)
+      case InsightsInsertKey(insightsInsertKey) => (insightsInsertKey, false)
+    }
+  }
+
+  object NewRelicApiKey {
+    case class LicenseKey(licenseKey: String) extends NewRelicApiKey
+
+    case class InsightsInsertKey(insightsInsertKey: String) extends NewRelicApiKey
+  }
+}

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
@@ -90,10 +90,9 @@ object NewRelicMetricsReporter {
 
   def buildSenderConfig(config: Config): SenderConfiguration = {
     val nrConfig = NewRelicConfig.fromConfig(config)
-    val (apiKey, useLicenseKey) = nrConfig.apiKey.apiKeyAndUseLicenseKey
     val senderConfig = MetricBatchSender.configurationBuilder()
-      .apiKey(apiKey)
-      .useLicenseKey(useLicenseKey)
+      .apiKey(nrConfig.apiKey.value)
+      .useLicenseKey(nrConfig.apiKey.isLicenseKey)
       .httpPoster(new OkHttpPoster(nrConfig.callTimeout))
       .auditLoggingEnabled(nrConfig.enableAuditLogging)
       .secondaryUserAgent(nrConfig.userAgent)

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/metrics/NewRelicMetricsReporter.scala
@@ -16,9 +16,6 @@
 
 package kamon.newrelic.metrics
 
-import java.net.{URI, URL}
-import java.time.Duration
-
 import com.newrelic.telemetry.{OkHttpPoster, SenderConfiguration}
 import com.newrelic.telemetry.metrics.{MetricBatch, MetricBatchSender}
 import com.typesafe.config.Config
@@ -26,7 +23,7 @@ import kamon.Kamon
 import kamon.metric.PeriodSnapshot
 import kamon.module.{MetricReporter, Module, ModuleFactory}
 import kamon.newrelic.AttributeBuddy.buildCommonAttributes
-import kamon.newrelic.LibraryVersion
+import kamon.newrelic.NewRelicConfig
 import kamon.status.Environment
 import org.slf4j.LoggerFactory
 
@@ -92,22 +89,15 @@ object NewRelicMetricsReporter {
   }
 
   def buildSenderConfig(config: Config): SenderConfiguration = {
-    val nrConfig = config.getConfig("kamon.newrelic")
-    val nrInsightsInsertKey = nrConfig.getString("nr-insights-insert-key")
-    val enableAuditLogging = nrConfig.getBoolean("enable-audit-logging")
-    val userAgent = s"newrelic-kamon-reporter/${LibraryVersion.version}"
-    val callTimeout = Duration.ofSeconds(5)
-
+    val nrConfig = NewRelicConfig.fromConfig(config)
+    val (apiKey, useLicenseKey) = nrConfig.apiKey.apiKeyAndUseLicenseKey
     val senderConfig = MetricBatchSender.configurationBuilder()
-      .apiKey(nrInsightsInsertKey)
-      .httpPoster(new OkHttpPoster(callTimeout))
-      .auditLoggingEnabled(enableAuditLogging)
-      .secondaryUserAgent(userAgent)
-
-    if (nrConfig.hasPath("metric-ingest-uri")) {
-      val uriOverride = nrConfig.getString("metric-ingest-uri")
-      senderConfig.endpoint(new URL(uriOverride))
-    }
+      .apiKey(apiKey)
+      .useLicenseKey(useLicenseKey)
+      .httpPoster(new OkHttpPoster(nrConfig.callTimeout))
+      .auditLoggingEnabled(nrConfig.enableAuditLogging)
+      .secondaryUserAgent(nrConfig.userAgent)
+    nrConfig.metricIngestUri.foreach(senderConfig.endpoint)
     senderConfig.build()
   }
 }

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
@@ -46,7 +46,7 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
   def buildConfig(config: Config): SenderConfiguration = {
     val nrConfig = NewRelicConfig.fromConfig(config)
     if (nrConfig.apiKey == InsightsInsertKey("none")) {
-      logger.error("No Insights Insert API Key defined for the kamon.newrelic.nr-insights-insert-key config setting. " +
+      logger.error("One of kamon.newrelic.license-key or kamon.newrelic.nr-insights-insert-key config settings should be defined. " +
         "No spans will be sent to New Relic.")
     }
     val senderConfig = SpanBatchSender.configurationBuilder()

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
@@ -16,13 +16,11 @@
 
 package kamon.newrelic.spans
 
-import java.net.URL
-import java.time.Duration
-
 import com.newrelic.telemetry.{OkHttpPoster, SenderConfiguration}
 import com.newrelic.telemetry.spans.SpanBatchSender
 import com.typesafe.config.Config
-import kamon.newrelic.LibraryVersion
+import kamon.newrelic.NewRelicConfig.NewRelicApiKey.InsightsInsertKey
+import kamon.newrelic.NewRelicConfig
 import org.slf4j.LoggerFactory
 
 trait SpanBatchSenderBuilder {
@@ -46,30 +44,19 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
   }
 
   def buildConfig(config: Config): SenderConfiguration = {
-    val nrConfig = config.getConfig("kamon.newrelic")
-    // TODO maybe some validation around these values?
-    val nrInsightsInsertKey = nrConfig.getString("nr-insights-insert-key")
-
-    if (nrInsightsInsertKey.equals("none")) {
+    val nrConfig = NewRelicConfig.fromConfig(config)
+    if (nrConfig.apiKey == InsightsInsertKey("none")) {
       logger.error("No Insights Insert API Key defined for the kamon.newrelic.nr-insights-insert-key config setting. " +
         "No spans will be sent to New Relic.")
     }
-    val enableAuditLogging = nrConfig.getBoolean("enable-audit-logging")
-
-    val userAgent = s"newrelic-kamon-reporter/${LibraryVersion.version}"
-    val callTimeout = Duration.ofSeconds(5)
-
+    val (apiKey, useLicenseKey) = nrConfig.apiKey.apiKeyAndUseLicenseKey
     val senderConfig = SpanBatchSender.configurationBuilder()
-      .apiKey(nrInsightsInsertKey)
-      .httpPoster(new OkHttpPoster(callTimeout))
-      .secondaryUserAgent(userAgent)
-      .auditLoggingEnabled(enableAuditLogging)
-
-    if (nrConfig.hasPath("span-ingest-uri")) {
-      val uriOverride = nrConfig.getString("span-ingest-uri")
-      senderConfig.endpoint(new URL(uriOverride))
-    }
-
+      .apiKey(apiKey)
+      .useLicenseKey(useLicenseKey)
+      .httpPoster(new OkHttpPoster(nrConfig.callTimeout))
+      .secondaryUserAgent(nrConfig.userAgent)
+      .auditLoggingEnabled(nrConfig.enableAuditLogging)
+    nrConfig.spanIngestUri.foreach(senderConfig.endpoint)
     senderConfig.build
   }
 }

--- a/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
+++ b/reporters/kamon-newrelic/src/main/scala/kamon/newrelic/spans/SpanBatchSenderBuilder.scala
@@ -49,10 +49,9 @@ class SimpleSpanBatchSenderBuilder() extends SpanBatchSenderBuilder {
       logger.error("No Insights Insert API Key defined for the kamon.newrelic.nr-insights-insert-key config setting. " +
         "No spans will be sent to New Relic.")
     }
-    val (apiKey, useLicenseKey) = nrConfig.apiKey.apiKeyAndUseLicenseKey
     val senderConfig = SpanBatchSender.configurationBuilder()
-      .apiKey(apiKey)
-      .useLicenseKey(useLicenseKey)
+      .apiKey(nrConfig.apiKey.value)
+      .useLicenseKey(nrConfig.apiKey.isLicenseKey)
       .httpPoster(new OkHttpPoster(nrConfig.callTimeout))
       .secondaryUserAgent(nrConfig.userAgent)
       .auditLoggingEnabled(nrConfig.enableAuditLogging)

--- a/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
+++ b/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/metrics/NewRelicMetricsReporterSpec.scala
@@ -157,9 +157,9 @@ class NewRelicMetricsReporterSpec extends AnyWordSpec with Matchers {
       assert("insights" == result.getApiKey)
       assert(!result.useLicenseKey)
     }
-    "use licence key" in {
-      val result = createSenderConfiguration(Map("licence-key" -> "licence"))
-      assert("licence" == result.getApiKey)
+    "use license key" in {
+      val result = createSenderConfiguration(Map("license-key" -> "license"))
+      assert("license" == result.getApiKey)
       assert(result.useLicenseKey)
     }
     "default the url when config not provided" in {

--- a/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/spans/SpanBatchSenderBuilderSpec.scala
+++ b/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/spans/SpanBatchSenderBuilderSpec.scala
@@ -16,31 +16,45 @@ import scala.collection.JavaConverters._
 class SpanBatchSenderBuilderSpec extends AnyWordSpec with Matchers {
 
   "the span batch sender builder" should {
+    val defaultConfig = Map(
+      "enable-audit-logging" -> false,
+      "license-key" -> "none",
+      "nr-insights-insert-key" -> "none"
+    )
+
     def createSenderConfiguration(configMap: Map[String, AnyRef]) = {
-      val nrConfig = ConfigValueFactory.fromMap((Map("enable-audit-logging" -> false) ++ configMap).asJava)
+      val nrConfig = ConfigValueFactory.fromMap((defaultConfig ++ configMap).asJava)
       val config = Kamon.config().withValue("kamon.newrelic", nrConfig)
       new SimpleSpanBatchSenderBuilder().buildConfig(config)
     }
 
-    "use insights insert key" in {
+    "use \"none\" insights insert key by default" in {
+      val result = createSenderConfiguration(Map.empty)
+      assert("none" == result.getApiKey)
+      assert(!result.useLicenseKey)
+    }
+    "be able to use insights insert key" in {
       val result = createSenderConfiguration(Map("nr-insights-insert-key" -> "insights"))
       assert("insights" == result.getApiKey)
       assert(!result.useLicenseKey)
     }
-    "use license key" in {
+    "be able to use license key" in {
       val result = createSenderConfiguration(Map("license-key" -> "license"))
       assert("license" == result.getApiKey)
       assert(result.useLicenseKey)
     }
-    "default the uri if not configured" in {
-      val result = createSenderConfiguration(Map("nr-insights-insert-key" -> "none"))
+    "use insights insert key if both configured" in {
+      val result = createSenderConfiguration(Map("license-key" -> "license", "nr-insights-insert-key" -> "insights"))
+      assert("insights" == result.getApiKey)
+      assert(!result.useLicenseKey)
+    }
+
+    "use default ingest uri if not configured" in {
+      val result = createSenderConfiguration(Map.empty)
       assert(new URL("https://trace-api.newrelic.com/trace/v1") == result.getEndpointUrl)
     }
     "be able to override the ingest uri" in {
-      val result = createSenderConfiguration(Map(
-        "nr-insights-insert-key" -> "none",
-        "span-ingest-uri" -> "https://example.com/foo",
-      ))
+      val result = createSenderConfiguration(Map("span-ingest-uri" -> "https://example.com/foo"))
       assert(new URL("https://example.com/foo") == result.getEndpointUrl)
     }
   }

--- a/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/spans/SpanBatchSenderBuilderSpec.scala
+++ b/reporters/kamon-newrelic/src/test/scala/kamon/newrelic/spans/SpanBatchSenderBuilderSpec.scala
@@ -27,9 +27,9 @@ class SpanBatchSenderBuilderSpec extends AnyWordSpec with Matchers {
       assert("insights" == result.getApiKey)
       assert(!result.useLicenseKey)
     }
-    "use licence key" in {
-      val result = createSenderConfiguration(Map("licence-key" -> "licence"))
-      assert("licence" == result.getApiKey)
+    "use license key" in {
+      val result = createSenderConfiguration(Map("license-key" -> "license"))
+      assert("license" == result.getApiKey)
       assert(result.useLicenseKey)
     }
     "default the uri if not configured" in {


### PR DESCRIPTION
solves #1248

- changes are compatible backwards
- extracted config parsing to the new file
- new `"licence-key"` can be passed
- added new tests
- upgraded new relic's telemetry lib version (this will solve vulnerabilities [this](https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044) and [that](https://security.snyk.io/vuln/SNYK-JAVA-ORGJETBRAINSKOTLIN-2628385))

to maintainers, please:
* review if formatting is ok, i've used intellij formatter
* review if i didn't miss a spot where insights key is used (ctrl+shift+f didn't find any)
* tell me how to publish snapshot of it. i want to test it e2e on my app