### PR TITLE
avoid running CI twice on every commit push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: Test all the things
-on: [ push, pull_request ]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 env:
   JAVA_OPTS: -Xms5120M -Xmx5120M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
   JVM_OPTS: -Xms5120M -Xmx5120M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8


### PR DESCRIPTION
The CI job would run twice every time we push a commit to a PR, once for the `push` and once for the `pull_request` event. These changes will minimize that. We will still run the `push` event when a PR gets merged to `master` even though the commit was already tested in the PR but I couldn't find a simple way to prevent that.