### PR TITLE
add kamon.init.attach-instrumentation setting

### DIFF
--- a/core/kamon-core/src/main/resources/reference.conf
+++ b/core/kamon-core/src/main/resources/reference.conf
@@ -19,6 +19,11 @@ kamon {
 
     # Hides the Kamon banner shown during Kamon's init process
     hide-banner = no
+
+    # Controls whether Kamon should try to use the runtime attacher during initialization. It is safe to disable
+    # the runtime attacher if you don't need instrumentation at all or if you are applying instrumentation via the
+    # -javaagent JVM option.
+    attach-instrumentation = yes
   }
 
   environment {

--- a/core/kamon-core/src/main/scala/kamon/Init.scala
+++ b/core/kamon-core/src/main/scala/kamon/Init.scala
@@ -39,7 +39,10 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     */
   def init(): Unit = {
     if(enabled()) {
-      self.attachInstrumentation()
+      if(shouldAttachInstrumentation()) {
+        self.attachInstrumentation()
+      }
+
       self.initScheduler()
       self.loadModules()
       self.moduleRegistry().init()
@@ -58,7 +61,10 @@ trait Init { self: ModuleManagement with Configuration with CurrentStatus with M
     self.reconfigure(config)
 
     if(enabled()) {
-      self.attachInstrumentation()
+      if (shouldAttachInstrumentation()) {
+        self.attachInstrumentation()
+      }
+
       self.initScheduler()
       self.loadModules()
       self.moduleRegistry().init()


### PR DESCRIPTION
Adding a new setting to control whether calls to Kamon.init() should try to attach instrumentation at runtime. Defaults to true to to stay compatible with previous behavior.

This should allow people to just call `Kamon.init()` on their apps and control the behavior via configuration instead of changing code or having if/else decisions on their initialization code.