### PR TITLE
do not lose span renames when the rename happens before returning actions in a play controller

### DIFF
--- a/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/PlayServerInstrumentation.scala
+++ b/instrumentation/kamon-play/src/main/scala/kamon/instrumentation/play/PlayServerInstrumentation.scala
@@ -291,7 +291,9 @@ object GenerateOperationNameOnFilterHandler {
   def enter(@Advice.Argument(0) request: RequestHeader): Unit = {
     request.attrs.get(Router.Attrs.HandlerDef).map(handler => {
       val span = Kamon.currentSpan()
-      span.name(_routerNameGenerator.generateOperationName(handler))
+      if (span.operationName() == "http.server.request") {
+        span.name(_routerNameGenerator.generateOperationName(handler))
+      }
       span.takeSamplingDecision()
     })
   }


### PR DESCRIPTION
This should fix #1411.

The root of the issue is that in some Play applications there could be controllers that look a bit like this:

```
def handleRequest(...) = {
  // some code
  Kamon.currentSpan().name("custom-name")

  CustomAction {
    // The actual request handling happens here
  }
}
```

In these cases the rename happens during the "routing" part of the request handling in Play (see [here](https://github.com/playframework/playframework/blob/3.0.9/core/play/src/main/scala/play/api/http/HttpRequestHandler.scala#L223-L228) and we apply the default operation names after that, during the filter handling which effectively overrides any operation name that was set during the routing stage.

It's hard to protect against unusual usage patterns like this (usually all processing would happen inside an Action) but regardless of what's causing the issue we should not overwrite operation names assigned by users. This PR just checks whether the operation name is the default and if so, it generates a new name. We do something similar in the Akka HTTP routing instrumentation as well.

I don't like that we are not reading the default operation name from config but for now I think we can live with that.