### PR TITLE
ThreadPoolConfigCopyAdvice often sets null prereqs

### DIFF
--- a/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/instrumentations/DispatcherInstrumentation.scala
+++ b/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/instrumentations/DispatcherInstrumentation.scala
@@ -167,9 +167,10 @@ object ThreadPoolConfigCopyAdvice {
 
   @Advice.OnMethodExit
   @static def exit(@Advice.This original: Any, @Advice.Return copy: Any): Unit = {
-    copy.asInstanceOf[HasDispatcherPrerequisites].setDispatcherPrerequisites(
-      original.asInstanceOf[HasDispatcherPrerequisites].dispatcherPrerequisites
-    )
+    val prereqs = original.asInstanceOf[HasDispatcherPrerequisites].dispatcherPrerequisites
+    if (prereqs != null) {
+      copy.asInstanceOf[HasDispatcherPrerequisites].setDispatcherPrerequisites(prereqs)
+    }
     copy.asInstanceOf[HasDispatcherName].setDispatcherName(original.asInstanceOf[HasDispatcherName].dispatcherName)
   }
 }


### PR DESCRIPTION
Found when testing #1352 

Even when testing with Scala 2.12, I see that the set in this PR often sets null
1352 affects Scala 2.13 far more than Scala 2.12.