### PR TITLE
acknowledge Lightbend in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 This software is licensed under the Apache 2 license, quoted below.
 
-Copyright © 2013-2014 the kamon project <http://kamon.io>
+Copyright © 2013-2024 the kamon project <http://kamon.io>
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of
@@ -13,3 +13,11 @@ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations under
 the License.
+
+------------------------------------------------------------------------
+
+The kamon-akka and kamon-pekko modules and other modules prefixed
+with "kamon-akka" and "kamon-pekko" contain code from the Akka project
+<https://akka.io/> which is licensed under the Apache License, Version 2.0.
+This code is from before Akka changed to the Business Source License 1.1.
+Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>


### PR DESCRIPTION
I'm the PMC Chair of Apache Pekko and have picked up some knowledge of how the Apache Software License is applied to code that is borrowed from 3rd party projects.
With the Apache Software License, you are meant to copy the LICENSE and NOTICE details from these 3rd party projects.

The last FOSS release of Akka (2.6.21) has a generic Apache License and no Notice.
https://github.com/akka/akka/blob/v2.6.21/LICENSE

I still think that since they changed to a different license that it is useful to declare that the Akka code copied into Kamon,
it is useful to declare that you are using Apache Licensed code developed by Lightbend.

I would also argue that you should add source headers to the Kamon source files that contain Akka code - but that can be added in another PR. When you copy 3rd party source, you are meant to keep the source headers too.

