### PR TITLE
check for field existence before trying to construct bridge

### DIFF
--- a/instrumentation/kamon-jdbc/src/main/scala/kamon/instrumentation/jdbc/StatementInstrumentation.scala
+++ b/instrumentation/kamon-jdbc/src/main/scala/kamon/instrumentation/jdbc/StatementInstrumentation.scala
@@ -90,7 +90,7 @@ class StatementInstrumentation extends InstrumentationBuilder {
     * information in that Statement to have the proper pool information and ensure that the check round trips will be
     * observed appropriately.
     */
-  onType("org.postgresql.jdbc.PgConnection")
+  onTypesMatching(named("org.postgresql.jdbc.PgConnection").and(declaresField(named("checkConnectionQuery"))))
     .bridge(classOf[PgConnectionIsAliveAdvice.PgConnectionPrivateAccess])
     .advise(method("isValid"), PgConnectionIsAliveAdvice)
 


### PR DESCRIPTION
Fixes `java.lang.NoSuchFieldError: checkConnectionQuery` (see https://github.com/kamon-io/Kamon/issues/1321)