### PR TITLE
Properly parse unsigned integer trace id

### DIFF
--- a/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
@@ -121,21 +121,21 @@ class DataDogSpanPropagationSpec extends AnyWordSpec with Matchers with OptionVa
 
   "SpanPropagation.DataDog.decodeUnsignedLongToHex" should {
     "decode unsigned long to expected hex value " in {
-        String expectedHex1 = "0";
-        String actualHex1 = dataDogPropagation.decodeUnsignedLongToHex("0");
-        assertEquals(expectedHex1, actualHex1);
+        val expectedHex1 = "0";
+        val actualHex1 = SpanPropagation.DataDog.decodeUnsignedLongToHex("0");
+        expectedHex1 shouldBe actualHex1;
 
-        String expectedHex2 = "ff";
-        String actualHex2 = dataDogPropagation.decodeUnsignedLongToHex("255");
-        assertEquals(expectedHex2, actualHex2);
+        val expectedHex2 = "ff";
+        val actualHex2 = SpanPropagation.DataDog.decodeUnsignedLongToHex("255");
+        expectedHex2 shouldBe actualHex2;
 
-        String expectedHex3 = "c5863f7d672b65bf";
-        String actualHex3 = dataDogPropagation.decodeUnsignedLongToHex("14233133480185390527");
-        assertEquals(expectedHex1, actualHex1);
+        val expectedHex3 = "c5863f7d672b65bf";
+        val actualHex3 = SpanPropagation.DataDog.decodeUnsignedLongToHex("14233133480185390527");
+        expectedHex3 shouldBe actualHex3;
 
-        String expectedHex4 = "ffffffffffffffff";
-        String actualHex4 = dataDogPropagation.decodeUnsignedLongToHex("18446744073709551615");
-        assertEquals(expectedHex4, actualHex4);
+        val expectedHex4 = "ffffffffffffffff";
+        val actualHex4 = SpanPropagation.DataDog.decodeUnsignedLongToHex("18446744073709551615");
+        expectedHex4 shouldBe actualHex4;
 
     }
   }

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
@@ -119,8 +119,8 @@ class DataDogSpanPropagationSpec extends AnyWordSpec with Matchers with OptionVa
   }
 
 
-  "Testing SpanPropagation.DataDog.decodeUnsignedLongToHex" should {
-    "works as expected " in {
+  "SpanPropagation.DataDog.decodeUnsignedLongToHex" should {
+    "decode unsigned long to expected hex value " in {
         String expectedHex1 = "0";
         String actualHex1 = dataDogPropagation.decodeUnsignedLongToHex("0");
         assertEquals(expectedHex1, actualHex1);

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
@@ -132,6 +132,11 @@ class DataDogSpanPropagationSpec extends AnyWordSpec with Matchers with OptionVa
         String expectedHex3 = "c5863f7d672b65bf";
         String actualHex3 = dataDogPropagation.decodeUnsignedLongToHex("14233133480185390527");
         assertEquals(expectedHex1, actualHex1);
+
+        String expectedHex4 = "ffffffffffffffff";
+        String actualHex4 = dataDogPropagation.decodeUnsignedLongToHex("18446744073709551615");
+        assertEquals(expectedHex4, actualHex4);
+
     }
   }
 

--- a/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
+++ b/core/kamon-core-tests/src/test/scala/kamon/trace/DataDogSpanPropagationSpec.scala
@@ -118,6 +118,23 @@ class DataDogSpanPropagationSpec extends AnyWordSpec with Matchers with OptionVa
     }
   }
 
+
+  "Testing SpanPropagation.DataDog.decodeUnsignedLongToHex" should {
+    "works as expected " in {
+        String expectedHex1 = "0";
+        String actualHex1 = dataDogPropagation.decodeUnsignedLongToHex("0");
+        assertEquals(expectedHex1, actualHex1);
+
+        String expectedHex2 = "ff";
+        String actualHex2 = dataDogPropagation.decodeUnsignedLongToHex("255");
+        assertEquals(expectedHex2, actualHex2);
+
+        String expectedHex3 = "c5863f7d672b65bf";
+        String actualHex3 = dataDogPropagation.decodeUnsignedLongToHex("14233133480185390527");
+        assertEquals(expectedHex1, actualHex1);
+    }
+  }
+
   def unsignedLongString(id: String): String = BigInt(id, 16).toString
 
   def headerReaderFromMap(map: Map[String, String]): HttpPropagation.HeaderReader = new HttpPropagation.HeaderReader {

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -24,6 +24,7 @@ import kamon.context.HttpPropagation.{HeaderReader, HeaderWriter}
 import kamon.context.generated.binary.span.{Span => ColferSpan}
 import kamon.context.{Context, _}
 import kamon.trace.Trace.SamplingDecision
+import java.lang.{Long => JLong}
 
 import scala.util.Try
 
@@ -450,7 +451,7 @@ object W3CTraceContext {
       * https://docs.datadoghq.com/tracing/guide/send_traces_to_agent_by_api/
       */
     def decodeUnsignedLongToHex(id: String): String =
-      Long.parseUnsignedLong(urlDecode(id), 10).toHexString
+      JLong.parseUnsignedLong(urlDecode(id), 10).toHexString
   }
 
   class DataDog extends Propagation.EntryReader[HeaderReader] with Propagation.EntryWriter[HeaderWriter] {

--- a/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
+++ b/core/kamon-core/src/main/scala/kamon/trace/SpanPropagation.scala
@@ -450,7 +450,7 @@ object W3CTraceContext {
       * https://docs.datadoghq.com/tracing/guide/send_traces_to_agent_by_api/
       */
     def decodeUnsignedLongToHex(id: String): String =
-      urlDecode(id).toLong.toHexString
+      Long.parseUnsignedLong(urlDecode(id), 10).toHexString
   }
 
   class DataDog extends Propagation.EntryReader[HeaderReader] with Propagation.EntryWriter[HeaderWriter] {


### PR DESCRIPTION
- for large integer values the `decodeUnsignedLongToHex` throws an `NumberFormatException` e.g

java.lang.NumberFormatException: For input string: "14293359187408121545"

-  the fix properly parses the string using[ Long.parseUnsignedLong](https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html#parseUnsignedLong-java.lang.String-) function