### PR TITLE
Allow failure log level configuration

### DIFF
--- a/reporters/kamon-datadog/src/main/resources/reference.conf
+++ b/reporters/kamon-datadog/src/main/resources/reference.conf
@@ -67,6 +67,8 @@ kamon {
       compression = false
     }
 
+    # The log level in which to log failures to submit metrics.
+    failure-log-level = "error"
 
     # All time values are collected in nanoseconds,
     # to scale before sending to datadog set "time-units" to "s" or "ms" or "µs".

--- a/reporters/kamon-datadog/src/main/scala/kamon/datadog/package.scala
+++ b/reporters/kamon-datadog/src/main/scala/kamon/datadog/package.scala
@@ -24,6 +24,8 @@ import com.typesafe.config.Config
 import kamon.metric.MeasurementUnit
 import kamon.metric.MeasurementUnit.{information, time}
 import okhttp3._
+import org.slf4j.Logger
+import org.slf4j.event.Level
 
 import scala.util.{Failure, Success, Try}
 
@@ -33,6 +35,23 @@ package object datadog {
     def getEpochNano: Long = {
       instant.getEpochSecond() * 1000000000 +
       instant.getNano()
+    }
+  }
+
+  implicit class LoggerExtras(val logger: Logger) extends AnyVal {
+    def logAtLevel(level: Level, msg: String): Unit = {
+      level match {
+        case Level.TRACE =>
+          logger.trace(msg)
+        case Level.DEBUG =>
+          logger.debug(msg)
+        case Level.INFO =>
+          logger.info(msg)
+        case Level.WARN =>
+          logger.warn(msg)
+        case Level.ERROR =>
+          logger.error(msg)
+      }
     }
   }
 
@@ -132,5 +151,15 @@ package object datadog {
     case "mb"  => information.megabytes
     case "gb"  => information.gigabytes
     case other => sys.error(s"Invalid time unit setting [$other], the possible values are [b, kb, mb, gb]")
+  }
+
+  def readLogLevel(level: String): Level = level match {
+    case "trace" => Level.TRACE
+    case "debug" => Level.DEBUG
+    case "info"  => Level.INFO
+    case "warn"  => Level.WARN
+    case "error" => Level.ERROR
+    case other =>
+      sys.error(s"Invalid log level setting [$other], the possible values are [trace, debug, info, warn, error]")
   }
 }


### PR DESCRIPTION
Datadog APIs sometimes give us timeouts or 502s, which seems to [happen to others as well](https://github.com/micrometer-metrics/micrometer/issues/1499).

The API reporter currently logs those failures in `ERROR` level which can be a bit frustrating for transient failures like those.

Here I try to add a configuration mechanism to control that log level. What do you think?