### PR TITLE
pekko-connectors-kafka works on Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1162,6 +1162,7 @@ lazy val `kamon-bundle-dependencies-3` = (project in file("bundle/kamon-bundle-d
     `kamon-pekko`,
     `kamon-pekko-http`,
     `kamon-pekko-grpc`,
+    `kamon-pekko-connectors-kafka`,
     `kamon-apache-httpclient`,
     `kamon-apache-cxf`
   )


### PR DESCRIPTION
I think it is omitted because the Akka equivalent does not work on Scala 3 (at least not any the Apache licensed versions)