### PR TITLE
Allow configuration of the percentile metrics to submit in Datadog API reporter

### DIFF
--- a/reporters/kamon-datadog/src/main/resources/reference.conf
+++ b/reporters/kamon-datadog/src/main/resources/reference.conf
@@ -70,6 +70,11 @@ kamon {
     # The log level in which to log failures to submit metrics.
     failure-log-level = "error"
 
+    # For histograms, which percentiles to submit.
+    # Each value configured here will correspond to a different custom metric submitted to Datadog.
+    # Currently only applicable to the API reporter.
+    percentiles = [95.0]
+
     # All time values are collected in nanoseconds,
     # to scale before sending to datadog set "time-units" to "s" or "ms" or "µs".
     # Value "n" is equivalent to omitting the setting

--- a/reporters/kamon-datadog/src/test/scala/kamon/datadog/DatadogAPIReporterSpec.scala
+++ b/reporters/kamon-datadog/src/test/scala/kamon/datadog/DatadogAPIReporterSpec.scala
@@ -22,6 +22,43 @@ class DatadogAPIReporterSpec extends AbstractHttpReporter with Matchers with Rec
       new DatadogAPIReporterFactory().create(ModuleFactory.Settings(Kamon.config(), ExecutionContext.global))
     val now = Instant.ofEpochMilli(1523395554)
 
+    val examplePeriodWithDistributions: PeriodSnapshot = {
+      val distributionExample = new Distribution {
+        override def dynamicRange: DynamicRange = ???
+        override def min: Long = 0
+        override def max: Long = 10
+        override def sum: Long = 100
+        override def count: Long = 5
+        override def percentile(rank: Double): Distribution.Percentile = new Percentile {
+          override def rank: Double = 0
+          override def value: Long = 0
+          override def countAtRank: Long = 0
+        }
+        override def percentiles: Seq[Distribution.Percentile] = ???
+        override def percentilesIterator: Iterator[Distribution.Percentile] = ???
+        override def buckets: Seq[Distribution.Bucket] = ???
+        override def bucketsIterator: Iterator[Distribution.Bucket] = ???
+      }
+      PeriodSnapshot.apply(
+        now.minusMillis(1000),
+        now,
+        Nil,
+        Nil,
+        Nil,
+        MetricSnapshot.ofDistributions(
+          "test.timer",
+          "test",
+          Metric.Settings.ForDistributionInstrument(
+            MeasurementUnit.none,
+            java.time.Duration.ZERO,
+            DynamicRange.Default
+          ),
+          Instrument.Snapshot.apply(TagSet.Empty, distributionExample) :: Nil
+        ) :: Nil,
+        Nil
+      )
+    }
+
     "sends metrics - compressed" in {
       val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK"))
       applyConfig("kamon.datadog.api.api-url = \"" + baseUrl + "\"")
@@ -90,50 +127,14 @@ class DatadogAPIReporterSpec extends AbstractHttpReporter with Matchers with Rec
 
     }
 
-    "send timer metrics" in {
+    "send timer metrics with the p95 percentile by default" in {
       val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK"))
       applyConfig("kamon.datadog.api.api-url = \"" + baseUrl + "\"")
       applyConfig("kamon.datadog.api.api-key = \"dummy\"")
       applyConfig("kamon.datadog.api.compression = false")
       reporter.reconfigure(Kamon.config())
 
-      val distribution = new Distribution {
-        override def dynamicRange: DynamicRange = ???
-        override def min: Long = 0
-        override def max: Long = 10
-        override def sum: Long = 100
-        override def count: Long = 5
-        override def percentile(rank: Double): Distribution.Percentile = new Percentile {
-          override def rank: Double = 0
-          override def value: Long = 0
-          override def countAtRank: Long = 0
-        }
-        override def percentiles: Seq[Distribution.Percentile] = ???
-        override def percentilesIterator: Iterator[Distribution.Percentile] = ???
-        override def buckets: Seq[Distribution.Bucket] = ???
-        override def bucketsIterator: Iterator[Distribution.Bucket] = ???
-      }
-
-      reporter.reportPeriodSnapshot(
-        PeriodSnapshot.apply(
-          now.minusMillis(1000),
-          now,
-          Nil,
-          Nil,
-          Nil,
-          MetricSnapshot.ofDistributions(
-            "test.timer",
-            "test",
-            Metric.Settings.ForDistributionInstrument(
-              MeasurementUnit.none,
-              java.time.Duration.ZERO,
-              DynamicRange.Default
-            ),
-            Instrument.Snapshot.apply(TagSet.Empty, distribution) :: Nil
-          ) :: Nil,
-          Nil
-        )
-      )
+      reporter.reportPeriodSnapshot(examplePeriodWithDistributions)
       val request = server.takeRequest()
       request.getRequestUrl.toString shouldEqual baseUrl + "?api_key=dummy"
       request.getMethod shouldEqual "POST"
@@ -144,6 +145,55 @@ class DatadogAPIReporterSpec extends AbstractHttpReporter with Matchers with Rec
             |{"metric":"test.timer.count","interval":1,"points":[[1523394,5]],"type":"count","host":"test","tags":["env:staging","service:kamon-application"]},
             |{"metric":"test.timer.median","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
             |{"metric":"test.timer.95percentile","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.max","interval":1,"points":[[1523394,10]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.min","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]}]}""".stripMargin
+        )
+    }
+
+    "send timer metrics allowing configuration of percentiles to submit" in {
+      val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK"))
+      applyConfig("kamon.datadog.api.api-url = \"" + baseUrl + "\"")
+      applyConfig("kamon.datadog.api.api-key = \"dummy\"")
+      applyConfig("kamon.datadog.api.compression = false")
+      applyConfig("kamon.datadog.percentiles = [95.0, 99, 94.5]")
+      reporter.reconfigure(Kamon.config())
+
+      reporter.reportPeriodSnapshot(examplePeriodWithDistributions)
+      val request = server.takeRequest()
+      request.getRequestUrl.toString shouldEqual baseUrl + "?api_key=dummy"
+      request.getMethod shouldEqual "POST"
+      Json.parse(request.getBody.readUtf8()) shouldEqual Json
+        .parse(
+          """{"series":[
+            |{"metric":"test.timer.avg","interval":1,"points":[[1523394,20]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.count","interval":1,"points":[[1523394,5]],"type":"count","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.median","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.95percentile","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.99percentile","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.94.5percentile","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.max","interval":1,"points":[[1523394,10]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.min","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]}]}""".stripMargin
+        )
+    }
+
+    "send timer metrics without percentiles" in {
+      val baseUrl = mockResponse("/test", new MockResponse().setStatus("HTTP/1.1 200 OK"))
+      applyConfig("kamon.datadog.api.api-url = \"" + baseUrl + "\"")
+      applyConfig("kamon.datadog.api.api-key = \"dummy\"")
+      applyConfig("kamon.datadog.api.compression = false")
+      applyConfig("kamon.datadog.percentiles = []")
+      reporter.reconfigure(Kamon.config())
+
+      reporter.reportPeriodSnapshot(examplePeriodWithDistributions)
+      val request = server.takeRequest()
+      request.getRequestUrl.toString shouldEqual baseUrl + "?api_key=dummy"
+      request.getMethod shouldEqual "POST"
+      Json.parse(request.getBody.readUtf8()) shouldEqual Json
+        .parse(
+          """{"series":[
+            |{"metric":"test.timer.avg","interval":1,"points":[[1523394,20]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.count","interval":1,"points":[[1523394,5]],"type":"count","host":"test","tags":["env:staging","service:kamon-application"]},
+            |{"metric":"test.timer.median","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
             |{"metric":"test.timer.max","interval":1,"points":[[1523394,10]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]},
             |{"metric":"test.timer.min","interval":1,"points":[[1523394,0]],"type":"gauge","host":"test","tags":["env:staging","service:kamon-application"]}]}""".stripMargin
         )


### PR DESCRIPTION
Currently, only p95 gets reported. Looking at p99 seems a fairly common and important use case. I tested this by making sure that these changes work against our Datadog account and I see the new metric.

Can we report p99 as well?