### PR TITLE
Fix version of pekko-actor dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -550,7 +550,7 @@ lazy val `kamon-pekko` = (project in file("instrumentation/kamon-pekko"))
   .settings(Seq(
     crossScalaVersions := Seq(`scala_2.12_version`, `scala_2.13_version`, scala_3_version),
     libraryDependencies ++= Seq(
-      "org.apache.pekko" %% "pekko-actor" % pekkoHttpVersion % "provided"
+      "org.apache.pekko" %% "pekko-actor" % "1.0.1" % "provided"
     )
   ))
   .dependsOn(


### PR DESCRIPTION
I noticed that the dependency is referring to pekko-http, but pekko-actor is not a pekko-http module.