### PR TITLE
use ByteString.toArrayUnsafe()

### DIFF
--- a/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/remote/internal/AkkaPduProtobufCodecDecodeMessageMethodAdvisor.scala
+++ b/instrumentation/kamon-akka/src/akka-2.6/scala/kamon/instrumentation/akka/instrumentations/akka_26/remote/internal/AkkaPduProtobufCodecDecodeMessageMethodAdvisor.scala
@@ -20,7 +20,7 @@ object AkkaPduProtobufCodecDecodeMessage {
 
   @OnMethodEnter
   @static def enter(@Argument(0) bs: ByteString, @Argument(1) provider: RemoteActorRefProvider, @Argument(2) localAddress: Address): Unit = {
-    val ackAndEnvelope = AckAndContextAwareEnvelopeContainer.parseFrom(bs.toArray)
+    val ackAndEnvelope = AckAndContextAwareEnvelopeContainer.parseFrom(bs.toArrayUnsafe())
     if (ackAndEnvelope.hasEnvelope && ackAndEnvelope.getEnvelope.hasTraceContext) {
       val remoteCtx = ackAndEnvelope.getEnvelope.getTraceContext
 

--- a/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/remote/internal/PekkoPduProtobufCodecDecodeMessageMethodAdvisor.scala
+++ b/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/remote/internal/PekkoPduProtobufCodecDecodeMessageMethodAdvisor.scala
@@ -24,7 +24,7 @@ object PekkoPduProtobufCodecDecodeMessage {
     @Argument(1) provider: RemoteActorRefProvider,
     @Argument(2) localAddress: Address
   ): Unit = {
-    val ackAndEnvelope = AckAndContextAwareEnvelopeContainer.parseFrom(bs.toArray)
+    val ackAndEnvelope = AckAndContextAwareEnvelopeContainer.parseFrom(bs.toArrayUnsafe())
     if (ackAndEnvelope.hasEnvelope && ackAndEnvelope.getEnvelope.hasTraceContext) {
       val remoteCtx = ackAndEnvelope.getEnvelope.getTraceContext
 


### PR DESCRIPTION
If we know that the code that we pass the byte array to doesn't modify the array then this call is ok - and more efficient as we avoid cloning the array for safety purposes. This code path is a hot path. Every Akka/Pekko remote that has Kamon Context Propagation is affected by the existing array cloning. 

Akka 2.5 does not support the ByteString.toArrayUnsafe() method.