### PR TITLE
ZIO2: Do a better job closing scopes

### DIFF
--- a/instrumentation/kamon-zio-2/src/main/scala/kamon/instrumentation/zio2/ZIO2Instrumentation.scala
+++ b/instrumentation/kamon-zio-2/src/main/scala/kamon/instrumentation/zio2/ZIO2Instrumentation.scala
@@ -54,7 +54,9 @@ object HasStorage {
   }
 }
 
+
 class NewSupervisor extends Supervisor[Any] {
+
 
   override def value(implicit trace: zio.Trace): UIO[Any] = ZIO.unit
 
@@ -64,21 +66,25 @@ class NewSupervisor extends Supervisor[Any] {
     parent: Option[Fiber.Runtime[Any, Any]],
     fiber: Fiber.Runtime[E, A_]
   )(implicit unsafe: Unsafe): Unit = {
-    fiber.asInstanceOf[HasContext].setContext(Kamon.currentContext())
+    val fi = fiber.asInstanceOf[HasContext with HasStorage]
+    fi.setContext(Kamon.currentContext())
   }
 
   override def onSuspend[E, A_](fiber: Fiber.Runtime[E, A_])(implicit unsafe: Unsafe): Unit = {
-    fiber.asInstanceOf[HasContext].setContext(Kamon.currentContext())
+    val fi = fiber.asInstanceOf[HasContext with HasStorage]
+    fi.setContext(Kamon.currentContext())
+    fi.kamonScope.close()
   }
 
   override def onResume[E, A_](fiber: Fiber.Runtime[E, A_])(implicit unsafe: Unsafe): Unit = {
-    val fiberInstance = fiber.asInstanceOf[HasContext with HasStorage]
-    val ctx = fiberInstance.context
-    fiberInstance.setKamonScope(Kamon.storeContext(ctx))
+    val fi = fiber.asInstanceOf[HasContext with HasStorage]
+    val ctx = fi.context
+    fi.setKamonScope(Kamon.storeContext(ctx))
   }
 
   override def onEnd[R, E, A_](value: Exit[E, A_], fiber: Fiber.Runtime[E, A_])(implicit unsafe: Unsafe): Unit = {
-    val fiberInstance = fiber.asInstanceOf[HasContext with HasStorage]
-    fiberInstance.kamonScope.close()
+    val fi = fiber.asInstanceOf[HasContext with HasStorage]
+    fi.kamonScope.close()
+    ()
   }
 }

--- a/instrumentation/kamon-zio-2/src/test/scala/kamon/instrumentation/zio2/ZIO2InstrumentationSpec.scala
+++ b/instrumentation/kamon-zio-2/src/test/scala/kamon/instrumentation/zio2/ZIO2InstrumentationSpec.scala
@@ -167,6 +167,12 @@ class ZIO2InstrumentationSpec extends AnyWordSpec with Matchers with ScalaFuture
     }
   }
 
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+
+    kamon.context.Storage.Debug.printNonEmptyThreads()
+  }
+
   private def getKey: UIO[String] = {
     ZIO.succeed(Kamon.currentContext().getTag(plain("key")))
   }


### PR DESCRIPTION
So I didn't know about the printing thing, but after enabling it there were some dirty threads, and this scope closing on suspend seems to fix it. This has been working pretty well in production for a bit.