### PR TITLE
fix: Regression on jar size, slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val `kamon-core` = (project in file("core/kamon-core"))
     ),
     libraryDependencies ++= Seq(
       "com.typesafe"      %  "config"       % "1.4.1",
-      "org.slf4j"         %  "slf4j-api"    % "1.7.25",
+      "org.slf4j"         %  "slf4j-api"    % "1.7.36",
       "org.hdrhistogram"  %  "HdrHistogram" % "2.1.9" % "provided,shaded",
       "org.jctools"       %  "jctools-core" % "3.3.0" % "provided,shaded",
       "com.oracle.substratevm" % "svm"      % "19.2.1" % "provided"

--- a/instrumentation/kamon-pekko/build.sbt
+++ b/instrumentation/kamon-pekko/build.sbt
@@ -6,16 +6,16 @@ inConfig(Compile)(Defaults.compileSettings ++ Seq(
 
 val pekkoVersion = "1.0.1"
 libraryDependencies ++= { if(scalaBinaryVersion.value == "2.11") Seq.empty else Seq(
-  kanelaAgent,
+  kanelaAgent % "provided",
   scalatest % Test,
   logbackClassic % Test,
-  "org.apache.pekko"   %% "pekko-actor"             % pekkoVersion,
-  "org.apache.pekko"   %% "pekko-testkit"           % pekkoVersion,
-  "org.apache.pekko"   %% "pekko-slf4j"             % pekkoVersion,
-  "org.apache.pekko"   %% "pekko-remote"            % pekkoVersion,
-  "org.apache.pekko"   %% "pekko-cluster"           % pekkoVersion,
-  "org.apache.pekko"   %% "pekko-cluster-sharding"  % pekkoVersion,
-  "org.apache.pekko"   %% "pekko-protobuf"          % pekkoVersion,
+  "org.apache.pekko"   %% "pekko-actor"             % pekkoVersion % "provided,test",
+  "org.apache.pekko"   %% "pekko-testkit"           % pekkoVersion % "provided,test",
+  "org.apache.pekko"   %% "pekko-slf4j"             % pekkoVersion % "provided,test",
+  "org.apache.pekko"   %% "pekko-remote"            % pekkoVersion % "provided,test",
+  "org.apache.pekko"   %% "pekko-cluster"           % pekkoVersion % "provided,test",
+  "org.apache.pekko"   %% "pekko-cluster-sharding"  % pekkoVersion % "provided,test",
+  "org.apache.pekko"   %% "pekko-protobuf"          % pekkoVersion % "provided,test",
   "org.apache.pekko"   %% "pekko-testkit"           % pekkoVersion % Test
 )}
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -27,9 +27,9 @@ object BaseProject extends AutoPlugin {
     lazy val Shaded = config("shaded").hide
 
     val kanelaAgent       = "io.kamon"              %  "kanela-agent"    % "1.0.17"
-    val slf4jApi          = "org.slf4j"             %  "slf4j-api"       % "1.7.25"
-    val slf4jnop          = "org.slf4j"             %  "slf4j-nop"       % "1.7.24"
-    val logbackClassic    = "ch.qos.logback"        %  "logback-classic" % "1.2.3"
+    val slf4jApi          = "org.slf4j"             %  "slf4j-api"       % "1.7.36"
+    val slf4jnop          = "org.slf4j"             %  "slf4j-nop"       % "1.7.36"
+    val logbackClassic    = "ch.qos.logback"        %  "logback-classic" % "1.2.12"
     val scalatest         = "org.scalatest"         %% "scalatest"       % "3.2.9"
     val hdrHistogram      = "org.hdrhistogram"      %  "HdrHistogram"    % "2.1.10"
     val okHttp            = "com.squareup.okhttp3"  %  "okhttp"          % "4.10.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.2
+sbt.version=1.9.6


### PR DESCRIPTION
Pekko instrumentation was accidentally pulling in 30MB of dependencies to kamon-bundle. Fix this unexpected transitive fetch, and bump slf4j to latest 1.7.x version (2.x.x not backwards-compatible with older implementations due to change to use service loader to detect implementations)