### PR TITLE
+ enable context tag propagation to http server metrics

### DIFF
--- a/instrumentation/kamon-akka-http/src/main/resources/reference.conf
+++ b/instrumentation/kamon-akka-http/src/main/resources/reference.conf
@@ -50,6 +50,14 @@ kamon.instrumentation.akka.http {
       # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
       #
       #enabled = yes
+      #
+      # Metrics can also use tags from context; this will apply to the following subset of metrics:
+      #   - http.server.request
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #
+      #use-context-tags = no
     }
   
     #

--- a/instrumentation/kamon-akka-http/src/test/resources/application.conf
+++ b/instrumentation/kamon-akka-http/src/test/resources/application.conf
@@ -54,6 +54,14 @@ kamon.instrumentation.akka.http {
       # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
       #
       #enabled = yes
+      #
+      # Metrics can also use tags from context; this will apply to the following subset of metrics:
+      #   - http.server.request
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #
+      #use-context-tags = no
     }
 
 

--- a/instrumentation/kamon-instrumentation-common/src/main/resources/reference.conf
+++ b/instrumentation/kamon-instrumentation-common/src/main/resources/reference.conf
@@ -43,6 +43,14 @@ kamon {
           # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
           #
           enabled = yes
+          #
+          # Metrics can also use tags from context; this will apply to the following subset of metrics:
+          #   - http.server.request
+          #   - http.server.request.active
+          #   - http.server.request.size
+          #   - http.server.response.size
+          #
+          use-context-tags = no
         }
 
         #

--- a/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/http/HttpServerMetrics.scala
+++ b/instrumentation/kamon-instrumentation-common/src/main/scala/kamon/instrumentation/http/HttpServerMetrics.scala
@@ -84,17 +84,17 @@ object HttpServerMetrics {
     /**
       * Increments the appropriate response counter depending on the the status code.
       */
-    def countCompletedRequest(statusCode: Int): Unit = {
+    def countCompletedRequest(statusCode: Int, contextTagSet: TagSet): Unit = {
       if(statusCode >= 200 && statusCode <= 299)
-        requestsSuccessful.increment()
+        requestsSuccessful.withTags(contextTagSet).increment()
       else if(statusCode >= 500 && statusCode <= 599)
-        requestsServerError.increment()
+        requestsServerError.withTags(contextTagSet).increment()
       else if(statusCode >= 400 && statusCode <= 499)
-        requestsClientError.increment()
+        requestsClientError.withTags(contextTagSet).increment()
       else if(statusCode >= 300 && statusCode <= 399)
-        requestsRedirection.increment()
+        requestsRedirection.withTags(contextTagSet).increment()
       else if(statusCode >= 100 && statusCode <= 199)
-        requestsInformational.increment()
+        requestsInformational.withTags(contextTagSet).increment()
       else {
         _logger.warn("Unknown HTTP status code {} found when recording HTTP server metrics", statusCode.toString)
       }

--- a/instrumentation/kamon-instrumentation-common/src/test/resources/application.conf
+++ b/instrumentation/kamon-instrumentation-common/src/test/resources/application.conf
@@ -7,15 +7,20 @@ kamon {
   propagation.http.default {
     tags.mappings {
       "correlation-id" = "x-correlation-id"
+      "namespace" = "namespace"
     }
   }
 
   instrumentation {
     http-server {
       default {
+        metrics {
+          use-context-tags = yes
+        }
         tracing {
           preferred-trace-id-tag = "correlation-id"
           tags.from-context.peer = span
+          tags.from-context.namespace = metric
           response-headers {
             trace-id = "x-trace-id"
             span-id = "x-span-id"

--- a/instrumentation/kamon-pekko-http/src/main/resources/reference.conf
+++ b/instrumentation/kamon-pekko-http/src/main/resources/reference.conf
@@ -50,6 +50,14 @@ kamon.instrumentation.pekko.http {
       # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
       #
       #enabled = yes
+      #
+      # Metrics can also use tags from context; this will apply to the following subset of metrics:
+      #   - http.server.request
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #
+      #use-context-tags = no
     }
   
     #

--- a/instrumentation/kamon-pekko-http/src/test/resources/application.conf
+++ b/instrumentation/kamon-pekko-http/src/test/resources/application.conf
@@ -54,6 +54,13 @@ kamon.instrumentation.pekko.http {
       # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
       #
       #enabled = yes
+      #
+      # Metrics can also use tags from context; this will apply to the following subset of metrics:
+      #   - http.server.request
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #use-context-tags = no
     }
 
 

--- a/instrumentation/kamon-play/src/main/resources/reference.conf
+++ b/instrumentation/kamon-play/src/main/resources/reference.conf
@@ -41,6 +41,14 @@ kamon.instrumentation.play.http {
       # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
       #
       #enabled = yes
+      #
+      # Metrics can also use tags from context; this will apply to the following subset of metrics:
+      #   - http.server.request
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #
+      #use-context-tags = no
     }
 
 

--- a/instrumentation/kamon-spring/src/main/resources/reference.conf
+++ b/instrumentation/kamon-spring/src/main/resources/reference.conf
@@ -49,6 +49,14 @@ kamon.instrumentation.spring {
       # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
       #
       enabled = yes
+      #
+      # Metrics can also use tags from context; this will apply to the following subset of metrics:
+      #   - http.server.request
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #
+      use-context-tags = no
     }
 
     #


### PR DESCRIPTION
I've stuck this behind a flag so as to not unexpectedly blow up the cardinality of anyone's metrics, but think it could be useful