### PR TITLE
fix EOF exception on the datadog trace reporter, fixes #1268

### DIFF
--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/package.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/package.scala
@@ -102,7 +102,7 @@ package object datadog {
         .connectTimeout(connectTimeout.toMillis, TimeUnit.MILLISECONDS)
         .readTimeout(readTimeout.toMillis, TimeUnit.MILLISECONDS)
         .writeTimeout(writeTimeout.toMillis, TimeUnit.MILLISECONDS)
-        .retryOnConnectionFailure(false)
+        .retryOnConnectionFailure(true)
 
       if (usingCompression) builder.addInterceptor(new DeflateInterceptor).build()
       else builder.build()


### PR DESCRIPTION
It seems like connections to the Datadog Agent become stale after a few seconds but the client doesn't register the disconnection, so when a new request comes and a connection is reused we get the error described in #1268. For some reason we had `.retryOnConnectionFailure(false)` on the OkHttp client :shrug: 

This helped: https://github.com/square/okhttp/issues/5390#issuecomment-610001882