### PR TITLE
+ prometheus: add configuration parameters to the accumulator

### DIFF
--- a/reporters/kamon-prometheus/src/main/resources/reference.conf
+++ b/reporters/kamon-prometheus/src/main/resources/reference.conf
@@ -4,7 +4,7 @@
 
 kamon.prometheus {
 
-  # Enable or disable publishing the Prometheus scraping enpoint using a embedded server.
+  # Enable or disable publishing the Prometheus scraping endpoint using a embedded server.
   start-embedded-http-server = yes
 
   # Enable or disable including tags from kamon.environment.tags as labels
@@ -96,6 +96,13 @@ kamon.prometheus {
       # "http.server*",
       # "*akka*"
     ]
+  }
+
+  periods {
+    # Period over which to accumulate snapshots in the reporter.
+    accumulation = "1825d"
+    # Period after which metrics are considered stale and are removed from the prometheus exported data.
+    stale = "1825d"
   }
 
   embedded-server {

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusPushgatewayReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusPushgatewayReporter.scala
@@ -31,8 +31,13 @@ class PrometheusPushgatewayReporter(
 ) extends MetricReporter {
 
   private val _logger = LoggerFactory.getLogger(classOf[PrometheusPushgatewayReporter])
+  private val _initialSettings = PrometheusSettings.readSettings(Kamon.config().getConfig(configPath))
   private val _snapshotAccumulator =
-    PeriodSnapshot.accumulator(Duration.ofDays(365 * 5), Duration.ZERO, Duration.ofDays(365 * 5))
+    PeriodSnapshot.accumulator(
+      _initialSettings.periodSettings.accumulationPeriod,
+      Duration.ZERO,
+      _initialSettings.periodSettings.stalePeriod
+    )
 
   @volatile private var httpClient: HttpClient = _
   @volatile private var settings: PrometheusSettings.Generic = _

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusReporter.scala
@@ -34,14 +34,19 @@ class PrometheusReporter(configPath: String = DefaultConfigPath, initialConfig: 
 
   private val _logger = LoggerFactory.getLogger(classOf[PrometheusReporter])
   private var _embeddedHttpServer: Option[EmbeddedHttpServer] = None
-  private val _snapshotAccumulator =
-    PeriodSnapshot.accumulator(Duration.ofDays(365 * 5), Duration.ZERO, Duration.ofDays(365 * 5))
 
   @volatile private var _preparedScrapeData: String =
     "# The kamon-prometheus module didn't receive any data just yet.\n"
 
   @volatile private var _config = initialConfig
   @volatile private var _reporterSettings = readSettings(initialConfig.getConfig(configPath))
+
+  private val _snapshotAccumulator =
+    PeriodSnapshot.accumulator(
+      _reporterSettings.generic.periodSettings.accumulationPeriod,
+      Duration.ZERO,
+      _reporterSettings.generic.periodSettings.stalePeriod
+    )
 
   {
     startEmbeddedServerIfEnabled()

--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/PrometheusSettings.scala
@@ -21,6 +21,8 @@ import kamon.tag.TagSet
 import kamon.util.Filter.Glob
 import kamon.{Kamon, UtilsOnConfig}
 
+import java.time.Duration
+
 import scala.collection.JavaConverters._
 
 object PrometheusSettings {
@@ -33,12 +35,18 @@ object PrometheusSettings {
     customBuckets: Map[String, Seq[java.lang.Double]],
     includeEnvironmentTags: Boolean,
     summarySettings: SummarySettings,
-    gaugeSettings: GaugeSettings
+    gaugeSettings: GaugeSettings,
+    periodSettings: PeriodSettings
   )
 
   case class SummarySettings(
     quantiles: Seq[java.lang.Double],
     metricMatchers: Seq[Glob]
+  )
+
+  case class PeriodSettings(
+    accumulationPeriod: Duration,
+    stalePeriod: Duration
   )
 
   case class GaugeSettings(metricMatchers: Seq[Glob])
@@ -57,6 +65,10 @@ object PrometheusSettings {
       ),
       gaugeSettings = GaugeSettings(
         metricMatchers = prometheusConfig.getStringList("gauges.metrics").asScala.map(Glob).toSeq
+      ),
+      periodSettings = PeriodSettings(
+        accumulationPeriod = prometheusConfig.getDuration("periods.accumulation"),
+        stalePeriod = prometheusConfig.getDuration("periods.stale")
       )
     )
   }


### PR DESCRIPTION
# PR Goal
As mentioned in #777, and some [discord conversations](https://discord.com/channels/866301994074243132/1311723807492411443), the issue of prometheus keeping removed metrics for 5 years can sometimes cause issues. 

# Choices
The current configuration behavior does not handle reconfiguration. I did not want to make choices on whether to keep data or not if a reload had to modify the snapshot accumulator, and unsure if making the accumulator variable was a good idea anyway. I am of course open to feedback on this issue