### PR TITLE
Throw more helpful error if kanela-agent jar is undiscoverable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1
         with:
-          jvm: adopt:8
+          jvm: adopt:17
           apps: sbt
       - name: Test
         run: sbt -v ";+core/test;+instrumentation/test;+reporters/test"
@@ -30,7 +30,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1
         with:
-          jvm: adopt:8
+          jvm: adopt:17
           apps: sbt
       - name: Test
         run: sbt -v "+scalafmtCheckAll;scalafmtSbtCheck"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1
         with:
-          jvm: adopt:17
+          jvm: adopt:8
           apps: sbt
       - name: Test
         run: sbt -v ";+core/test;+instrumentation/test;+reporters/test"
@@ -30,7 +30,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: coursier/setup-action@v1
         with:
-          jvm: adopt:17
+          jvm: adopt:8
           apps: sbt
       - name: Test
         run: sbt -v "+scalafmtCheckAll;scalafmtSbtCheck"

--- a/build.sbt
+++ b/build.sbt
@@ -1007,7 +1007,6 @@ lazy val bundle = (project in file("bundle"))
     `kamon-runtime-attacher`
   )
 
-import com.lightbend.sbt.javaagent.Modules
 import BundleKeys._
 
 lazy val commonBundleSettings = Seq(
@@ -1045,8 +1044,8 @@ lazy val `kamon-runtime-attacher` = (project in file("bundle/kamon-runtime-attac
     moduleName := "kamon-runtime-attacher",
     buildInfoPackage := "kamon.runtime.attacher",
     buildInfoKeys := Seq[BuildInfoKey](kanelaAgentJarName),
-    kanelaAgentJar := update.value.matching(Modules.exactFilter(kanelaAgent)).head,
-    kanelaAgentJarName := kanelaAgentJar.value.getName,
+    kanelaAgentJar := BaseProject.findKanelaAgentJar.value,
+    kanelaAgentJarName := BaseProject.findKanelaAgentJar.value.getName,
     Compile / resourceGenerators += Def.task(Seq(kanelaAgentJar.value)).taskValue,
     assembly / assemblyShadeRules := Seq(
       ShadeRule.zap("**module-info").inAll,

--- a/bundle/kamon-runtime-attacher/src/main/scala/kamon/runtime/Attacher.scala
+++ b/bundle/kamon-runtime-attacher/src/main/scala/kamon/runtime/Attacher.scala
@@ -29,7 +29,9 @@ object Attacher {
 
     } else {
 
-      val embeddedAgentFile = Attacher.getClass.getClassLoader.getResourceAsStream(BuildInfo.kanelaAgentJarName)
+      val embeddedAgentFile =
+        Option(Attacher.getClass.getClassLoader.getResourceAsStream(BuildInfo.kanelaAgentJarName))
+          .getOrElse(throw new RuntimeException(s"Couldn't find kanela jar resource '${BuildInfo.kanelaAgentJarName}'"))
       val temporaryAgentFile = Files.createTempFile(BuildInfo.kanelaAgentJarName, ".jar")
       Files.copy(embeddedAgentFile, temporaryAgentFile, StandardCopyOption.REPLACE_EXISTING)
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -228,11 +228,10 @@ object BaseProject extends AutoPlugin {
       case s @ Nil => throw new NoClassDefFoundError("No kanela agent jar found")
       case h +: Nil =>
         if (h.getName.matches(hasSemver)) println("Single matching kanela-agent jar found")
-        else System.err.println("kanela-agent jar did not contain version")
+        else System.err.println("kanela-agent jar name did not contain version")
         h
       case s =>
         System.err.println(s"Multiple matching jars - ${s.map(f => f.getName)}")
-        val hasSemver = """.*[0-9]+\.[0-9]+\.[0-9]+.*"""
         s.filter(_.getName.matches(hasSemver)) match {
           case Nil =>
             System.err.println("No jars matching semver ")


### PR DESCRIPTION
Also log errors if we somehow manage to find an unversioned kanela-agent jar on the path

I haven't managed to replicate any aspect of https://github.com/kamon-io/Kamon/issues/1392 locally and quite frankly can't really see how it could've happened. Adding some logs to the jar discovery process in case it happens again...