### PR TITLE
expose text Content-Type in embedded http server

### DIFF
--- a/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
+++ b/reporters/kamon-prometheus/src/main/scala/kamon/prometheus/embeddedhttp/SunEmbeddedHttpServer.scala
@@ -41,6 +41,7 @@ class SunEmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSou
           val bytes = data.getBytes(StandardCharsets.UTF_8)
           var os: OutputStream = null
           try {
+            httpExchange.getResponseHeaders.set("Content-Type", "text/plain; charset=UTF-8")
             if (shouldUseCompression(httpExchange)) {
               httpExchange.getResponseHeaders.set("Content-Encoding", "gzip")
               httpExchange.sendResponseHeaders(200, 0)
@@ -51,7 +52,7 @@ class SunEmbeddedHttpServer(hostname: String, port: Int, path: String, scrapeSou
               httpExchange.sendResponseHeaders(200, bytes.length)
               os.write(bytes)
             }
-          } finally Option(os).map(_.close())
+          } finally Option(os).foreach(_.close())
         } else httpExchange.sendResponseHeaders(404, -1)
       }
     }


### PR DESCRIPTION
As of today, the Kamon embedded server does not set the `Content-Type` in its response headers. 
This breaks Prometheus 3.0 which requires this header to be properly set : 
https://prometheus.io/docs/prometheus/3.0/migration/#scrape-protocols

To fix this issue, I have modified `SunHttpServerSpecSuite`