### PR TITLE
Use ConfigUtil.splitPath to build environment tag keys from a config path

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagsSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagsSpec.scala
@@ -43,7 +43,9 @@ class EnvironmentTagsSpec extends AnyWordSpec with Matchers {
       |      }
       |    }
       |
-      |    "tag-with-quotes" = value
+      |    "defined-using-quotes" = value
+      |
+      |    "\"tag-with-quotes\"" = value
       |
       |    "@tag-with-special-chars" = value
       |  }
@@ -86,16 +88,17 @@ class EnvironmentTagsSpec extends AnyWordSpec with Matchers {
       tags("region") shouldBe "asia-1"
 
       tags.toMap shouldBe Map(
-        "@tag-with-special-chars"->"value",
-        "env"->"staging",
-        "host"->"my-hostname",
-        "instance"->"my-instance-name",
-        "k8s.namespace.name"->"production",
+        "@tag-with-special-chars" -> "value",
+        "env" -> "staging",
+        "host" -> "my-hostname",
+        "instance" -> "my-instance-name",
+        "k8s.namespace.name" -> "production",
         "region" -> "asia-1",
-        "service"->"environment-spec",
+        "service" -> "environment-spec",
         "some.tag.@inside" -> "value",
-        "some.tag.inside"->"example",
-        "tag-with-quotes"->"value"
+        "some.tag.inside" -> "example",
+        "defined-using-quotes" -> "value",
+        "\"tag-with-quotes\"" -> "value"
       )
     }
 
@@ -126,9 +129,11 @@ class EnvironmentTagsSpec extends AnyWordSpec with Matchers {
           | "region",
           | "env",
           | "k8s.namespace.name",
-          | "some.tag.inside", "some.tag.@inside",
-          | "tag-with-quotes",
-          | "@tag-with-special-chars"
+          | "some.tag.inside",
+          | "some.tag.@inside",
+          | "defined-using-quotes",
+          | "@tag-with-special-chars",
+          | "\"tag-with-quotes\""
           |]
         """.stripMargin)
 

--- a/core/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagsSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/util/EnvironmentTagsSpec.scala
@@ -39,8 +39,13 @@ class EnvironmentTagsSpec extends AnyWordSpec with Matchers {
       |    some {
       |      tag {
       |        inside = example
+      |        "@inside" = value
       |      }
       |    }
+      |
+      |    "tag-with-quotes" = value
+      |
+      |    "@tag-with-special-chars" = value
       |  }
       |}
     """.stripMargin
@@ -80,6 +85,18 @@ class EnvironmentTagsSpec extends AnyWordSpec with Matchers {
       tags("env") shouldBe "staging"
       tags("region") shouldBe "asia-1"
 
+      tags.toMap shouldBe Map(
+        "@tag-with-special-chars"->"value",
+        "env"->"staging",
+        "host"->"my-hostname",
+        "instance"->"my-instance-name",
+        "k8s.namespace.name"->"production",
+        "region" -> "asia-1",
+        "service"->"environment-spec",
+        "some.tag.@inside" -> "value",
+        "some.tag.inside"->"example",
+        "tag-with-quotes"->"value"
+      )
     }
 
     "remove excluded tags" in {
@@ -105,7 +122,14 @@ class EnvironmentTagsSpec extends AnyWordSpec with Matchers {
           |include-service = no
           |include-host = no
           |include-instance = no
-          |exclude = [ "region", "env", "k8s.namespace.name", "some.tag.inside" ]
+          |exclude = [
+          | "region",
+          | "env",
+          | "k8s.namespace.name",
+          | "some.tag.inside", "some.tag.@inside",
+          | "tag-with-quotes",
+          | "@tag-with-special-chars"
+          |]
         """.stripMargin)
 
       val tags = EnvironmentTags.from(testEnv, config)

--- a/core/kamon-core/src/main/scala/kamon/status/Environment.scala
+++ b/core/kamon-core/src/main/scala/kamon/status/Environment.scala
@@ -19,7 +19,7 @@ package status
 
 import java.net.InetAddress
 import java.util.concurrent.ThreadLocalRandom
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigUtil}
 import kamon.tag.TagSet
 import kamon.util.HexCodec
 import org.slf4j.LoggerFactory
@@ -83,7 +83,7 @@ object Environment {
       tagsConfig.entrySet()
         .iterator()
         .asScala
-        .map { e => e.getKey -> e.getValue.unwrapped().toString }
+        .map { e => ConfigUtil.splitPath(e.getKey).asScala.mkString(".") -> e.getValue.unwrapped().toString }
         .toMap
     )
   }


### PR DESCRIPTION
Config paths are different from config keys, and their difference is explained in the documentation from `com.typesafe.config.Config`.

The existing implementation uses the config path of kamon environment tags as the keys of a `TagSet`. This has the drawback of quoting some tags when it is not necessary. I am not sure if there a reason to assume a tag key corresponds to Config path, I am assuming there is not. Please correct me if I am wrong.

This PR tries to avoid quoting of tags by using `ConfigUtil.splitPath()` to break and unquote the path.