### PR TITLE
Perform retries for certain HTTP status codes when submitting metrics to Datadog API

### DIFF
--- a/reporters/kamon-datadog/src/main/resources/reference.conf
+++ b/reporters/kamon-datadog/src/main/resources/reference.conf
@@ -40,6 +40,14 @@ kamon {
       connect-timeout = 5 seconds
       read-timeout = 5 seconds
       write-timeout = 5 seconds
+
+      # Try this number of times to submit metrics to the Datadog API.
+      # Only in case of HTTP response status of 408, 429, 502, 503 or 504 is the request attempted again.
+      # A `0` value disables retries.
+      retries = 3
+
+      # The initial retry delay that gets exponentially increased after each retry attempt.
+      init-retry-delay = 500 milliseconds
     }
 
     #
@@ -65,6 +73,14 @@ kamon {
 
       # Use 'Deflate' compression when posting to the Datadog API
       compression = false
+
+      # Try this number of times to submit metrics to the Datadog API.
+      # Only in case of HTTP response status of 408, 429, 502, 503 or 504 is the request attempted again.
+      # A `0` value disables retries.
+      retries = 3
+
+      # The initial retry delay that gets exponentially increased after each retry attempt.
+      init-retry-delay = 500 milliseconds
     }
 
 

--- a/reporters/kamon-datadog/src/test/scala/kamon/datadog/AbstractHttpReporter.scala
+++ b/reporters/kamon-datadog/src/test/scala/kamon/datadog/AbstractHttpReporter.scala
@@ -22,6 +22,10 @@ abstract class AbstractHttpReporter extends AnyWordSpec with BeforeAndAfterAll {
     server.url(path).toString
   }
 
+  protected def mockResponse(response: MockResponse): Unit = {
+    server.enqueue(response)
+  }
+
   override protected def afterAll(): Unit = {
     super.afterAll()
     server.shutdown()


### PR DESCRIPTION
This proposes adding some retries when Datadog responds with certain status codes. We're using Datadog API reporter and it is frequent to have some transient failures, which is the motivation for these changes.

I've also considered dealing with some `Failure`s but, besides making testing harder, it is also not clear if those correspond to situations where the server did not receive the request at all and, thus, we might be duplicating data. 

So, having retries only for the success case of the request and work with HTTP status codes seemed more sensible.

What do you think, does this make sense?