### PR TITLE
Fix Akka's and Pekko's `doomsday-wildcard` config

### DIFF
--- a/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/AkkaInstrumentation.scala
+++ b/instrumentation/kamon-akka/src/common/scala/kamon/instrumentation/akka/AkkaInstrumentation.scala
@@ -115,7 +115,7 @@ object AkkaInstrumentation {
     private def safeFilter(config: Config, allowDoomsday: Boolean): Filter = {
       val includes = config.getStringList("includes").asScala
       if(!allowDoomsday && includes.contains("**")) {
-        val newIncludes = "includes = " + includes.filter(_ == "**").map(s => s""""$s"""").mkString("[ ", ", ", " ]")
+        val newIncludes = "includes = " + includes.filterNot(_ == "**").map(s => s""""$s"""").mkString("[ ", ", ", " ]")
         val safeFilterConfig = ConfigFactory.parseString(newIncludes).withFallback(config)
 
         Filter.from(safeFilterConfig)

--- a/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/PekkoInstrumentation.scala
+++ b/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/PekkoInstrumentation.scala
@@ -115,7 +115,7 @@ object PekkoInstrumentation {
     private def safeFilter(config: Config, allowDoomsday: Boolean): Filter = {
       val includes = config.getStringList("includes").asScala
       if (!allowDoomsday && includes.contains("**")) {
-        val newIncludes = "includes = " + includes.filter(_ == "**").map(s => s""""$s"""").mkString("[ ", ", ", " ]")
+        val newIncludes = "includes = " + includes.filterNot(_ == "**").map(s => s""""$s"""").mkString("[ ", ", ", " ]")
         val safeFilterConfig = ConfigFactory.parseString(newIncludes).withFallback(config)
 
         Filter.from(safeFilterConfig)


### PR DESCRIPTION
> [!CAUTION]
> **I am pretty pretty sure the current code is flawed**

`doomsday-wildcard` is `off` by default ([see config](https://github.com/kamon-io/Kamon/blob/v2.7.7/instrumentation/kamon-pekko/src/main/resources/reference.conf#L69)).

All I do now is, I set `includes` to `"**"`. Now I expect that `includes` just doesn't have any effect at all - basically like having an empty `includes` (which is the default).
So I end up with this (partically) config:
```
{
  "kamon": {
    "instrumentation": {
      "pekko": {
        "filters": {
          "actors": {
            "doomsday-wildcard": "off",
            "track": {
              "excludes": [
                "*/system/**",
                "*/user/IO-**"
              ],
              "includes": [
                "**"
              ]
            }
          }
        }
    }
  }
}
```

However - I do see actors getting tracked now which should not - because the `doomsday-wildcard` just does not work...

Let's look at the code:
https://github.com/kamon-io/Kamon/blob/db2c3edd508d0b21c178a7cb6a6d7e9be371851e/instrumentation/kamon-pekko/src/main/scala/kamon/instrumentation/pekko/PekkoInstrumentation.scala#L115-L125

`val newIncludes` _always_ (!) ends up as string `"includes = [ "**" ]"`:
```scala
$ scala
Welcome to Scala 2.13.16 (OpenJDK 64-Bit Server VM, Java 17.0.15).
Type in expressions for evaluation. Or try :help.

scala> val includes = List("one", "**", "two") // simulates: config.getStringList("includes").asScala 
val includes: List[String] = List(one, **, two)

scala> val newIncludes = "includes = " + includes.filter(_ == "**").map(s => s""""$s"""").mkString("[ ", ", ", " ]")
val newIncludes: String = includes = [ "**" ]
```

So you always filter out the `**` wildcard and therefore always build the string `"includes = [ "**" ]"`!
Afterwards you always override the provided config with 
```scala
val safeFilterConfig = ConfigFactory.parseString(newIncludes).withFallback(config)
// always (!) ends up as
val safeFilterConfig = ConfigFactory.parseString("includes = [ \"**\" ]").withFallback(config)
```

Correct would be to either use `filterNot` or `filter(_ != "**")`:

```scala
scala> val newIncludes = "includes = " + includes.filterNot(_ == "**").map(s => s""""$s"""").mkString("[ ", ", ", " ]")
val newIncludes: String = includes = [ "one", "two" ]
```

IMHO it would be nice to push out a 2.7.8 release with this fix :wink: 
Maybe even including #1402?
Thanks!

