### PR TITLE
drop Play 2.7 and test on Play 2.8, 2.9, and 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -612,9 +612,11 @@ lazy val `kamon-play` = (project in file("instrumentation/kamon-play"))
     crossScalaVersions := Seq(`scala_2.13_version`)
   )
   .dependsOn(
-    `kamon-akka` % "compile,test-common,test-play-2.8,test-play-2.7",
-    `kamon-akka-http` % "compile,test-common,test-play-2.8,test-play-2.7",
-    `kamon-testkit` % "test-common,test-play-2.8,test-play-2.7"
+    `kamon-akka` % "compile,test-common,test-play-28,test-play-29",
+    `kamon-akka-http` % "compile,test-common,test-play-28,test-play-29",
+    `kamon-pekko` % "compile,test-common,test-play-30",
+    `kamon-pekko-http` % "compile,test-common,test-play-30",
+    `kamon-testkit` % "test-common,test-play-28,test-play-29,test-play-30"
   )
 
 lazy val `kamon-okhttp` = (project in file("instrumentation/kamon-okhttp"))

--- a/instrumentation/kamon-play/build.sbt
+++ b/instrumentation/kamon-play/build.sbt
@@ -1,41 +1,62 @@
 import sbt.Tests._
 
-val `Play-2.7-version` = "2.7.9"
-val `Play-2.8-version` = "2.8.2"
+val `Play-2.8-version` = "2.8.22"
+val `Play-2.9-version` = "2.9.7"
+val `Play-3.0-version` = "3.0.7"
 
 /**
   * Test Configurations
   */
 lazy val TestCommon = config("test-common") extend (Compile)
-lazy val `Test-Play-2.7` = config("test-play-2.7")
-lazy val `Test-Play-2.8` = config("test-play-2.8")
+lazy val `Test-Play-28` = config("test-play-28")
+lazy val `Test-Play-29` = config("test-play-29")
+lazy val `Test-Play-30` = config("test-play-30")
 
 configs(
   TestCommon,
-  `Test-Play-2.8`,
-  `Test-Play-2.7`
+  `Test-Play-28`,
+  `Test-Play-29`,
+  `Test-Play-30`
 )
 
 libraryDependencies ++= Seq(
   kanelaAgent % "provided",
-  "com.typesafe.play" %% "play" % `Play-2.7-version` % "provided,test-common,test-play-2.7",
-  "com.typesafe.play" %% "play-netty-server" % `Play-2.7-version` % "provided,test-common,test-play-2.7",
-  "com.typesafe.play" %% "play-akka-http-server" % `Play-2.7-version` % "provided,test-common,test-play-2.7",
-  "com.typesafe.play" %% "play-ws" % `Play-2.7-version` % "provided,test-common,test-play-2.7",
-  "com.typesafe.play" %% "play-test" % `Play-2.7-version` % "provided,test-common,test-play-2.7",
-  "com.typesafe.play" %% "play-logback" % `Play-2.7-version` % "test-common,test-play-2.7",
-  scalatest % "test-common,test-play-2.8,test-play-2.7",
-  "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % "test-play-2.8,test-play-2.7"
+  scalatest % "test-common,test-play-28,test-play-29,test-play-30"
 )
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-akka-http2-support" % `Play-2.8-version` % "test-play-2.8",
-  "com.typesafe.play" %% "play" % `Play-2.8-version` % "test-play-2.8",
-  "com.typesafe.play" %% "play-netty-server" % `Play-2.8-version` % "test-play-2.8",
-  "com.typesafe.play" %% "play-akka-http-server" % `Play-2.8-version` % "test-play-2.8",
-  "com.typesafe.play" %% "play-ws" % `Play-2.8-version` % "test-play-2.8",
-  "com.typesafe.play" %% "play-test" % `Play-2.8-version` % "test-play-2.8",
-  "com.typesafe.play" %% "play-logback" % `Play-2.8-version` % "test-play-2.8"
+  "com.typesafe.play" %% "play-akka-http2-support" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "com.typesafe.play" %% "play" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "com.typesafe.play" %% "play-netty-server" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "com.typesafe.play" %% "play-akka-http-server" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "com.typesafe.play" %% "play-ws" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "com.typesafe.play" %% "play-test" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "com.typesafe.play" %% "play-logback" % `Play-2.8-version` % "provided,test-common,test-play-28",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % "provided,test-common,test-play-28",
+  "com.google.inject" % "guice" % "5.1.0" % "test-play-28",
+  "com.google.inject.extensions" % "guice-assistedinject" % "5.1.0" % "test-play-28"
+)
+
+libraryDependencies ++= Seq(
+  "com.typesafe.play" %% "play-akka-http2-support" % `Play-2.9-version` % "test-play-29",
+  "com.typesafe.play" %% "play" % `Play-2.9-version` % "test-play-29",
+  "com.typesafe.play" %% "play-netty-server" % `Play-2.9-version` % "test-play-29",
+  "com.typesafe.play" %% "play-akka-http-server" % `Play-2.9-version` % "test-play-29",
+  "com.typesafe.play" %% "play-ws" % `Play-2.9-version` % "test-play-29",
+  "com.typesafe.play" %% "play-test" % `Play-2.9-version` % "test-play-29",
+  "com.typesafe.play" %% "play-logback" % `Play-2.9-version` % "test-play-29",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "6.0.1" % "test-play-29"
+)
+
+libraryDependencies ++= Seq(
+  "org.playframework" %% "play-pekko-http2-support" % `Play-3.0-version` % "test-play-30",
+  "org.playframework" %% "play" % `Play-3.0-version` % "test-play-30",
+  "org.playframework" %% "play-netty-server" % `Play-3.0-version` % "test-play-30",
+  "org.playframework" %% "play-pekko-http-server" % `Play-3.0-version` % "test-play-30",
+  "org.playframework" %% "play-ws" % `Play-3.0-version` % "test-play-30",
+  "org.playframework" %% "play-test" % `Play-3.0-version` % "test-play-30",
+  "org.playframework" %% "play-logback" % `Play-3.0-version` % "test-play-30",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % "test-play-30"
 )
 
 /**
@@ -53,15 +74,28 @@ inConfig(TestCommon)(Defaults.testSettings ++ instrumentationSettings ++ baseTes
   crossScalaVersions := Seq(`scala_2.13_version`)
 ))
 
-inConfig(`Test-Play-2.7`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
-  sources := joinSources(TestCommon, `Test-Play-2.7`).value,
+inConfig(`Test-Play-28`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
+  sources := joinSources(TestCommon, `Test-Play-28`).value,
+  crossScalaVersions := Seq(`scala_2.13_version`),
+  testGrouping := singleTestPerJvm(definedTests.value, javaOptions.value),
+  unmanagedResourceDirectories ++= (Compile / unmanagedResourceDirectories).value,
+  unmanagedResourceDirectories ++= (TestCommon / unmanagedResourceDirectories).value,
+  javaOptions ++= Seq(
+    "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
+    "--add-opens=java.base/sun.security.ssl=ALL-UNNAMED"
+  )
+))
+
+inConfig(`Test-Play-29`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
+  sources := joinSources(TestCommon, `Test-Play-29`).value,
+  crossScalaVersions := Seq(`scala_2.13_version`),
   testGrouping := singleTestPerJvm(definedTests.value, javaOptions.value),
   unmanagedResourceDirectories ++= (Compile / unmanagedResourceDirectories).value,
   unmanagedResourceDirectories ++= (TestCommon / unmanagedResourceDirectories).value
 ))
 
-inConfig(`Test-Play-2.8`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
-  sources := joinSources(TestCommon, `Test-Play-2.8`).value,
+inConfig(`Test-Play-30`)(Defaults.testSettings ++ instrumentationSettings ++ baseTestSettings ++ Seq(
+  sources := joinSources(TestCommon, `Test-Play-30`).value,
   crossScalaVersions := Seq(`scala_2.13_version`),
   testGrouping := singleTestPerJvm(definedTests.value, javaOptions.value),
   unmanagedResourceDirectories ++= (Compile / unmanagedResourceDirectories).value,
@@ -70,8 +104,9 @@ inConfig(`Test-Play-2.8`)(Defaults.testSettings ++ instrumentationSettings ++ ba
 
 Test / test := Def.taskDyn {
   Def.task {
-    (`Test-Play-2.7` / test).value
-    (`Test-Play-2.8` / test).value
+    (`Test-Play-28` / test).value
+    (`Test-Play-29` / test).value
+    (`Test-Play-30` / test).value
   }
 }.value
 

--- a/instrumentation/kamon-play/project/build.properties
+++ b/instrumentation/kamon-play/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.8

--- a/instrumentation/kamon-play/src/test-common/resources/conf/application-pekko-http.conf
+++ b/instrumentation/kamon-play/src/test-common/resources/conf/application-pekko-http.conf
@@ -1,0 +1,4 @@
+include "application.conf"
+
+play.server.provider=play.core.server.PekkoHttpServerProvider
+play.server.pekko.http2.enabled = false


### PR DESCRIPTION
This change starts testing the Play instrumentation in Play 2.9 and 3.0 and drops 2.7. The instrumentation didn't change at all so it will continue to work in Play 2.7 but we are not going to be testing older versions anymore.

There is one tiny disparity on how the instrumentation works with Pekko vs Akka: the `component` tag for metrics and spans will be `pekko.http.server` instead of `play.server.pekko-http` because we would need to do a more significant effort in refactoring the tests and possibly the build and that effort doesn't seem to be worth it. Technically speaking it is still correct information because after all, the HTTP server IS Pekko HTTP, but just by looking at the metrics/spans you wouldn't know that this is actually Play Framework using Pekko HTTP instead of using Pekko HTTP directly. 