### PR TITLE
Fix AWS SDK v2 span naming to match v1 convention

### DIFF
--- a/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkClientExecutionInterceptor.scala
+++ b/instrumentation/kamon-aws-sdk/src/main/scala/kamon/instrumentation/aws/sdk/AwsSdkClientExecutionInterceptor.scala
@@ -42,7 +42,7 @@ class AwsSdkClientExecutionInterceptor extends ExecutionInterceptor {
       val serviceName = executionAttributes.getAttribute(SdkExecutionAttribute.SERVICE_NAME)
       val clientType = executionAttributes.getAttribute(SdkExecutionAttribute.CLIENT_TYPE)
 
-      val clientSpan = Kamon.clientSpanBuilder(operationName, serviceName)
+      val clientSpan = Kamon.clientSpanBuilder(s"$serviceName.$operationName", serviceName)
         .tag("aws.sdk.client_type", clientType.name())
         .start()
 

--- a/instrumentation/kamon-aws-sdk/src/test/scala/kamon/instrumentation/aws/sdk/DynamoDBTracingSpec.scala
+++ b/instrumentation/kamon-aws-sdk/src/test/scala/kamon/instrumentation/aws/sdk/DynamoDBTracingSpec.scala
@@ -60,7 +60,7 @@ class DynamoDBTracingSpec extends AnyWordSpec with Matchers with OptionValues wi
 
       eventually(timeout(5 seconds)) {
         val span = testSpanReporter().nextSpan().value
-        span.operationName shouldBe "CreateTable"
+        span.operationName shouldBe "DynamoDb.CreateTable"
         span.metricTags.get(plain("component")) shouldBe "DynamoDb"
       }
     }


### PR DESCRIPTION
Fixes #1421

## Summary

The SDK v1 `AwsSdkRequestHandler` uses `serviceName.operationName` format for span names (e.g. `AmazonDynamoDBv2.Query`), but the SDK v2 `AwsSdkClientExecutionInterceptor` only uses `operationName` (e.g. `Query`).

This inconsistency makes it difficult to identify which AWS service a span belongs to in distributed traces, especially when multiple AWS services are used in the same application.

This one-line fix applies the same `$serviceName.$operationName` naming convention to the SDK v2 interceptor, producing span names like `DynamoDb.Query`, `S3.GetObject`, `Sts.AssumeRole`, etc.

## Changes

- `AwsSdkClientExecutionInterceptor.scala`: Prepend `serviceName.` to the operation name, matching the v1 handler behavior
- `DynamoDBTracingSpec.scala`: Update test expectation to match new naming

## Before / After

| SDK | Before | After |
|-----|--------|-------|
| v1 | `AmazonDynamoDBv2.Query` | `AmazonDynamoDBv2.Query` (unchanged) |
| v2 | `Query` | `DynamoDb.Query` |