### PR TITLE
CI: upgrade to actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   ci:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: git fetch -f --depth=1 origin '+refs/tags/*:refs/tags/*'
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1
@@ -20,7 +20,7 @@ jobs:
   lint:
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       JAVA_OPTS: -Xms5120M -Xmx5120M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms5120M -Xmx5120M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: git fetch -f --depth=1 origin '+refs/tags/*:refs/tags/*'
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1


### PR DESCRIPTION
GitHub want users to use newer versions of actions because the newer versions use more up to date versions of Node. They want to stop supporting old versions of Node.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/