### PR TITLE
kamon-pekko: reorder some code to avoid unnecessary eval

### DIFF
--- a/instrumentation/kamon-akka/src/akka-2.5/scala/kamon/instrumentation/akka/instrumentations/akka_25/DispatcherInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/akka-2.5/scala/kamon/instrumentation/akka/instrumentations/akka_25/DispatcherInstrumentation.scala
@@ -117,13 +117,12 @@ object InstrumentNewExecutorServiceOnAkka24 {
 
   def around(@This factory: HasDispatcherPrerequisites with HasDispatcherName, @SuperCall callable: Callable[ExecutorService]): ExecutorService = {
     val executor = callable.call()
-    val actorSystemName = factory.dispatcherPrerequisites.settings.name
     val dispatcherName = factory.dispatcherName
-    val scheduledActionName = actorSystemName + "/" + dispatcherName
-    val systemTags = TagSet.of("akka.system", actorSystemName)
-
 
     if(Kamon.filter(AkkaInstrumentation.TrackDispatcherFilterName).accept(dispatcherName)) {
+      val actorSystemName = factory.dispatcherPrerequisites.settings.name
+      val scheduledActionName = actorSystemName + "/" + dispatcherName
+      val systemTags = TagSet.of("akka.system", actorSystemName)
       val defaultEcOption = factory.dispatcherPrerequisites.defaultExecutionContext
 
       if(dispatcherName == Dispatchers.DefaultDispatcherId && defaultEcOption.isDefined) {
@@ -142,12 +141,12 @@ object InstrumentNewExecutorServiceOnAkka25 {
 
   def around(@This factory: HasDispatcherPrerequisites with HasDispatcherName, @SuperCall callable: Callable[ExecutorService]): ExecutorService = {
     val executor = callable.call()
-    val actorSystemName = factory.dispatcherPrerequisites.settings.name
     val dispatcherName = factory.dispatcherName
-    val scheduledActionName = actorSystemName + "/" + dispatcherName
-    val systemTags = TagSet.of("akka.system", actorSystemName)
 
     if(Kamon.filter(AkkaInstrumentation.TrackDispatcherFilterName).accept(dispatcherName)) {
+      val actorSystemName = factory.dispatcherPrerequisites.settings.name
+      val scheduledActionName = actorSystemName + "/" + dispatcherName
+      val systemTags = TagSet.of("akka.system", actorSystemName)
       val defaultEcOption = factory.dispatcherPrerequisites.defaultExecutionContext
 
       if(dispatcherName == Dispatchers.DefaultDispatcherId && defaultEcOption.isDefined) {

--- a/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/DispatcherInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/DispatcherInstrumentation.scala
@@ -109,12 +109,12 @@ object InstrumentNewExecutorServiceOnAkka26 {
 
   @static def around(@This factory: HasDispatcherPrerequisites with HasDispatcherName, @SuperCall callable: Callable[ExecutorService]): ExecutorService = {
     val executor = callable.call()
-    val actorSystemName = factory.dispatcherPrerequisites.settings.name
     val dispatcherName = factory.dispatcherName
-    val scheduledActionName = actorSystemName + "/" + dispatcherName
-    val systemTags = TagSet.of("akka.system", actorSystemName)
 
     if(Kamon.filter(AkkaInstrumentation.TrackDispatcherFilterName).accept(dispatcherName)) {
+      val actorSystemName = factory.dispatcherPrerequisites.settings.name
+      val scheduledActionName = actorSystemName + "/" + dispatcherName
+      val systemTags = TagSet.of("akka.system", actorSystemName)
       val defaultEcOption = factory.dispatcherPrerequisites.defaultExecutionContext
 
       if(dispatcherName == Dispatchers.DefaultDispatcherId && defaultEcOption.isDefined) {

--- a/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/instrumentations/DispatcherInstrumentation.scala
+++ b/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/instrumentations/DispatcherInstrumentation.scala
@@ -127,16 +127,16 @@ object InstrumentNewExecutorServiceOnPekko {
     @SuperCall callable: Callable[ExecutorService]
   ): ExecutorService = {
     val executor = callable.call()
-    val actorSystemName = if (factory.dispatcherPrerequisites != null) {
-      factory.dispatcherPrerequisites.settings.name
-    } else {
-      "unknown"
-    }
     val dispatcherName = factory.dispatcherName
-    val scheduledActionName = actorSystemName + "/" + dispatcherName
-    val systemTags = TagSet.of("pekko.system", actorSystemName)
 
     if (Kamon.filter(PekkoInstrumentation.TrackDispatcherFilterName).accept(dispatcherName)) {
+      val actorSystemName = if (factory.dispatcherPrerequisites != null) {
+        factory.dispatcherPrerequisites.settings.name
+      } else {
+        "unknown"
+      }
+      val scheduledActionName = actorSystemName + "/" + dispatcherName
+      val systemTags = TagSet.of("pekko.system", actorSystemName)
       val defaultEcOption = Option(factory.dispatcherPrerequisites)
         .flatMap(_.defaultExecutionContext)
 


### PR DESCRIPTION
* some vals are only needed if the Kamon.filter call returns true
* started with kamon-pekko but have added similar changes for kamon-akka now 