### PR TITLE
make kamon-pekko tolerant of null dispatcherPrerequisites

### DIFF
--- a/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/instrumentations/DispatcherInstrumentation.scala
+++ b/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/instrumentations/DispatcherInstrumentation.scala
@@ -127,13 +127,18 @@ object InstrumentNewExecutorServiceOnPekko {
     @SuperCall callable: Callable[ExecutorService]
   ): ExecutorService = {
     val executor = callable.call()
-    val actorSystemName = factory.dispatcherPrerequisites.settings.name
+    val actorSystemName = if (factory.dispatcherPrerequisites != null) {
+      factory.dispatcherPrerequisites.settings.name
+    } else {
+      "unknown"
+    }
     val dispatcherName = factory.dispatcherName
     val scheduledActionName = actorSystemName + "/" + dispatcherName
     val systemTags = TagSet.of("pekko.system", actorSystemName)
 
     if (Kamon.filter(PekkoInstrumentation.TrackDispatcherFilterName).accept(dispatcherName)) {
-      val defaultEcOption = factory.dispatcherPrerequisites.defaultExecutionContext
+      val defaultEcOption = Option(factory.dispatcherPrerequisites)
+        .flatMap(_.defaultExecutionContext)
 
       if (dispatcherName == Dispatchers.DefaultDispatcherId && defaultEcOption.isDefined) {
         ExecutorInstrumentation.instrumentExecutionContext(


### PR DESCRIPTION
relates to #1352 

unit tests pass and tested with https://github.com/pjfanning/kamon-pekko-http-test

The NPE may pop up in other use cases but this sorts the one seen in #1352 

I know a fuller fix is needed - one that ensures the dispatcherPrerequisites are found but that can be done independently.