### PR TITLE
Add kamon-http4k server instrumentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,7 @@ val instrumentationProjects = Seq[ProjectReference](
   `kamon-alpakka-kafka`,
   `kamon-http4s-1_0`,
   `kamon-http4s-0_23`,
+  `kamon-http4k`,
   `kamon-apache-httpclient`,
   `kamon-apache-cxf`
 )
@@ -792,6 +793,24 @@ lazy val `kamon-http4s-0_23` = (project in file("instrumentation/kamon-http4s-0.
       "org.http4s" %% "http4s-blaze-client" % "0.23.14" % Test,
       "org.http4s" %% "http4s-blaze-server" % "0.23.14" % Test,
       "org.http4s" %% "http4s-dsl" % "0.23.19" % Test,
+      scalatest % Test
+    )
+  )
+  .dependsOn(
+    `kamon-core`,
+    `kamon-instrumentation-common`,
+    `kamon-testkit` % Test
+  )
+
+lazy val `kamon-http4k` = (project in file("instrumentation/kamon-http4k"))
+  .disablePlugins(AssemblyPlugin)
+  .enablePlugins(JavaAgent)
+  .settings(instrumentationSettings)
+  .settings(
+    name := "kamon-http4k",
+    crossScalaVersions := Seq(`scala_2.13_version`, `scala_3_version`),
+    libraryDependencies ++= Seq(
+      "org.http4k" % "http4k-core" % "6.55.0.0" % "provided,test",
       scalatest % Test
     )
   )

--- a/instrumentation/kamon-http4k/src/main/resources/reference.conf
+++ b/instrumentation/kamon-http4k/src/main/resources/reference.conf
@@ -1,0 +1,237 @@
+# ======================================= #
+# Kamon-Http4k Reference Configuration   #
+# ======================================= #
+
+kamon.instrumentation.http4k {
+
+  # Settings to control the HTTP Server instrumentation.
+  server {
+
+    #
+    # Configuration for HTTP context propagation.
+    #
+    propagation {
+
+      # Enables or disables HTTP context propagation on this HTTP server instrumentation. Please note that if
+      # propagation is disabled then some distributed tracing features will not be work as expected (e.g. Spans can
+      # be created and reported but will not be linked across boundaries nor take trace identifiers from tags).
+      #enabled = yes
+
+      # HTTP propagation channel to be used by this instrumentation. Take a look at the kamon.propagation.http.default
+      # configuration for more details on how to configure the detault HTTP context propagation.
+      channel = "default"
+    }
+
+    #
+    # Configuration for HTTP server metrics collection.
+    #
+    metrics {
+
+      # Enables collection of HTTP server metrics. When enabled the following metrics will be
+      # collected:
+      #
+      #   - http.server.requests
+      #   - http.server.request.active
+      #   - http.server.request.size
+      #   - http.server.response.size
+      #
+      # All metrics have at least three tags: component, interface and port. Additionally, the http.server.requests
+      # metric will also have a status_code tag with the status code group (1xx, 2xx and so on).
+      #
+      #enabled = yes
+    }
+
+    #
+    # Configuration for HTTP request tracing.
+    #
+    tracing {
+
+      # Enables HTTP request tracing. When enabled the instrumentation will create Spans for incoming requests
+      # and finish them when the response is sent back to the clients.
+      #enabled = yes
+
+      # Select a context tag that provides a preferred trace identifier. The preferred trace identifier will be used
+      # only if all these conditions are met:
+      #   - the context tag is present.
+      #   - there is no parent Span on the incoming context (i.e. this is the first service on the trace).
+      #   - the identifier is valid in accordance to the identity provider.
+      #preferred-trace-id-tag = "none"
+
+      # Enables collection of span metrics using the `span.processing-time` metric.
+      #span-metrics = on
+      
+      # Select which tags should be included as span and span metric tags. The possible options are:
+      #   - span: the tag is added as a Span tag (i.e. using span.tag(...))
+      #   - metric: the tag is added a a Span metric tag (i.e. using span.tagMetric(...))
+      #   - off: the tag is not used.
+      #
+      tags {
+
+        # Use the http.url tag.
+        #url = span
+
+        # Use the http.method tag.
+        #method = metric
+
+        # Use the http.status_code tag.
+        #status-code = metric
+
+        # Copy tags from the context into the Spans with the specified purpouse. For example, to copy a customer_type
+        # tag from the context into the HTTP Server Span created by the instrumentation, the following configuration
+        # should be added:
+        #
+        # from-context {
+        #   customer_type = span
+        # }
+        #
+        from-context {
+
+        }
+      }
+
+      # Controls writing trace and span identifiers to HTTP response headers sent by the instrumented servers. The
+      # configuration can be set to either "none" to disable writing the identifiers on the response headers or to
+      # the header name to be used when writing the identifiers.
+      response-headers {
+
+        # HTTP response header name for the trace identifier, or "none" to disable it.
+        #trace-id = "trace-id"
+
+        # HTTP response header name for the server span identifier, or "none" to disable it.
+        #span-id = none
+      }
+
+      # Custom mappings between routes and operation names.
+      operations {
+
+        # The default operation name to be used when creating Spans to handle the HTTP server requests. In most
+        # cases it is not possible to define an operation name right at the moment of starting the HTTP server Span
+        # and in those cases, this operation name will be initially assigned to the Span. Instrumentation authors
+        # should do their best effort to provide a suitable operation name or make use of the "mappings" facilities.
+        default = "http.server.request"
+
+        # The operation name to be assigned when an application cannot find any route/endpoint/controller to handle
+        # a given request. Depending on the instrumented framework, it might be possible to apply this operation
+        # name automatically or not, check the frameworks' instrumentation docs for more details.
+        unhandled = "unhandled"
+
+        # FQCN for a HttpOperationNameGenerator implementation, or ony of the following shorthand forms:
+        #   - default: Uses the set default operation name
+        #   - method: Uses the request HTTP method as the operation name.
+        #
+        name-generator = "kamon.http4k.PathOperationNameGenerator"
+
+        # Provides custom mappings from HTTP paths into operation names. Meant to be used in cases where the bytecode
+        # instrumentation is not able to provide a sensible operation name that is free of high cardinality values.
+        # For example, with the following configuration:
+        #   mappings {
+        #     "/organization/*/user/*/profile" = "/organization/:orgID/user/:userID/profile"
+        #     "/events/*/rsvps" = "EventRSVPs"
+        #   }
+        #
+        # Requests to "/organization/3651/user/39652/profile" and "/organization/22234/user/54543/profile" will have
+        # the same operation name "/organization/:orgID/user/:userID/profile".
+        #
+        # Similarly, requests to "/events/aaa-bb-ccc/rsvps" and "/events/1234/rsvps" will have the same operation
+        # name "EventRSVPs".
+        #
+        # The patterns are expressed as globs and the operation names are free form.
+        #
+        mappings {
+        }
+      }
+    }
+  }
+
+  # Settings to control the HTTP Client instrumentation
+  #
+  # NOTE: Client instrumentation is not yet implemented for http4k. This section is reserved
+  # for a future kamon-http4k client filter.
+  #
+  client {
+
+    #
+    # Configuration for HTTP context propagation.
+    #
+    propagation {
+
+      # Enables or disables HTTP context propagation on this HTTP server instrumentation. Please note that if
+      # propagation is disabled then some distributed tracing features will not be work as expected (e.g. Spans can
+      # be created and reported but will not be linked across boundaries nor take trace identifiers from tags).
+      #enabled = yes
+
+      # HTTP propagation channel to be used by this instrumentation. Take a look at the kamon.propagation.http.default
+      # configuration for more details on how to configure the detault HTTP context propagation.
+      #channel = "default"
+    }
+
+    tracing {
+
+      # Enables HTTP request tracing. When enabled the instrumentation will create Spans for outgoing requests
+      # and finish them when the response is received from the server.
+      #enabled = yes
+
+      # Enables collection of span metrics using the `span.processing-time` metric.
+      #span-metrics = on
+
+      # Select which tags should be included as span and span metric tags. The possible options are:
+      #   - span: the tag is added as a Span tag (i.e. using span.tag(...))
+      #   - metric: the tag is added a a Span metric tag (i.e. using span.tagMetric(...))
+      #   - off: the tag is not used.
+      #
+      tags {
+
+        # Use the http.url tag.
+        #url = span
+
+        # Use the http.method tag.
+        #method = metric
+
+        # Use the http.status_code tag.
+        #status-code = metric
+
+        # Copy tags from the context into the Spans with the specified purpouse. For example, to copy a customer_type
+        # tag from the context into the HTTP Server Span created by the instrumentation, the following configuration
+        # should be added:
+        #
+        # from-context {
+        #   customer_type = span
+        # }
+        #
+        from-context {
+
+        }
+      }
+
+      operations {
+
+        # The default operation name to be used when creating Spans to handle the HTTP client requests. The HTTP
+        # Client instrumentation will always try to use the HTTP Operation Name Generator configured bellow to get
+        # a name, but if it fails to generate it then this name will be used.
+        #default = "http.client.request"
+
+        # FQCN for a HttpOperationNameGenerator implementation, or ony of the following shorthand forms:
+        #   - hostname: Uses the request Host as the operation name.
+        #   - method: Uses the request HTTP method as the operation name.
+        #
+        name-generator = "kamon.http4k.PathOperationNameGenerator"
+      }
+    }
+  }
+
+
+}
+
+
+kanela.modules {
+  http4k {
+    name = "Http4k Instrumentation"
+    description = "Provides context propagation, distributed tracing and HTTP server metrics for http4k. Instrumentation is applied via the http4k Filter abstraction and works with all server backends."
+
+    # Instrumentation does not require any Kanela bytecode instrumentation.
+    instrumentations = []
+
+    within = []
+  }
+}
+

--- a/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/Http4k.scala
+++ b/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/Http4k.scala
@@ -1,0 +1,70 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2024 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.http4k
+
+import com.typesafe.config.Config
+import kamon.util.DynamicAccess
+import kamon.Kamon
+import kamon.instrumentation.http.{HttpMessage, HttpOperationNameGenerator}
+
+object Http4k {
+
+  @volatile var nameGenerator: HttpOperationNameGenerator =
+    nameGeneratorFromConfig(Kamon.config())
+
+  private def nameGeneratorFromConfig(
+    config: Config
+  ): HttpOperationNameGenerator = {
+    val dynamic = new DynamicAccess(getClass.getClassLoader)
+    val nameGeneratorFQCN = config.getString(
+      "kamon.instrumentation.http4k.client.tracing.operations.name-generator"
+    )
+    dynamic
+      .createInstanceFor[HttpOperationNameGenerator](nameGeneratorFQCN, Nil)
+  }
+
+  Kamon.onReconfigure { newConfig =>
+    nameGenerator = nameGeneratorFromConfig(newConfig)
+  }
+}
+
+class DefaultNameGenerator extends HttpOperationNameGenerator {
+
+  import java.util.Locale
+  import scala.collection.concurrent.TrieMap
+
+  private val localCache = TrieMap.empty[String, String]
+  private val normalizePattern = """\$([^<]+)<[^>]+>""".r
+
+  override def name(request: HttpMessage.Request): Option[String] =
+    Some(
+      localCache.getOrElseUpdate(
+        s"${request.method}${request.path}", {
+          // Convert paths of form GET /foo/bar/$paramname<regexp>/blah to foo.bar.paramname.blah.get
+          val p = normalizePattern
+            .replaceAllIn(request.path, "$1")
+            .replace('/', '.')
+            .dropWhile(_ == '.')
+          val normalisedPath = {
+            if (p.lastOption.exists(_ != '.')) s"$p."
+            else p
+          }
+          s"$normalisedPath${request.method.toLowerCase(Locale.ENGLISH)}"
+        }
+      )
+    )
+}

--- a/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/KamonFilter.scala
+++ b/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/KamonFilter.scala
@@ -1,0 +1,65 @@
+package kamon.http4k
+
+import kamon.Kamon
+import kamon.instrumentation.http.HttpServerInstrumentation
+import kotlin.jvm.functions.Function1
+import org.http4k.core.{Filter, Request, Response}
+
+/** Kamon server instrumentation for http4k.
+  *
+  * Wraps any [[HttpHandler]] with Kamon HTTP server instrumentation.
+  *
+  * http4k's instrumentation point is the [[Filter]] abstraction,
+  * which is independent of the underlying server backend.
+  * This then works with every http4k server backend.
+  *
+  * Usage:
+  * {{{
+  *   val app: HttpHandler = routes(...)
+  *   val instrumented: HttpHandler = KamonFilter("0.0.0.0", 8080).then(app)
+  *   instrumented.asServer(Netty(8080)).start()
+  * }}}
+  */
+object KamonFilter {
+
+  // For: typealias HttpHandler = (request: Request) -> Response
+  type WildcardHandler = Function1[_ >: Request, _ <: Response]
+  type HttpHandler = Function1[Request, Response]
+
+  /** Build a [[Filter]] that applies Kamon HTTP server instrumentation to every request.
+    */
+  def apply(interface: String, port: Int): Filter = {
+    val config = Kamon.config().getConfig("kamon.instrumentation.http4k.server")
+    val instrumentation = HttpServerInstrumentation.from(config, "http4k.server", interface, port)
+
+    // fun interface Filter : (HttpHandler) -> HttpHandler
+    new Filter {
+      override def invoke(next: WildcardHandler): WildcardHandler =
+        new HttpHandler {
+          override def invoke(request: Request): Response = {
+            val handler = instrumentation.createHandler(buildRequestMessage(request))
+            val scope = Kamon.storeContext(handler.context)
+
+            try {
+              handler.requestReceived()
+              val response = next.invoke(request)
+              if (response.getStatus().getCode() == 404) {
+                handler.span.name(instrumentation.settings.unhandledOperationName)
+              }
+              val finalResponse = handler.buildResponse(buildResponseBuilder(response), handler.context)
+              handler.responseSent()
+              finalResponse
+            } catch {
+              case e: Throwable =>
+                handler.span.fail(e.getMessage)
+                handler.buildResponse(errorResponseBuilder, handler.context)
+                handler.responseSent()
+                throw e
+            } finally {
+              scope.close()
+            }
+          }
+        }
+    }
+  }
+}

--- a/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/PathOperationNameGenerator.scala
+++ b/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/PathOperationNameGenerator.scala
@@ -1,0 +1,9 @@
+package kamon.http4k
+
+import kamon.instrumentation.http.{HttpMessage, HttpOperationNameGenerator}
+
+class PathOperationNameGenerator extends HttpOperationNameGenerator {
+  override def name(request: HttpMessage.Request): Option[String] = Some(
+    request.path
+  )
+}

--- a/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/package.scala
+++ b/instrumentation/kamon-http4k/src/main/scala/kamon/http4k/package.scala
@@ -1,0 +1,73 @@
+package kamon
+
+import kamon.instrumentation.http.HttpMessage
+import kamon.instrumentation.http.HttpMessage.ResponseBuilder
+import org.http4k.core.{Request, Response, Status}
+
+import scala.jdk.CollectionConverters._
+
+package object http4k {
+
+  def buildRequestMessage(request: Request): HttpMessage.Request =
+    new HttpMessage.Request {
+      override def url: String = request.getUri().toString()
+
+      override def path: String = request.getUri().getPath()
+
+      override def method: String = request.getMethod().name()
+
+      override def host: String = {
+        val h = request.getUri().getHost()
+        if (h == null) "" else h
+      }
+
+      override def port: Int = {
+        val p = request.getUri().getPort()
+        if (p == null) 0 else p.intValue()
+      }
+
+      override def read(header: String): Option[String] =
+        Option(request.header(header))
+
+      override def readAll(): Map[String, String] = {
+        val builder = Map.newBuilder[String, String]
+        request.getHeaders().asScala.foreach { pair =>
+          val value = pair.getSecond()
+          if (value != null) builder += (pair.getFirst() -> value)
+        }
+        builder.result()
+      }
+    }
+
+  def buildResponseBuilder(response: Response): ResponseBuilder[Response] =
+    new ResponseBuilder[Response] {
+      // http4k Response is immutable. Keep a local var for modifications
+      private var _response = response
+
+      override def statusCode: Int = _response.getStatus().getCode()
+
+      override def write(header: String, value: String): Unit =
+        _response = _response.header(header, value)
+
+      override def build(): Response = _response
+    }
+
+  def errorResponseBuilder: ResponseBuilder[Response] =
+    new ResponseBuilder[Response] {
+      override def write(header: String, value: String): Unit = ()
+      override def statusCode: Int = 500
+      override def build(): Response = Response.create(Status.INTERNAL_SERVER_ERROR)
+    }
+
+  def notFoundResponseBuilder: ResponseBuilder[Response] =
+    new ResponseBuilder[Response] {
+      private var _response = Response.create(Status.NOT_FOUND)
+
+      override def statusCode: Int = 404
+
+      override def write(header: String, value: String): Unit =
+        _response = _response.header(header, value)
+
+      override def build(): Response = _response
+    }
+}

--- a/instrumentation/kamon-http4k/src/test/resources/application.conf
+++ b/instrumentation/kamon-http4k/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+kamon.instrumentation.http4k.server.tracing.operations {
+      mappings {
+        "/tracing/*/ok" = "/tracing/:name/ok"
+      }
+}

--- a/instrumentation/kamon-http4k/src/test/resources/logback.xml
+++ b/instrumentation/kamon-http4k/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/instrumentation/kamon-http4k/src/test/scala/kamon/http4k/ServerInstrumentationSpec.scala
+++ b/instrumentation/kamon-http4k/src/test/scala/kamon/http4k/ServerInstrumentationSpec.scala
@@ -1,0 +1,177 @@
+/*
+ * =========================================================================================
+ * Copyright © 2013-2024 the kamon project <http://kamon.io/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ * =========================================================================================
+ */
+
+package kamon.http4k
+
+import kamon.Kamon
+import kamon.tag.Lookups.{plain, plainLong}
+import kamon.testkit.{InitAndStopKamonAfterAll, TestSpanReporter}
+import kamon.trace.Span
+import org.http4k.client.URLConnectionHttpClient
+import org.http4k.core.{Http4kKt, Method, Request, Response, Status}
+import org.http4k.routing.{HttpKt, PathMethod}
+import org.http4k.server.{ServerConfig, SunHttp}
+import org.scalatest.concurrent.Eventually
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues
+import org.scalatest.BeforeAndAfterEach
+import kotlin.jvm.functions.Function1
+
+class ServerInstrumentationSpec
+    extends AnyWordSpec
+    with Matchers
+    with Eventually
+    with SpanSugar
+    with OptionValues
+    with TestSpanReporter
+    with InitAndStopKamonAfterAll
+    with BeforeAndAfterEach {
+
+  type HttpHandler = Function1[Request, Response]
+
+  override def beforeEach(): Unit = {
+    testSpanReporter().clear()
+    super.beforeEach()
+  }
+
+  // A simple http4k app with a handful of routes
+  val testRoutes = HttpKt.routes(
+    new PathMethod("/tracing/ok", Method.GET).to(
+      new HttpHandler {
+        override def invoke(req: Request): Response = Response.create(Status.OK).body("ok")
+      }
+    ),
+    new PathMethod("/tracing/not-found", Method.GET).to(
+      new HttpHandler {
+        override def invoke(req: Request): Response = Response.create(Status.NOT_FOUND)
+      }
+    ),
+    new PathMethod("/tracing/error", Method.GET).to(
+      new HttpHandler {
+        override def invoke(req: Request): Response = Response.create(Status.INTERNAL_SERVER_ERROR)
+      }
+    ),
+    new PathMethod("/tracing/ok", Method.POST).to(
+      new HttpHandler {
+        override def invoke(req: Request): Response = Response.create(Status.OK)
+      }
+    ),
+    new PathMethod("/tracing/something/ok", Method.GET).to(
+      new HttpHandler {
+        override def invoke(req: Request): Response = Response.create(Status.OK).body("ok something")
+      }
+    )
+  )
+
+  val interface = "127.0.0.1"
+  val port = 43568
+
+  // Wrap with Kamon instrumentation. KamonFilter is backend-agnostic
+  val app = Http4kKt.then(KamonFilter(interface, port), testRoutes)
+
+  // Start a SunHttp server (built-in JDK server)
+  val server = new SunHttp(port).toServer(app).start()
+
+  val client = URLConnectionHttpClient.create()
+
+  override def afterAll(): Unit = {
+    server.stop()
+    super.afterAll()
+  }
+
+  private def get(path: String): Response =
+    client.invoke(Request.create(Method.GET, s"http://$interface:$port$path"))
+
+  "The KamonFilter server instrumentation" should {
+
+    "create a span for a successful request" in {
+      val okSpan = Kamon.spanBuilder("parent-span").start()
+
+      Kamon.runWithSpan(okSpan) {
+        get("/tracing/ok")
+      }
+
+      eventually(timeout(3 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName shouldBe "/tracing/ok"
+        span.kind shouldBe Span.Kind.Server
+        span.metricTags.get(plain("component")) shouldBe "http4k.server"
+        span.metricTags.get(plain("http.method")) shouldBe "GET"
+        span.metricTags.get(plainLong("http.status_code")) shouldBe 200
+        span.hasError shouldBe false
+      }
+    }
+
+    "apply glob operation name mappings from config" in {
+      // application.conf maps "/tracing/*/ok" -> "/tracing/:name/ok"
+      get("/tracing/something/ok")
+
+      eventually(timeout(3 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName shouldBe "/tracing/:name/ok"
+      }
+    }
+
+    "mark a span as failed for a 5xx response" in {
+      get("/tracing/error")
+
+      eventually(timeout(3 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.metricTags.get(plainLong("http.status_code")) shouldBe 500
+        span.hasError shouldBe true
+      }
+    }
+
+    "create a span for a POST request" in {
+      client.invoke(Request.create(Method.POST, s"http://$interface:$port/tracing/ok"))
+
+      eventually(timeout(3 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.metricTags.get(plain("http.method")) shouldBe "POST"
+        span.metricTags.get(plainLong("http.status_code")) shouldBe 200
+      }
+    }
+
+    "propagate an incoming trace context from request headers" in {
+      val parentSpan = Kamon.spanBuilder("remote-parent").start()
+      val ctx = Kamon.currentContext().withEntry(Span.Key, parentSpan)
+
+      var request = Request.create(Method.GET, s"http://$interface:$port/tracing/ok")
+      Kamon.defaultHttpPropagation().write(ctx, (h, v) => request = request.header(h, v))
+
+      // Make the request. The server filter should re-attach to the parent
+      client.invoke(request)
+      parentSpan.finish()
+
+      eventually(timeout(3 seconds)) {
+        val spans = testSpanReporter().spans()
+        val serverSpan = spans.find(_.kind == Span.Kind.Server)
+        serverSpan.value.parentId shouldBe parentSpan.id
+      }
+    }
+
+    "use the unhandled operation name for unmatched routes" in {
+      get("/does/not/exist")
+
+      eventually(timeout(3 seconds)) {
+        val span = testSpanReporter().nextSpan().value
+        span.operationName shouldBe "unhandled"
+      }
+    }
+  }
+}


### PR DESCRIPTION

### Motivation
We have a service running `http4k` and would like to use Kamon with it.

### Description
This PR adds a new `kamon-http4k` server instrumentation module, based on the structure and logic of `kamon-http4s-1.0` (some files are mostly identical)

Since `http4k` is built around the `Filter` abstraction, the instrumentation is implemented as a backend-agnostic `Filter` that works out-of-the-box with any backend (e.g. Netty, SunHttp, etc.).

Tests included in `ServerInstrumentationSpec` pass successfully.

Additionally, a demo application that uses this feature can be found in this repo: https://github.com/vaslabs-ltd/kamon-http4k-poc.

cc: @vaslabs
